### PR TITLE
feat(mc-board): refresh rolodex tab count on contact save/delete

### DIFF
--- a/plugins/mc-board/web/src/components/rolodex-tab.tsx
+++ b/plugins/mc-board/web/src/components/rolodex-tab.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import type { KeyboardEvent as ReactKeyboardEvent, FormEvent, MouseEvent } from "react";
+import { useSWRConfig } from "swr";
 
 interface Contact {
   id: string;
@@ -400,6 +401,7 @@ export function RolodexTab() {
   const [formMode, setFormMode] = useState<Contact | "new" | null>(null);
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
   const searchRef = useRef<HTMLInputElement>(null);
+  const { mutate: globalMutate } = useSWRConfig();
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedQuery(query), 150);
@@ -427,7 +429,8 @@ export function RolodexTab() {
   const handleSaved = useCallback(() => {
     setFormMode(null);
     fetchContacts();
-  }, [fetchContacts]);
+    globalMutate("/api/rolodex/count");
+  }, [fetchContacts, globalMutate]);
 
   const handleDelete = useCallback(async (contact: Contact) => {
     setSelected(null);
@@ -439,7 +442,8 @@ export function RolodexTab() {
     } catch {
       fetchContacts();
     }
-  }, [data, fetchContacts]);
+    globalMutate("/api/rolodex/count");
+  }, [data, fetchContacts, globalMutate]);
 
   const handleEdit = useCallback((contact: Contact) => {
     setSelected(null);


### PR DESCRIPTION
## Summary
- Adds `globalMutate('/api/rolodex/count')` calls to `handleSaved` and `handleDelete` in `rolodex-tab.tsx`
- Ensures the Rolodex tab badge count updates immediately when contacts are added or removed
- The tab already shows `Contacts (N)` via the existing `/api/rolodex/count` SWR fetch in `app-shell.tsx` — this PR completes the feature by making it reactive

Closes #50

## Test plan
- [ ] Add a new contact — verify the tab badge count increments
- [ ] Delete a contact — verify the tab badge count decrements
- [ ] Edit a contact (no add/remove) — verify the count stays the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)