### PR TITLE
fix: authenticate gh CLI during setup persist

### DIFF
--- a/plugins/mc-board/web/src/app/api/setup/persist/route.ts
+++ b/plugins/mc-board/web/src/app/api/setup/persist/route.ts
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { readSetupState, writeSetupState } from "@/lib/setup-state";
 import { vaultSet } from "@/lib/vault";
+import { execFileSync } from "node:child_process";
 
 /**
  * POST /api/setup/persist
@@ -39,6 +40,23 @@ export async function POST() {
 
   // Gemini
   persist("geminiApiKey", "gemini-api-key");
+
+  // Authenticate gh CLI with the GitHub token
+  const ghToken = (state as Record<string, string>).ghToken;
+  if (ghToken) {
+    try {
+      execFileSync("gh", ["auth", "login", "--with-token"], {
+        input: ghToken,
+        encoding: "utf-8",
+        timeout: 15_000,
+        env: { ...process.env, GH_PROMPT_DISABLED: "1" },
+      });
+      results.push({ key: "gh-auth", ok: true });
+    } catch (e) {
+      const err = e as { stderr?: string };
+      results.push({ key: "gh-auth", ok: false, error: err.stderr?.trim() || "gh auth failed" });
+    }
+  }
 
   // Mark as persisted
   writeSetupState({ secretsPersisted: true } as Record<string, string | boolean>);

--- a/tests/install-checks.test.sh
+++ b/tests/install-checks.test.sh
@@ -121,6 +121,16 @@ else
 fi
 
 echo ""
+echo "── credential injection checks"
+
+# #48: persist route authenticates gh CLI
+if grep -q 'gh.*auth.*login.*--with-token' "$REPO_DIR/plugins/mc-board/web/src/app/api/setup/persist/route.ts"; then
+  pass "#48 persist route runs gh auth login"
+else
+  fail "#48 persist route doesn't authenticate gh CLI" "add gh auth login --with-token to persist route"
+fi
+
+echo ""
 echo "── vault env check"
 
 if grep -q 'OPENCLAW_VAULT_ROOT' "$REPO_DIR/plugins/mc-board/web/src/lib/vault.ts"; then


### PR DESCRIPTION
## Summary

After saving credentials to vault, the persist route now runs `gh auth login --with-token` so the agent can use `gh` CLI immediately without manual authentication.

## What changed

- `plugins/mc-board/web/src/app/api/setup/persist/route.ts` — added `gh auth login --with-token` after saving the GitHub token to vault
- `tests/install-checks.test.sh` — added test verifying persist route authenticates gh

## Test plan

- [x] 17/17 install checks passing
- [ ] Verify on fresh Mac Mini install — `gh auth status` should show authenticated after setup

Fixes #48