### PR TITLE
fix(setup): apply gh auth, defaultRepo, and SMTP config on install complete

### DIFF
--- a/apps/am-setup/app/api/setup/complete/route.ts
+++ b/apps/am-setup/app/api/setup/complete/route.ts
@@ -141,6 +141,65 @@ function ensureGatewayRunning(): { ok: boolean; error?: string } {
 }
 
 /**
+ * Authenticate the gh CLI using the GitHub token from setup-state or vault.
+ * This ensures `gh` commands work immediately after install.
+ */
+function applyGithubAuth(): { ok: boolean; error?: string } {
+  const state = readSetupState();
+  const token = (state as Record<string, string>).ghToken;
+  if (!token) {
+    return { ok: false, error: "No GitHub token found in setup state" };
+  }
+
+  const ghBin = findBin("gh");
+  if (!ghBin) {
+    return { ok: false, error: "gh CLI not found on PATH" };
+  }
+
+  const result = spawnSync(ghBin, ["auth", "login", "--with-token"], {
+    input: token,
+    encoding: "utf-8",
+    timeout: 15_000,
+    env: { ...process.env, GH_PROMPT_DISABLED: "1" },
+  });
+
+  if (result.status !== 0) {
+    return { ok: false, error: result.stderr?.trim() || "gh auth login failed" };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Set the mc-github defaultRepo in openclaw.json plugin config.
+ */
+function setGithubDefaultRepo() {
+  const state = readSetupState();
+  const username = (state as Record<string, string>).ghUsername;
+  if (!username) return;
+
+  const configPath = path.join(STATE_DIR, "openclaw.json");
+  let cfg: Record<string, unknown> = {};
+  try {
+    if (fs.existsSync(configPath)) {
+      cfg = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    }
+  } catch { /* start fresh */ }
+
+  const plugins = (cfg.plugins ?? {}) as Record<string, unknown>;
+  const entries = (plugins.entries ?? {}) as Record<string, Record<string, unknown>>;
+  const mcGithub = entries["mc-github"] ?? {};
+  if (!mcGithub.defaultRepo) {
+    mcGithub.defaultRepo = `${username}/miniclaw-os`;
+  }
+  entries["mc-github"] = mcGithub;
+  plugins.entries = entries;
+  cfg.plugins = plugins;
+
+  fs.writeFileSync(configPath, JSON.stringify(cfg, null, 2) + "\n", "utf-8");
+}
+
+/**
  * Run mc-smoke and return the output.
  */
 function runSmoke(): { output: string; passed: boolean } {
@@ -170,6 +229,15 @@ export async function POST() {
   // Configure openclaw.json, register telegram channel, store token in vault
   configureGateway(botId, setupState.telegramBotToken);
 
+  // Authenticate gh CLI with the GitHub token (non-fatal if it fails)
+  const ghAuth = applyGithubAuth();
+  if (!ghAuth.ok) {
+    console.warn("gh auth login skipped:", ghAuth.error);
+  }
+
+  // Set mc-github defaultRepo in openclaw.json
+  setGithubDefaultRepo();
+
   // Create USER/brain/ and seed the board DB with default projects
   seedBoardDb();
 
@@ -187,6 +255,7 @@ export async function POST() {
   return NextResponse.json({
     ok: true,
     state,
+    ghAuth,
     gateway: gw,
     smoke: { output: smoke.output, passed: smoke.passed },
   });

--- a/apps/am-setup/app/api/setup/github/route.ts
+++ b/apps/am-setup/app/api/setup/github/route.ts
@@ -42,8 +42,12 @@ export async function POST(req: Request) {
       });
     }
 
-    // Save to setup state
-    writeSetupState({ ghConfigured: true } as Record<string, string | boolean>);
+    // Save to setup state (token + username for later use by complete handler)
+    writeSetupState({
+      ghToken: token.trim(),
+      ghUsername: user.login,
+      ghConfigured: true,
+    } as Record<string, string | boolean>);
 
     return NextResponse.json({
       ok: true,

--- a/plugins/mc-board/web/src/app/api/setup/complete/route.ts
+++ b/plugins/mc-board/web/src/app/api/setup/complete/route.ts
@@ -155,6 +155,65 @@ function ensureGatewayRunning(): { ok: boolean; error?: string } {
 }
 
 /**
+ * Authenticate the gh CLI using the GitHub token from setup-state or vault.
+ * This ensures `gh` commands work immediately after install.
+ */
+function applyGithubAuth(): { ok: boolean; error?: string } {
+  const state = readSetupState();
+  const token = (state as Record<string, string>).ghToken;
+  if (!token) {
+    return { ok: false, error: "No GitHub token found in setup state" };
+  }
+
+  const ghBin = findBin("gh");
+  if (!ghBin) {
+    return { ok: false, error: "gh CLI not found on PATH" };
+  }
+
+  const result = spawnSync(ghBin, ["auth", "login", "--with-token"], {
+    input: token,
+    encoding: "utf-8",
+    timeout: 15_000,
+    env: { ...process.env, GH_PROMPT_DISABLED: "1" },
+  });
+
+  if (result.status !== 0) {
+    return { ok: false, error: result.stderr?.trim() || "gh auth login failed" };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Set the mc-github defaultRepo in openclaw.json plugin config.
+ */
+function setGithubDefaultRepo() {
+  const state = readSetupState();
+  const username = (state as Record<string, string>).ghUsername;
+  if (!username) return;
+
+  const configPath = path.join(STATE_DIR, "openclaw.json");
+  let cfg: Record<string, unknown> = {};
+  try {
+    if (fs.existsSync(configPath)) {
+      cfg = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    }
+  } catch { /* start fresh */ }
+
+  const plugins = (cfg.plugins ?? {}) as Record<string, unknown>;
+  const entries = (plugins.entries ?? {}) as Record<string, Record<string, unknown>>;
+  const mcGithub = entries["mc-github"] ?? {};
+  if (!mcGithub.defaultRepo) {
+    mcGithub.defaultRepo = `${username}/miniclaw-os`;
+  }
+  entries["mc-github"] = mcGithub;
+  plugins.entries = entries;
+  cfg.plugins = plugins;
+
+  fs.writeFileSync(configPath, JSON.stringify(cfg, null, 2) + "\n", "utf-8");
+}
+
+/**
  * Run mc-smoke and return the output.
  */
 function runSmoke(): { output: string; passed: boolean } {
@@ -332,6 +391,15 @@ export async function POST() {
   // Configure openclaw.json, register telegram channel, store token in vault
   configureGateway(botId, setupState.telegramBotToken, setupState.telegramChatId);
 
+  // Authenticate gh CLI with the GitHub token (non-fatal if it fails)
+  const ghAuth = applyGithubAuth();
+  if (!ghAuth.ok) {
+    console.warn("gh auth login skipped:", ghAuth.error);
+  }
+
+  // Set mc-github defaultRepo in openclaw.json
+  setGithubDefaultRepo();
+
   // Create USER/brain/ and seed the board DB with default projects
   seedBoardDb();
 
@@ -355,6 +423,7 @@ export async function POST() {
   return NextResponse.json({
     ok: true,
     state,
+    ghAuth,
     gateway: gw,
     smoke: { output: smoke.output, passed: smoke.passed },
   });

--- a/plugins/mc-email/src/client.ts
+++ b/plugins/mc-email/src/client.ts
@@ -7,11 +7,11 @@ import type { EmailMessage, SendEmailOptions } from "./types.js";
 function createImapClient(cfg: EmailConfig): ImapFlow {
   const password = getAppPassword(cfg.vaultBin);
   if (!password) {
-    throw new Error("Gmail app password not found in vault. Run: mc mc-email auth");
+    throw new Error("Email app password not found in vault. Run: mc mc-email auth");
   }
   return new ImapFlow({
-    host: "imap.gmail.com",
-    port: 993,
+    host: cfg.imapHost,
+    port: cfg.imapPort,
     secure: true,
     auth: {
       user: cfg.emailAddress,
@@ -119,9 +119,9 @@ export class GmailClient {
       throw new Error("Gmail app password not found in vault. Run: mc mc-email auth");
     }
     const transport = nodemailer.createTransport({
-      host: "smtp.gmail.com",
-      port: 587,
-      secure: false,
+      host: this.cfg.smtpHost,
+      port: this.cfg.smtpPort,
+      secure: this.cfg.smtpPort === 465,
       auth: {
         user: this.cfg.emailAddress,
         pass: password,

--- a/plugins/mc-email/src/config.ts
+++ b/plugins/mc-email/src/config.ts
@@ -1,16 +1,32 @@
 import * as path from "node:path";
 import * as os from "node:os";
+import { vaultGet } from "./vault.js";
 
 const STATE_DIR = process.env.OPENCLAW_STATE_DIR ?? path.join(os.homedir(), ".openclaw");
 
 export interface EmailConfig {
   vaultBin: string;
   emailAddress: string;
+  smtpHost: string;
+  smtpPort: number;
+  imapHost: string;
+  imapPort: number;
 }
 
 export function resolveConfig(raw: Record<string, unknown>): EmailConfig {
+  const vaultBin = (raw.vaultBin as string) || path.join(STATE_DIR, "miniclaw", "SYSTEM", "bin", "mc-vault");
+
+  const smtpHost = (raw.smtpHost as string) || vaultGet(vaultBin, "smtp-host") || "smtp.gmail.com";
+  const smtpPortRaw = (raw.smtpPort as string) || vaultGet(vaultBin, "smtp-port") || "587";
+  const imapHost = (raw.imapHost as string) || (smtpHost === "smtp.gmail.com" ? "imap.gmail.com" : smtpHost.replace(/^smtp\./, "imap."));
+  const imapPort = (raw.imapPort as number) || 993;
+
   return {
-    vaultBin: (raw.vaultBin as string) || path.join(STATE_DIR, "miniclaw", "SYSTEM", "bin", "mc-vault"),
+    vaultBin,
     emailAddress: (raw.emailAddress as string) || "augmentedmike@gmail.com",
+    smtpHost,
+    smtpPort: parseInt(smtpPortRaw, 10),
+    imapHost,
+    imapPort,
   };
 }


### PR DESCRIPTION
## Summary
- Add `applyGithubAuth()` to both setup complete handlers (am-setup + mc-board) to run `gh auth login --with-token` during setup completion, fixing the issue where gh CLI stays unauthenticated after install
- Add `setGithubDefaultRepo()` to write `mc-github.defaultRepo` to `openclaw.json` plugin config using the ghUsername from setup-state
- Save `ghToken` + `ghUsername` to setup-state in the am-setup github route (was missing — mc-board version already had this)
- Update `mc-email` config to read `smtp-host`/`smtp-port` from vault instead of hardcoding Gmail, supporting non-Gmail providers like Namecheap Private Email

## Files Changed
- `apps/am-setup/app/api/setup/complete/route.ts` — add gh auth + defaultRepo steps
- `apps/am-setup/app/api/setup/github/route.ts` — save ghToken + ghUsername to setup-state
- `plugins/mc-board/web/src/app/api/setup/complete/route.ts` — add gh auth + defaultRepo steps
- `plugins/mc-email/src/config.ts` — read SMTP host/port from vault, add to EmailConfig interface
- `plugins/mc-email/src/client.ts` — use configurable host:port instead of hardcoded Gmail

## Test plan
- [ ] Run setup wizard end-to-end, verify `gh auth status` shows authenticated after completion
- [ ] Verify `openclaw.json` has `plugins.entries.mc-github.defaultRepo` set
- [ ] Verify mc-email sends via correct SMTP host (check vault for smtp-host/smtp-port)
- [ ] Verify backwards compat: Gmail users still work (defaults to smtp.gmail.com:587)

Fixes: crd_730c5c94