### PR TITLE
feat: add Chrome with remote debugging to install

### DIFF
--- a/SYSTEM/bin/mc-chrome
+++ b/SYSTEM/bin/mc-chrome
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# mc-chrome — launch Google Chrome with remote debugging enabled
+set -euo pipefail
+
+CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+PORT="${MC_CHROME_DEBUG_PORT:-9222}"
+
+if [[ ! -x "$CHROME" ]]; then
+  echo "error: Google Chrome not found at $CHROME — install via: brew install --cask google-chrome" >&2
+  exit 1
+fi
+
+exec "$CHROME" --remote-debugging-port="$PORT" "$@"

--- a/SYSTEM/bin/mc-smoke
+++ b/SYSTEM/bin/mc-smoke
@@ -555,6 +555,22 @@ else
   fail "claude code not on PATH" "run: npm install -g @anthropic-ai/claude-code"
 fi
 
+# ── browser ──────────────────────────────────────────────────────────────────
+section "browser"
+
+if [[ -d "/Applications/Google Chrome.app" ]]; then
+  pass "Google Chrome installed"
+else
+  fail "Google Chrome not installed" "brew install --cask google-chrome"
+fi
+
+MC_CHROME="$MINICLAW_DIR/SYSTEM/bin/mc-chrome"
+if [[ -x "$MC_CHROME" ]]; then
+  pass "mc-chrome launcher present ($MC_CHROME)"
+else
+  fail "mc-chrome launcher missing" "expected at $MC_CHROME"
+fi
+
 # ── power management (macOS) ──────────────────────────────────────────────────
 if [[ "$(uname)" == "Darwin" ]]; then
   section "power management"

--- a/install.sh
+++ b/install.sh
@@ -293,6 +293,26 @@ else
     || warn "Git Butler install failed — download from https://gitbutler.com"
 fi
 
+# Google Chrome (required for browser automation via remote debugging)
+if [[ -d "/Applications/Google Chrome.app" ]]; then
+  ok "Google Chrome already installed"
+elif [[ "$CHECK_ONLY" == true ]]; then
+  fail "Google Chrome not found (/Applications/Google Chrome.app)"
+else
+  info "Installing Google Chrome..."
+  run_quiet brew install --cask google-chrome \
+    && ok "Google Chrome installed" \
+    || warn "Google Chrome install failed — download from https://google.com/chrome"
+fi
+
+# mc-chrome launcher (starts Chrome with remote debugging on port 9222)
+MC_CHROME="$REPO_DIR/SYSTEM/bin/mc-chrome"
+if [[ -x "$MC_CHROME" ]]; then
+  ok "mc-chrome launcher present"
+else
+  fail "mc-chrome launcher missing — expected at $MC_CHROME"
+fi
+
 # ── Step 2b: Power management (macOS) ────────────────────────────────────────
 if [[ "$(uname)" == "Darwin" ]]; then
   step "Step 2b: Power management (always-on)"

--- a/tests/install-checks.test.sh
+++ b/tests/install-checks.test.sh
@@ -189,6 +189,23 @@ else
 fi
 
 echo ""
+echo "── browser setup checks"
+
+# #93: install.sh references google-chrome
+if grep -q 'google-chrome' "$REPO_DIR/install.sh"; then
+  pass "#93 install.sh installs Google Chrome"
+else
+  fail "#93 install.sh missing google-chrome" "add brew install --cask google-chrome"
+fi
+
+# #93: mc-smoke has browser section
+if grep -q 'section "browser"' "$REPO_DIR/SYSTEM/bin/mc-smoke"; then
+  pass "#93 mc-smoke has browser section"
+else
+  fail "#93 mc-smoke missing browser section" "add browser checks to mc-smoke"
+fi
+
+echo ""
 echo "── vault env check"
 
 if grep -q 'OPENCLAW_VAULT_ROOT' "$REPO_DIR/plugins/mc-board/web/src/lib/vault.ts"; then


### PR DESCRIPTION
## Summary
- Adds Google Chrome installation (via `brew install --cask google-chrome`) to `install.sh` after the Git Butler step
- Creates `SYSTEM/bin/mc-chrome` launcher script that starts Chrome with `--remote-debugging-port=9222`
- Adds a `browser` section to `mc-smoke` checking Chrome is installed and `mc-chrome` is present
- Adds test assertions in `install-checks.test.sh` for the new Chrome setup

Fixes #93

## Test plan
- [x] `bash tests/install-checks.test.sh` passes (25/25)
- [ ] Run `install.sh` on a clean machine and verify Chrome is installed
- [ ] Run `mc-chrome` and verify Chrome opens with remote debugging on port 9222
- [ ] Run `mc-smoke` and verify the browser section reports pass