### PR TITLE
feat: standardize projects folder to ~/.openclaw/miniclaw/USER/projects

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 REPO_URL="https://github.com/augmentedmike/miniclaw-os.git"
-INSTALL_DIR="${HOME}/.openclaw/projects/miniclaw-os"
+INSTALL_DIR="${HOME}/.openclaw/miniclaw/USER/projects/miniclaw-os"
 STATE_DIR="${HOME}/.openclaw"
 WEB_DIR="$STATE_DIR/web"
 APP_PORT=4220
@@ -103,8 +103,9 @@ fi
 rm -rf "$EXTRACT_TMP"
 
 # ── Prep state dir ───────────────────────────────────────────────────────────
-mkdir -p "$STATE_DIR/USER" "$STATE_DIR/logs"
+mkdir -p "$STATE_DIR/USER" "$STATE_DIR/logs" "$STATE_DIR/miniclaw/USER/projects"
 rm -f "$STATE_DIR/USER/setup-state.json"
+ln -sfn "$STATE_DIR/miniclaw/USER/projects" "$HOME/mc-projects"
 
 # ── Rebuild native modules for this machine's Node version ────────────────────
 echo "  Preparing native modules..."

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd 2>/dev/null)" || REPO_DIR="$(pwd)"
 STATE_DIR="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
 MINICLAW_DIR="$STATE_DIR/miniclaw"
-PROJECTS_DIR="$STATE_DIR/projects"
+PROJECTS_DIR="$STATE_DIR/miniclaw/USER/projects"
 LOG_FILE="/tmp/miniclaw-install.log"
 ARCH=$(uname -m)
 
@@ -411,8 +411,10 @@ fi
 step "Step 6: Directories"
 
 mkdir -p "$MINICLAW_DIR/plugins" "$PROJECTS_DIR"
+ln -sfn "$PROJECTS_DIR" "$HOME/mc-projects"
 ok "~/.openclaw/miniclaw/"
-ok "~/.openclaw/projects/"
+ok "~/.openclaw/miniclaw/USER/projects/"
+ok "~/mc-projects symlink"
 
 # Copy MANIFEST.json so the CLI can read the MiniClaw version at runtime
 if [[ -f "$REPO_DIR/MANIFEST.json" ]]; then


### PR DESCRIPTION
## Summary
- Updates `bootstrap.sh` to clone miniclaw-os into `~/.openclaw/miniclaw/USER/projects/miniclaw-os` instead of `~/.openclaw/projects/miniclaw-os`
- Updates `install.sh` to use `$STATE_DIR/miniclaw/USER/projects` as `PROJECTS_DIR` instead of `$STATE_DIR/projects`
- Both scripts now create `~/.openclaw/miniclaw/USER/projects/` and the `~/mc-projects` symlink automatically during fresh install

Fixes #53