### PR TITLE
feat: seed rolodex with human and agent contacts on setup

### DIFF
--- a/plugins/mc-board/web/src/app/api/setup/complete/route.ts
+++ b/plugins/mc-board/web/src/app/api/setup/complete/route.ts
@@ -6,6 +6,7 @@ import { vaultSet } from "@/lib/vault";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
+import * as crypto from "node:crypto";
 import { execSync, spawnSync } from "node:child_process";
 
 const STATE_DIR = process.env.OPENCLAW_STATE_DIR ?? path.join(process.env.HOME || "", ".openclaw");
@@ -404,6 +405,61 @@ function registerCronJobs() {
   }
 }
 
+/**
+ * Seed the rolodex with the human owner and agent contacts.
+ * Writes contacts.json so the rolodex SQLite migration picks them up on first open.
+ * Only seeds if contacts.json doesn't exist yet or is empty.
+ */
+function seedRolodexContacts() {
+  const setupState = readSetupState();
+  const rolodexDir = path.join(STATE_DIR, "USER", "rolodex");
+  const contactsPath = path.join(rolodexDir, "contacts.json");
+
+  // Skip if contacts.json already has data
+  if (fs.existsSync(contactsPath)) {
+    try {
+      const existing = JSON.parse(fs.readFileSync(contactsPath, "utf-8"));
+      if (Array.isArray(existing) && existing.length > 0) return;
+    } catch { /* treat parse errors as empty */ }
+  }
+
+  fs.mkdirSync(rolodexDir, { recursive: true });
+
+  const contacts = [];
+
+  // Human owner contact
+  const humanName = (setupState as Record<string, string>).ghUsername || "Human Owner";
+  const humanEmail = setupState.emailAddress || "";
+  contacts.push({
+    id: crypto.randomUUID(),
+    name: humanName,
+    emails: humanEmail ? [humanEmail] : [],
+    phones: [],
+    domains: [],
+    tags: ["owner", "human"],
+    trustStatus: "verified",
+    lastVerified: new Date().toISOString(),
+    notes: "Human owner — added during setup.",
+  });
+
+  // Agent contact
+  const agentName = setupState.assistantName || "MiniClaw";
+  const agentShort = setupState.shortName || agentName;
+  contacts.push({
+    id: crypto.randomUUID(),
+    name: agentName,
+    emails: [],
+    phones: [],
+    domains: [],
+    tags: ["agent", "self"],
+    trustStatus: "verified",
+    lastVerified: new Date().toISOString(),
+    notes: `AI agent (${agentShort}) — added during setup.`,
+  });
+
+  fs.writeFileSync(contactsPath, JSON.stringify(contacts, null, 2) + "\n", "utf-8");
+}
+
 export async function POST() {
   const setupState = readSetupState();
   const botId = normalizeBotId(setupState.telegramBotUsername);
@@ -435,6 +491,9 @@ export async function POST() {
 
   // Re-run workspace personalization now that setup-state.json is complete
   personalizeWorkspace();
+
+  // Seed rolodex with human owner and agent contacts
+  seedRolodexContacts();
 
   // Install and start the openclaw gateway
   const gw = ensureGatewayRunning();

--- a/tests/install-checks.test.sh
+++ b/tests/install-checks.test.sh
@@ -179,6 +179,16 @@ else
 fi
 
 echo ""
+echo "── rolodex seed checks"
+
+# #49/#54: complete route seeds rolodex contacts
+if grep -q 'seedRolodexContacts' "$REPO_DIR/plugins/mc-board/web/src/app/api/setup/complete/route.ts"; then
+  pass "#49/#54 complete route seeds rolodex contacts"
+else
+  fail "#49/#54 complete route missing rolodex seed" "add seedRolodexContacts to setup complete"
+fi
+
+echo ""
 echo "── vault env check"
 
 if grep -q 'OPENCLAW_VAULT_ROOT' "$REPO_DIR/plugins/mc-board/web/src/lib/vault.ts"; then


### PR DESCRIPTION
## Summary
- Adds `seedRolodexContacts()` to the setup complete route that creates two seed contacts in `contacts.json`: the human owner (with email from setup state, tagged `owner`/`human`) and the agent itself (tagged `agent`/`self`)
- Only seeds if `contacts.json` doesn't exist or is empty; the existing rolodex SQLite migration picks up the JSON on first DB open
- Adds install-checks test verifying the complete route includes `seedRolodexContacts`

Fixes #49
Fixes #54

## Test plan
- [x] `bash tests/install-checks.test.sh` passes the new rolodex seed check
- [ ] Fresh install: verify `~/.openclaw/USER/rolodex/contacts.json` is created with two contacts after setup completion
- [ ] Re-run setup complete: verify existing contacts are not duplicated