### PR TITLE
fix(mc-board): enforce WIP limit on CLI move, process route, and cron tick

### DIFF
--- a/plugins/mc-board/cli/commands.ts
+++ b/plugins/mc-board/cli/commands.ts
@@ -4,7 +4,8 @@ import type { ProjectStore } from "../src/project-store.js";
 import { formatConflictError } from "../src/dedup.js";
 import { ActiveWorkStore } from "../src/active-work.js";
 import { ArchiveStore } from "../src/archive.js";
-import { COLUMNS, canTransition, canTransitionSystem, checkGate, formatGateError } from "../src/state.js";
+import { COLUMNS, canTransition, canTransitionSystem, checkGate, checkWipLimit, formatGateError } from "../src/state.js";
+import { getWipLimit } from "../src/store.js";
 import {
   renderCardDetail,
   renderColumnContext,
@@ -429,6 +430,18 @@ Examples:
           const gate = checkGate(card, target);
           if (!gate.ok) {
             process.stderr.write(formatGateError(card.column, target, gate.failures) + "\n");
+            process.exit(1);
+          }
+
+          // WIP limit check — reject if target column is at capacity
+          const wipLimit = getWipLimit(target, ctx.stateDir);
+          const wipCount = store.countByColumn(target);
+          const wip = checkWipLimit(wipCount, wipLimit);
+          if (!wip.ok) {
+            process.stderr.write(
+              `WIP LIMIT: "${target}" already has ${wip.current}/${wip.max} cards. ` +
+              `Use --force to override.\n`,
+            );
             process.exit(1);
           }
         }

--- a/plugins/mc-board/src/state.ts
+++ b/plugins/mc-board/src/state.ts
@@ -97,6 +97,25 @@ export function checkGate(card: Card, target: Column): GateResult {
   return failures.length === 0 ? { ok: true } : { ok: false, failures };
 }
 
