### PR TITLE
fix: voice-ingest Python 3.9 compatibility

### DIFF
--- a/SYSTEM/bin/voice-ingest
+++ b/SYSTEM/bin/voice-ingest
@@ -8,6 +8,8 @@ Usage:
   voice-ingest --human-id <id> --channel <ch> --batch <file.jsonl>
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import os


### PR DESCRIPTION
## Summary
- Adds `from __future__ import annotations` to `SYSTEM/bin/voice-ingest` so that `bytes | None`, `str | None`, `list[float]`, and `tuple[int, int]` type hints are lazy-evaluated strings instead of runtime expressions
- This fixes the `TypeError: unsupported operand type(s) for |` crash on Python 3.9 (which macOS may ship by default)

## Test plan
- [ ] Run `python3.9 SYSTEM/bin/voice-ingest --help` and confirm no TypeError
- [ ] Run `python3.10+ SYSTEM/bin/voice-ingest --help` and confirm no regression

Fixes #80