### PR TITLE
fix: rolodex web uses correct USER/rolodex/ path

### DIFF
--- a/plugins/mc-board/web/src/lib/rolodex.ts
+++ b/plugins/mc-board/web/src/lib/rolodex.ts
@@ -43,10 +43,10 @@ function resolveDbPath(): string {
 function resolveJsonPath(): string {
   if (process.env.ROLODEX_STORAGE_PATH) return process.env.ROLODEX_STORAGE_PATH;
   const stateDir = process.env.OPENCLAW_STATE_DIR ?? path.join(os.homedir(), ".openclaw");
-  // Check new location first, then fall back to legacy
-  const newPath = path.join(stateDir, "USER", "rolodex", "contacts.json");
-  if (fs.existsSync(newPath)) return newPath;
-  return path.join(os.homedir(), ".openclaw", "rolodex", "contacts.json");
+  const jsonPath = path.join(stateDir, "USER", "rolodex", "contacts.json");
+  const dir = path.dirname(jsonPath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  return jsonPath;
 }
 
 let _db: Database.Database | null = null;

--- a/tests/install-checks.test.sh
+++ b/tests/install-checks.test.sh
@@ -131,6 +131,17 @@ else
 fi
 
 echo ""
+echo "── path consistency checks"
+
+# #52: rolodex web uses USER/rolodex/ not legacy path
+if grep -q 'USER.*rolodex.*contacts' "$REPO_DIR/plugins/mc-board/web/src/lib/rolodex.ts" && \
+   ! grep -q 'homedir.*"rolodex"' "$REPO_DIR/plugins/mc-board/web/src/lib/rolodex.ts"; then
+  pass "#52 rolodex web uses USER/rolodex/ path (no legacy fallback)"
+else
+  fail "#52 rolodex web still has legacy path fallback" "remove fallback to ~/.openclaw/rolodex/"
+fi
+
+echo ""
 echo "── vault env check"
 
 if grep -q 'OPENCLAW_VAULT_ROOT' "$REPO_DIR/plugins/mc-board/web/src/lib/vault.ts"; then


### PR DESCRIPTION
## Summary

The web UI showed empty contacts because it fell back to a legacy path (~/.openclaw/rolodex/) when the correct path (~/.openclaw/USER/rolodex/) didn't exist yet. Now always uses USER/rolodex/ and creates the directory on first access.

## What changed

- `plugins/mc-board/web/src/lib/rolodex.ts` — removed legacy fallback, always use `$STATE_DIR/USER/rolodex/contacts.json`, mkdir if missing
- `tests/install-checks.test.sh` — added path consistency test

## Test plan

- [x] 18/18 install checks passing
- [ ] Verify on mini: add contact via CLI, confirm visible in web UI

Fixes #52