### PR TITLE
fix: mc-kb execute() signature — toolCallId first param

### DIFF
--- a/plugins/mc-kb/tools/definitions.ts
+++ b/plugins/mc-kb/tools/definitions.ts
@@ -63,13 +63,14 @@ export function createKbTools(
       parameters: schema(
         {
           query: str("Search query — describe what you're looking for"),
-          type: optStr("Filter by entry type: fact, workflow, guide, howto, error, postmortem, concept"),
+          type: optStr("Filter by entry type: fact, workflow, guide, howto, error, postmortem, lesson"),
           tag: optStr("Filter by tag"),
           n: optNum("Max results (default 5)"),
         },
         ["query"],
       ) as never,
-      execute: async (input: { query: string; type?: string; tag?: string; n?: number }) => {
+      execute: async (_id: string, _input: unknown) => {
+        const input = _input as { query: string; type?: string; tag?: string; n?: number };
         const start = Date.now();
         logger.debug(`mc-kb/tool kb_search: query="${input.query}" type=${input.type ?? "any"}`);
         try {
@@ -100,7 +101,7 @@ export function createKbTools(
         "workflows, how-to guides, facts about the system, project postmortems.",
       parameters: schema(
         {
-          type: str("Entry type: fact, workflow, guide, howto, error, postmortem, concept"),
+          type: str("Entry type: fact, workflow, guide, howto, error, postmortem, lesson"),
           title: str("Concise descriptive title"),
           content: str("Full markdown content — the actual knowledge"),
           summary: optStr("1-2 sentence summary"),
@@ -110,10 +111,11 @@ export function createKbTools(
         },
         ["type", "title", "content"],
       ) as never,
-      execute: async (input: {
-        type: string; title: string; content: string;
-        summary?: string; tags?: string; source?: string; severity?: string;
-      }) => {
+      execute: async (_id: string, _input: unknown) => {
+        const input = _input as {
+          type: string; title: string; content: string;
+          summary?: string; tags?: string; source?: string; severity?: string;
+        };
         const start = Date.now();
         logger.debug(`mc-kb/tool kb_add: type=${input.type} title="${input.title}"`);
         try {
@@ -167,10 +169,11 @@ export function createKbTools(
         },
         ["id"],
       ) as never,
-      execute: async (input: {
-        id: string; type?: string; title?: string; content?: string;
-        summary?: string; tags?: string; severity?: string;
-      }) => {
+      execute: async (_id: string, _input: unknown) => {
+        const input = _input as {
+          id: string; type?: string; title?: string; content?: string;
+          summary?: string; tags?: string; severity?: string;
+        };
         const start = Date.now();
         logger.debug(`mc-kb/tool kb_update: id=${input.id}`);
         try {
@@ -221,7 +224,8 @@ export function createKbTools(
         { id: str("Entry ID (kb_<hex>)") },
         ["id"],
       ) as never,
-      execute: async (input: { id: string }) => {
+      execute: async (_id: string, _input: unknown) => {
+        const input = _input as { id: string };
         logger.debug(`mc-kb/tool kb_get: id=${input.id}`);
         try {
           const entry = store.get(input.id);

--- a/tests/install-checks.test.sh
+++ b/tests/install-checks.test.sh
@@ -131,6 +131,16 @@ else
 fi
 
 echo ""
+echo "── tool signature checks"
+
+# #46: mc-kb execute() has correct signature (_id, _input)
+if grep -q 'execute.*_id.*string.*_input.*unknown' "$REPO_DIR/plugins/mc-kb/tools/definitions.ts"; then
+  pass "#46 mc-kb execute() has correct (_id, _input) signature"
+else
+  fail "#46 mc-kb execute() missing toolCallId first param" "params received as string instead of object"
+fi
+
+echo ""
 echo "── dependency checks"
 
 # #56: gh CLI installed by install.sh


### PR DESCRIPTION
## Summary

All 4 mc-kb tool execute() functions were missing the `toolCallId` first parameter. The runtime calls `execute(toolCallId, params)` but handlers were defined as `execute(input)`, so `input` received the toolCallId string — causing `NOT NULL constraint failed: entries.type` on every kb_add call.

## What changed

- `plugins/mc-kb/tools/definitions.ts` — all 4 execute() functions now take `(_id: string, _input: unknown)` and cast `_input` to the expected type
- Fixed `concept` → `lesson` in tool description strings (VALID_TYPES mismatch)
- `tests/install-checks.test.sh` — added signature verification test

## Test plan

- [x] 20/20 install checks passing

Fixes #46