### PR TITLE
fix: install gh CLI via brew

### DIFF
--- a/SYSTEM/bin/mc-smoke
+++ b/SYSTEM/bin/mc-smoke
@@ -541,6 +541,13 @@ else:
   esac
 fi
 
+# gh CLI available
+if command -v gh &>/dev/null; then
+  pass "gh CLI on PATH ($(gh --version 2>/dev/null | head -1))"
+else
+  fail "gh CLI not on PATH" "run: brew install gh"
+fi
+
 # Claude Code available
 if command -v claude &>/dev/null; then
   pass "claude code on PATH ($(claude --version 2>/dev/null | head -1))"

--- a/install.sh
+++ b/install.sh
@@ -275,6 +275,7 @@ if [[ -d "$NPM_GLOBAL_BIN" && ":$PATH:" != *":$NPM_GLOBAL_BIN:"* ]]; then
 fi
 
 brew_install git
+brew_install gh
 brew_install python@3 python3
 brew_install jq
 brew_install age

--- a/tests/install-checks.test.sh
+++ b/tests/install-checks.test.sh
@@ -131,6 +131,16 @@ else
 fi
 
 echo ""
+echo "── dependency checks"
+
+# #56: gh CLI installed by install.sh
+if grep -q 'brew_install gh' "$REPO_DIR/install.sh"; then
+  pass "#56 install.sh installs gh CLI"
+else
+  fail "#56 install.sh missing gh CLI" "add brew_install gh to step 2"
+fi
+
+echo ""
 echo "── path consistency checks"
 
 # #52: rolodex web uses USER/rolodex/ not legacy path


### PR DESCRIPTION
## Summary

mc-contribute and mc-github require `gh` CLI but it wasn't installed by `install.sh`. Now added via `brew_install gh` alongside git in step 2. mc-smoke verifies it's on PATH.

## What changed

- `install.sh` — added `brew_install gh`
- `SYSTEM/bin/mc-smoke` — added gh CLI PATH check
- `tests/install-checks.test.sh` — added test

## Test plan

- [x] 19/19 install checks passing

Fixes #56