### PR TITLE
fix: gateway stability — mc-guardian plugin + mc-kb null safety

### DIFF
--- a/plugins/mc-guardian/index.ts
+++ b/plugins/mc-guardian/index.ts
@@ -1,0 +1,100 @@
+/**
+ * mc-guardian — OpenClaw plugin
+ *
+ * Replaces the default uncaughtException handler with one that logs non-fatal
+ * errors instead of calling process.exit(1). This prevents a single plugin's
+ * SqliteError, TypeError, or other unhandled rejection from crashing the
+ * entire gateway and killing all in-flight conversations.
+ *
+ * Fatal errors (out of memory, stack overflow) still crash the process.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+
+const FATAL_PATTERNS = [
+  /out of memory/i,
+  /allocation failed/i,
+  /maximum call stack/i,
+  /FATAL ERROR/,
+];
+
+function isFatal(err: Error): boolean {
+  const msg = err.message || "";
+  const stack = err.stack || "";
+  return FATAL_PATTERNS.some((p) => p.test(msg) || p.test(stack));
+}
+
+export default function register(api: OpenClawPluginApi): void {
+  const cfg = (api.pluginConfig ?? {}) as { enabled?: boolean };
+  const enabled = cfg.enabled ?? true;
+
+  if (!enabled) {
+    api.logger.info("mc-guardian loaded (disabled)");
+    return;
+  }
+
+  const stateDir =
+    (process.env.OPENCLAW_STATE_DIR ?? "").trim() ||
+    path.join(os.homedir(), ".openclaw");
+  const logFile = path.join(stateDir, "guardian.log");
+
+  let absorbedCount = 0;
+
+  function appendLog(level: string, msg: string): void {
+    const line = `${new Date().toISOString()} [${level}] ${msg}\n`;
+    try {
+      fs.appendFileSync(logFile, line);
+    } catch {
+      // Best-effort logging — don't crash trying to log
+    }
+  }
+
+  // Replace uncaughtException handler
+  process.removeAllListeners("uncaughtException");
+  process.on("uncaughtException", (err: Error) => {
+    if (isFatal(err)) {
+      appendLog("FATAL", `Fatal error, exiting: ${err.stack || err.message}`);
+      api.logger.error(`mc-guardian: FATAL — ${err.message} — exiting`);
+      process.exit(1);
+    }
+
+    absorbedCount++;
+    const msg = `Absorbed uncaughtException #${absorbedCount}: ${err.stack || err.message}`;
+    appendLog("WARN", msg);
+    api.logger.warn(`mc-guardian: ${msg}`);
+  });
+
+  // Also handle unhandled promise rejections
+  process.removeAllListeners("unhandledRejection");
+  process.on("unhandledRejection", (reason: unknown) => {
+    absorbedCount++;
+    const msg =
+      reason instanceof Error
+        ? reason.stack || reason.message
+        : String(reason);
+    const logMsg = `Absorbed unhandledRejection #${absorbedCount}: ${msg}`;
+    appendLog("WARN", logMsg);
+    api.logger.warn(`mc-guardian: ${logMsg}`);
+  });
+
+  // Status command
+  api.registerCommand({
+    name: "guardian_status",
+    description: "Show mc-guardian absorbed error count",
+    acceptsArgs: false,
+    handler: () => ({
+      text:
+        `*mc-guardian status*\n` +
+        `Enabled: ${enabled}\n` +
+        `Absorbed errors: ${absorbedCount}\n` +
+        `Log file: ${logFile}`,
+    }),
+  });
+
+  api.logger.info(
+    `mc-guardian loaded — replacing uncaughtException/unhandledRejection handlers`,
+  );
+}

--- a/plugins/mc-guardian/openclaw.plugin.json
+++ b/plugins/mc-guardian/openclaw.plugin.json
@@ -1,0 +1,14 @@
+{
+  "id": "mc-guardian",
+  "name": "Miniclaw Guardian",
+  "description": "Absorbs non-fatal uncaught exceptions to prevent plugin errors from crashing the gateway process.",
+  "version": "0.1.0",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": { "type": "boolean", "description": "Enable/disable guardian (default: true)" }
+    },
+    "required": []
+  }
+}

--- a/plugins/mc-guardian/package.json
+++ b/plugins/mc-guardian/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "mc-guardian",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "index.ts",
+  "description": "Absorbs non-fatal uncaught exceptions to prevent plugin errors from crashing the gateway",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/plugins/mc-kb/tools/definitions.ts
+++ b/plugins/mc-kb/tools/definitions.ts
@@ -115,7 +115,11 @@ export function createKbTools(
         summary?: string; tags?: string; source?: string; severity?: string;
       }) => {
         const start = Date.now();
-        logger.debug(`mc-kb/tool kb_add: type=${input.type} title="${input.title}"`);
+        // Defensive defaults — the LLM sometimes omits required fields
+        const type = input.type || "fact";
+        const title = input.title || "Untitled";
+        const content = input.content || "";
+        logger.debug(`mc-kb/tool kb_add: type=${type} title="${title}"`);
         try {
           const tags = input.tags
             ? input.tags.split(",").map((t) => t.trim()).filter(Boolean)
@@ -124,16 +128,16 @@ export function createKbTools(
           // Generate embedding if embedder is ready (null = not ready, falls back to FTS-only)
           let vector: Float32Array | undefined;
           try {
-            const v = await embedder.embed(`${input.title}\n${input.summary ?? ""}\n${input.content.slice(0, 512)}`);
+            const v = await embedder.embed(`${title}\n${input.summary ?? ""}\n${content.slice(0, 512)}`);
             vector = v ?? undefined;
           } catch (e) {
             logger.warn(`mc-kb/tool kb_add: embedding failed (FTS-only fallback): ${e}`);
           }
 
           const entry = store.add({
-            type: input.type as Parameters<typeof store.add>[0]["type"],
-            title: input.title,
-            content: input.content,
+            type: type as Parameters<typeof store.add>[0]["type"],
+            title: title,
+            content: content,
             summary: input.summary,
             tags,
             source: input.source ?? "agent",

--- a/tests/install-checks.test.sh
+++ b/tests/install-checks.test.sh
@@ -216,6 +216,33 @@ else
 fi
 
 echo ""
+echo "── gateway stability checks (#94)"
+
+# #94: mc-guardian plugin exists
+if [[ -f "$REPO_DIR/plugins/mc-guardian/openclaw.plugin.json" ]] && \
+   [[ -f "$REPO_DIR/plugins/mc-guardian/index.ts" ]]; then
+  pass "#94 mc-guardian plugin exists with manifest and entry point"
+else
+  fail "#94 mc-guardian plugin missing" "create plugins/mc-guardian/"
+fi
+
+# #94: mc-kb kb_add has null-safe defaults for type/title/content
+if grep -q 'input.type || "fact"' "$REPO_DIR/plugins/mc-kb/tools/definitions.ts" && \
+   grep -q 'input.title || "Untitled"' "$REPO_DIR/plugins/mc-kb/tools/definitions.ts" && \
+   grep -q 'input.content || ""' "$REPO_DIR/plugins/mc-kb/tools/definitions.ts"; then
+  pass "#94 mc-kb kb_add has null-safe defaults for type/title/content"
+else
+  fail "#94 mc-kb kb_add missing null-safe defaults" "add fallback defaults before use"
+fi
+
+# #94: mc-guardian handles uncaughtException
+if grep -q 'uncaughtException' "$REPO_DIR/plugins/mc-guardian/index.ts"; then
+  pass "#94 mc-guardian replaces uncaughtException handler"
+else
+  fail "#94 mc-guardian missing uncaughtException handler" "add process.on uncaughtException"
+fi
+
+echo ""
 echo "── vault env check"
 
 if grep -q 'OPENCLAW_VAULT_ROOT' "$REPO_DIR/plugins/mc-board/web/src/lib/vault.ts"; then


### PR DESCRIPTION
## Summary
- **mc-guardian plugin**: New plugin that replaces the default `uncaughtException` and `unhandledRejection` handlers. Non-fatal errors (SqliteError, TypeError from plugins) are absorbed and logged instead of crashing the entire gateway. Fatal errors (OOM, stack overflow) still cause process.exit(1).
- **mc-kb kb_add null safety**: Added fallback defaults for `type`, `title`, and `content` fields so undefined values from the LLM don't crash with `TypeError: Cannot read properties of undefined`.
- **Tests**: Added 3 install-checks for #94 fixes.

Note: Items #4 (ThrottleInterval) and #5 (core plugin isolation) from the issue are in openclaw core, not this repo. ThrottleInterval is already at 5 in this repo's plists. The mc-voice openDb() fix (item #2) was already applied in a prior commit.

## Test plan
- [x] `bash tests/install-checks.test.sh` passes (29/29)
- [ ] Deploy and verify mc-guardian absorbs plugin errors without crashing gateway
- [ ] Verify mc-kb kb_add handles undefined content gracefully

Fixes #94