+// ---- WIP limit check ----
+
+export interface WipLimitResult {
+  ok: boolean;
+  current: number;
+  max: number;
+}
+
+/**
+ * Check if a column is at or over its WIP limit.
+ * Returns { ok: true } if there's room, { ok: false, current, max } if at capacity.
+ */
+export function checkWipLimit(currentCount: number, maxConcurrent: number): WipLimitResult {
+  if (currentCount >= maxConcurrent) {
+    return { ok: false, current: currentCount, max: maxConcurrent };
+  }
+  return { ok: true, current: currentCount, max: maxConcurrent };
+}
+
 // ---- Error formatting ----
 
 export function formatGateError(from: Column, to: Column, failures: GateFailure[]): string {

--- a/plugins/mc-board/src/store.ts
+++ b/plugins/mc-board/src/store.ts
@@ -1,7 +1,37 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
 import type { Database } from "./db.js";
 import type { Card, Column, Priority, WorkLogEntry } from "./card.js";
 import { generateId, sortCards } from "./card.js";
 import { type TitleConflict, findTitleConflict } from "./dedup.js";
+
+const COL_TO_JOB: Record<string, string> = {
+  "backlog": "board-backlog-triage",
+  "in-progress": "board-in-progress-triage",
+  "in-review": "board-in-review-triage",
+};
+
+const DEFAULT_WIP_LIMIT = 3;
+
+/**
+ * Read the WIP limit (maxConcurrent) for a column from board-cron.json.
+ * Falls back to DEFAULT_WIP_LIMIT if not configured.
+ */
+export function getWipLimit(column: Column, stateDir?: string): number {
+  const dir = stateDir ?? process.env.OPENCLAW_STATE_DIR ?? path.join(os.homedir(), ".openclaw");
+  const jobsFile = process.env.BOARD_CRON_JOBS ?? path.join(dir, "USER", "brain", "board-cron.json");
+  const jobId = COL_TO_JOB[column];
+  if (!jobId) return DEFAULT_WIP_LIMIT;
+  try {
+    const raw = JSON.parse(fs.readFileSync(jobsFile, "utf8"));
+    const job = raw[jobId];
+    if (job && typeof job.maxConcurrent === "number" && job.maxConcurrent > 0) {
+      return job.maxConcurrent;
+    }
+  } catch {}
+  return DEFAULT_WIP_LIMIT;
+}
 
 type WorkType = "work" | "verify";
 
@@ -191,6 +221,11 @@ export class CardStore {
       `INSERT INTO card_history (card_id, col, moved_at) VALUES (?, ?, ?)`,
     ).run(card.id, target, now);
     return this.findById(card.id);
+  }
+
+  countByColumn(column: Column): number {
+    const row = this.db.prepare(`SELECT COUNT(*) as cnt FROM cards WHERE col = ?`).get(column) as { cnt: number };
+    return row.cnt;
   }
 
   delete(id: string): void {

--- a/plugins/mc-board/web/src/app/api/cron/tick/route.ts
+++ b/plugins/mc-board/web/src/app/api/cron/tick/route.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 import { listCronJobs, updateCronJob } from "@/lib/cron";
-import { listCards, getActiveWork } from "@/lib/data";
+import { listCards, getActiveWork, getRunningByCol } from "@/lib/data";
 import { releaseCard } from "@/lib/actions";
 import { sortCards } from "@/lib/sort";
 
@@ -174,6 +174,16 @@ export async function GET(req: Request) {
     if (!prompt) { skipped.push(`${job.id}: no prompt`); continue; }
 
     const maxConcurrent = job.maxConcurrent ?? 3;
+
+    // Subtract already-running agents from the available slots
+    const runningByCol = getRunningByCol();
+    const runningCount = (runningByCol[column] ?? []).length;
+    const availableSlots = Math.max(0, maxConcurrent - runningCount);
+    if (availableSlots === 0) {
+      skipped.push(`${job.id}: at WIP limit (${runningCount}/${maxConcurrent} running)`);
+      continue;
+    }
+
     const allCards = listCards();
     const shippedIds = new Set(allCards.filter(c => c.column === "shipped").map(c => c.id));
     const cards = sortCards(allCards.filter(c => {
@@ -187,7 +197,7 @@ export async function GET(req: Request) {
         if (c.depends_on.some(dep => !shippedIds.has(dep))) return false;
         return true;
       }), activeIds)
-      .slice(0, maxConcurrent);
+      .slice(0, availableSlots);
 
     if (cards.length === 0) { skipped.push(`${job.id}: no eligible cards`); continue; }
 

--- a/plugins/mc-board/web/src/app/api/process/[column]/[cardId]/route.ts
+++ b/plugins/mc-board/web/src/app/api/process/[column]/[cardId]/route.ts
@@ -1,9 +1,44 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getCard } from "@/lib/data";
+import { getCard, getDb } from "@/lib/data";
 import { pickupCard } from "@/lib/actions";
 import { enqueue } from "@/lib/agent-queue";
+import { listCronJobs } from "@/lib/cron";
 
 export const dynamic = "force-dynamic";
+
+const COL_TO_JOB: Record<string, string> = {
+  "backlog": "board-backlog-triage",
+  "in-progress": "board-in-progress-triage",
+  "in-review": "board-in-review-triage",
+};
+
+function getWipLimitForColumn(column: string): number {
+  const jobId = COL_TO_JOB[column];
+  if (!jobId) return 3;
+  const jobs = listCronJobs();
+  const job = jobs.find(j => j.id === jobId);
+  return job?.maxConcurrent ?? 3;
+}
+
+function countCardsInColumn(column: string): number {
+  const db = getDb();
+  if (!db) return 0;
+  try {
+    const row = db.prepare(`SELECT COUNT(*) as cnt FROM cards WHERE col = ?`).get(column) as { cnt: number };
+    return row.cnt;
+  } catch { return 0; }
+}
+
+function countQueuedOrRunning(column: string): number {
+  const db = getDb();
+  if (!db) return 0;
+  try {
+    const row = db.prepare(
+      `SELECT COUNT(*) as cnt FROM agent_queue WHERE col = ? AND status IN ('pending', 'running')`,
+    ).get(column) as { cnt: number };
+    return row.cnt;
+  } catch { return 0; }
+}
 
 export async function POST(
   req: NextRequest,
@@ -19,6 +54,16 @@ export async function POST(
   if (!card) return new Response(`Card not found: ${cardId}`, { status: 404 });
   if (card.column !== column) {
     return new Response(`Card ${cardId} is in "${card.column}", not "${column}"`, { status: 409 });
+  }
+
+  // WIP limit check — reject if too many agents already queued/running for this column
+  const wipLimit = getWipLimitForColumn(column);
+  const queuedOrRunning = countQueuedOrRunning(column);
+  if (queuedOrRunning >= wipLimit) {
+    return NextResponse.json(
+      { ok: false, reason: `WIP limit reached for "${column}": ${queuedOrRunning}/${wipLimit} agents queued/running` },
+      { status: 429 },
+    );
   }
 
   // Write to agent_queue — the standalone runner daemon picks this up and spawns claude.


### PR DESCRIPTION
## Summary
- Adds WIP limit enforcement to CLI `brain move` command — rejects moves when target column is at capacity
- Process API route returns 429 when agent queue is at WIP limit
- Cron tick subtracts running agents from available slots before enqueuing new work
- `--force` flag preserved for override when explicitly needed

Fixes #87

## Test plan
- [x] CLI move rejects at capacity (tested with 9/3 cards)
- [x] Cron tick respects running agent count
- [x] Process route returns 429 at limit
- [x] `--force` bypasses WIP check

🤖 Generated with [Claude Code](https://claude.com/claude-code)