### PR TITLE
[Claude Coder] feat: add mc-voice plugin — local speech-to-text via whisper.cpp

### DIFF
--- a/SYSTEM/bin/transcribe
+++ b/SYSTEM/bin/transcribe
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# transcribe — local speech-to-text via whisper.cpp
+#
+# Usage:
+#   transcribe <audio_file>                  # base model
+#   transcribe <audio_file> --model medium   # better accuracy, slower
+#   transcribe <audio_file> --language en    # force language
+
+set -euo pipefail
+
+STATE_DIR="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
+MINICLAW_DIR="$STATE_DIR/miniclaw"
+WHISPER_BIN="$MINICLAW_DIR/SYSTEM/bin/whisper-cpp"
+MODELS_DIR="$MINICLAW_DIR/SYSTEM/whisper-models"
+
+MODEL="base"
+LANGUAGE="en"
+AUDIO_FILE=""
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --model)   MODEL="$2"; shift 2 ;;
+    --language) LANGUAGE="$2"; shift 2 ;;
+    -h|--help)
+      echo "Usage: transcribe <audio_file> [--model tiny|base|small|medium|large] [--language en]"
+      exit 0 ;;
+    *)
+      if [[ -z "$AUDIO_FILE" ]]; then
+        AUDIO_FILE="$1"; shift
+      else
+        echo "Unknown argument: $1" >&2; exit 1
+      fi ;;
+  esac
+done
+
+[[ -z "$AUDIO_FILE" ]] && { echo "Usage: transcribe <audio_file> [--model MODEL] [--language LANG]" >&2; exit 1; }
+[[ ! -f "$AUDIO_FILE" ]] && { echo "File not found: $AUDIO_FILE" >&2; exit 1; }
+
+# Resolve model file
+if [[ "$MODEL" == "large" ]]; then
+  MODEL_FILE="$MODELS_DIR/ggml-large.bin"
+else
+  MODEL_FILE="$MODELS_DIR/ggml-${MODEL}.en.bin"
+fi
+
+[[ ! -f "$MODEL_FILE" ]] && { echo "Model not found: $MODEL_FILE" >&2; echo "Run: mc mc-voice download-model --model $MODEL" >&2; exit 1; }
+[[ ! -x "$WHISPER_BIN" ]] && { echo "whisper-cpp not found at $WHISPER_BIN" >&2; echo "Re-run install.sh to build whisper.cpp" >&2; exit 1; }
+
+# Convert to 16kHz mono WAV for whisper.cpp
+WAV_TMP=""
+if command -v sox &>/dev/null; then
+  WAV_TMP="$(mktemp /tmp/transcribe-XXXXXX.wav)"
+  sox "$AUDIO_FILE" -r 16000 -c 1 -b 16 "$WAV_TMP" 2>/dev/null || WAV_TMP=""
+fi
+
+INPUT="${WAV_TMP:-$AUDIO_FILE}"
+
+"$WHISPER_BIN" \
+  --model "$MODEL_FILE" \
+  --language "$LANGUAGE" \
+  --no-timestamps \
+  --file "$INPUT"
+
+# Clean up
+[[ -n "$WAV_TMP" && -f "$WAV_TMP" ]] && rm -f "$WAV_TMP"

--- a/install.sh
+++ b/install.sh
@@ -358,6 +358,58 @@ else
   fail "mc-chrome launcher missing — expected at $MC_CHROME"
 fi
 
+# ── Step 2a: whisper.cpp + sox (mc-voice / transcribe) ───────────────────────
+step "Step 2a: whisper.cpp (local speech-to-text)"
+
+brew_install sox sox
+
+WHISPER_BIN="$MINICLAW_DIR/SYSTEM/bin/whisper-cpp"
+WHISPER_MODELS_DIR="$MINICLAW_DIR/SYSTEM/whisper-models"
+mkdir -p "$WHISPER_MODELS_DIR"
+
+if [[ -x "$WHISPER_BIN" ]]; then
+  ok "whisper-cpp already built"
+elif [[ "$CHECK_ONLY" == true ]]; then
+  warn "whisper-cpp not found at $WHISPER_BIN"
+else
+  info "Building whisper.cpp from source..."
+  WHISPER_BUILD_DIR="/tmp/whisper-cpp-build-$$"
+  rm -rf "$WHISPER_BUILD_DIR"
+  if git clone --depth 1 https://github.com/ggerganov/whisper.cpp.git "$WHISPER_BUILD_DIR" >>"$LOG_FILE" 2>&1; then
+    if (cd "$WHISPER_BUILD_DIR" && cmake -B build -DCMAKE_BUILD_TYPE=Release >>"$LOG_FILE" 2>&1 \
+       && cmake --build build --config Release -j "$(sysctl -n hw.ncpu)" >>"$LOG_FILE" 2>&1); then
+      # Copy the main binary
+      cp "$WHISPER_BUILD_DIR/build/bin/whisper-cli" "$WHISPER_BIN" 2>/dev/null \
+        || cp "$WHISPER_BUILD_DIR/build/bin/main" "$WHISPER_BIN" 2>/dev/null \
+        || cp "$WHISPER_BUILD_DIR/build/main" "$WHISPER_BIN" 2>/dev/null
+      chmod +x "$WHISPER_BIN"
+      ok "whisper-cpp built and installed"
+    else
+      warn "whisper.cpp build failed — check $LOG_FILE"
+    fi
+    rm -rf "$WHISPER_BUILD_DIR"
+  else
+    warn "whisper.cpp clone failed — check network"
+  fi
+fi
+
+# Download default base.en model (~142MB)
+BASE_MODEL="$WHISPER_MODELS_DIR/ggml-base.en.bin"
+if [[ -f "$BASE_MODEL" ]]; then
+  ok "whisper base.en model present"
+elif [[ "$CHECK_ONLY" == true ]]; then
+  warn "whisper base.en model not found"
+else
+  info "Downloading whisper base.en model (~142MB)..."
+  if curl -fsSL "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin" -o "$BASE_MODEL.tmp" 2>>"$LOG_FILE"; then
+    mv "$BASE_MODEL.tmp" "$BASE_MODEL"
+    ok "whisper base.en model downloaded"
+  else
+    rm -f "$BASE_MODEL.tmp"
+    warn "Model download failed — run: mc mc-voice download-model"
+  fi
+fi
+
 # ── Step 2b: Power management (macOS) ────────────────────────────────────────
 if [[ "$(uname)" == "Darwin" ]]; then
   step "Step 2b: Power management (always-on)"

--- a/plugins/mc-voice/cli/commands.ts
+++ b/plugins/mc-voice/cli/commands.ts
@@ -1,0 +1,101 @@
+import type { Command } from "commander";
+import type { Logger } from "openclaw/plugin-sdk";
+import type { VoiceConfig, WhisperModel } from "../src/config.js";
+import { transcribe, downloadModel, modelExists, modelPath } from "../src/whisper.js";
+import { record, ensureSox } from "../src/recorder.js";
+
+interface Ctx {
+  program: Command;
+  cfg: VoiceConfig;
+  logger: Logger;
+}
+
+export function registerVoiceCommands(ctx: Ctx): void {
+  const { program, cfg } = ctx;
+
+  const sub = program
+    .command("mc-voice")
+    .description("Local speech-to-text via whisper.cpp");
+
+  // ---- transcribe ----
+  sub
+    .command("transcribe <file>")
+    .description("Transcribe an audio file to text using whisper.cpp")
+    .option("-m, --model <model>", "Whisper model (tiny|base|small|medium|large)", cfg.model)
+    .option("-l, --language <lang>", "Language code", cfg.language)
+    .action((file: string, opts: { model: WhisperModel; language: string }) => {
+      const result = transcribe(cfg, file, { model: opts.model, language: opts.language });
+      console.log(result.text);
+    });
+
+  // ---- record ----
+  sub
+    .command("record")
+    .description("Record audio from microphone (16kHz mono WAV)")
+    .option("-d, --duration <seconds>", "Max recording duration in seconds")
+    .option("-o, --output <file>", "Output file path")
+    .action((opts: { duration?: string; output?: string }) => {
+      const outFile = record(cfg, {
+        duration: opts.duration ? parseInt(opts.duration, 10) : undefined,
+        outputFile: opts.output,
+      });
+      console.log(outFile);
+    });
+
+  // ---- dictate (record + transcribe) ----
+  sub
+    .command("dictate")
+    .description("Record from microphone then transcribe (press Ctrl+C to stop recording)")
+    .option("-m, --model <model>", "Whisper model", cfg.model)
+    .option("-l, --language <lang>", "Language code", cfg.language)
+    .option("-d, --duration <seconds>", "Max recording duration in seconds")
+    .action((opts: { model: WhisperModel; language: string; duration?: string }) => {
+      const audioFile = record(cfg, {
+        duration: opts.duration ? parseInt(opts.duration, 10) : undefined,
+      });
+      console.log("\nTranscribing...\n");
+      const result = transcribe(cfg, audioFile, { model: opts.model, language: opts.language });
+      console.log(result.text);
+    });
+
+  // ---- download-model ----
+  sub
+    .command("download-model")
+    .description("Download a whisper.cpp model")
+    .option("-m, --model <model>", "Model to download (tiny|base|small|medium|large)", cfg.model)
+    .action(async (opts: { model: WhisperModel }) => {
+      await downloadModel(cfg, opts.model);
+    });
+
+  // ---- status ----
+  sub
+    .command("status")
+    .description("Check whisper.cpp and model availability")
+    .action(() => {
+      console.log(`whisper-cpp binary: ${cfg.whisperBin}`);
+      try {
+        const { execFileSync } = require("node:child_process");
+        execFileSync(cfg.whisperBin, ["--help"], { encoding: "utf-8", timeout: 5000 });
+        console.log("  Status: installed");
+      } catch {
+        console.log("  Status: NOT FOUND");
+      }
+
+      console.log(`\nModels directory: ${cfg.modelsDir}`);
+      const models: WhisperModel[] = ["tiny", "base", "small", "medium", "large"];
+      for (const m of models) {
+        const exists = modelExists(cfg, m);
+        const marker = exists ? "[✓]" : "[ ]";
+        console.log(`  ${marker} ${m} → ${modelPath(cfg, m)}`);
+      }
+
+      console.log(`\nRecordings: ${cfg.recordingsDir}`);
+
+      try {
+        ensureSox();
+        console.log("sox: installed");
+      } catch {
+        console.log("sox: NOT FOUND — run: brew install sox");
+      }
+    });
+}

--- a/plugins/mc-voice/index.ts
+++ b/plugins/mc-voice/index.ts
@@ -1,0 +1,17 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { resolveConfig } from "./src/config.js";
+import { registerVoiceCommands } from "./cli/commands.js";
+import { createVoiceTools } from "./tools/definitions.js";
+
+export default function register(api: OpenClawPluginApi): void {
+  const cfg = resolveConfig((api.pluginConfig ?? {}) as Record<string, unknown>);
+  api.logger.info(`mc-voice loaded (model=${cfg.model}, lang=${cfg.language})`);
+
+  api.registerCli((ctx) => {
+    registerVoiceCommands({ program: ctx.program, cfg, logger: api.logger });
+  });
+
+  for (const tool of createVoiceTools(cfg, api.logger)) {
+    api.registerTool(tool);
+  }
+}

--- a/plugins/mc-voice/openclaw.plugin.json
+++ b/plugins/mc-voice/openclaw.plugin.json
@@ -1,0 +1,13 @@
+{
+  "id": "mc-voice",
+  "name": "Miniclaw Voice",
+  "description": "Local speech-to-text via whisper.cpp — record and transcribe audio files.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "model": { "type": "string", "enum": ["tiny", "base", "small", "medium", "large"], "default": "base" },
+      "language": { "type": "string", "default": "en" }
+    }
+  }
+}

--- a/plugins/mc-voice/package.json
+++ b/plugins/mc-voice/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "mc-voice",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "index.ts",
+  "description": "Local speech-to-text via whisper.cpp — record and transcribe audio files",
+  "dependencies": {},
+  "devDependencies": {
+    "openclaw": "npm:@miniclaw_official/openclaw@^2026.3.8"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/plugins/mc-voice/smoke.test.ts
+++ b/plugins/mc-voice/smoke.test.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "vitest";
+import register from "./index.js";
+import { createVoiceTools } from "./tools/definitions.js";
+
+test("register is a default-exported function", () => {
+  expect(typeof register).toBe("function");
+});
+
+test("createVoiceTools returns an array of tools", () => {
+  const cfg = {
+    model: "base" as const,
+    language: "en",
+    whisperBin: "/tmp/whisper-cpp",
+    modelsDir: "/tmp/whisper-models",
+    recordingsDir: "/tmp/voice",
+  };
+  const tools = createVoiceTools(cfg, { info() {}, warn() {}, error() {}, debug() {} } as any);
+  expect(Array.isArray(tools)).toBe(true);
+  expect(tools.length).toBeGreaterThan(0);
+  for (const t of tools) {
+    expect(typeof t.name).toBe("string");
+    expect(t.name).toMatch(/^voice_/);
+  }
+});

--- a/plugins/mc-voice/src/config.ts
+++ b/plugins/mc-voice/src/config.ts
@@ -1,0 +1,32 @@
+import * as path from "node:path";
+import * as os from "node:os";
+
+const STATE_DIR = process.env.OPENCLAW_STATE_DIR ?? path.join(os.homedir(), ".openclaw");
+
+export type WhisperModel = "tiny" | "base" | "small" | "medium" | "large";
+
+export interface VoiceConfig {
+  model: WhisperModel;
+  language: string;
+  whisperBin: string;
+  modelsDir: string;
+  recordingsDir: string;
+}
+
+const VALID_MODELS: WhisperModel[] = ["tiny", "base", "small", "medium", "large"];
+
+export function resolveConfig(raw: Record<string, unknown>): VoiceConfig {
+  const model = VALID_MODELS.includes(raw.model as WhisperModel)
+    ? (raw.model as WhisperModel)
+    : "base";
+
+  const miniclaw = path.join(STATE_DIR, "miniclaw");
+
+  return {
+    model,
+    language: (raw.language as string) || "en",
+    whisperBin: path.join(miniclaw, "SYSTEM", "bin", "whisper-cpp"),
+    modelsDir: path.join(miniclaw, "SYSTEM", "whisper-models"),
+    recordingsDir: path.join(miniclaw, "USER", "voice"),
+  };
+}

--- a/plugins/mc-voice/src/recorder.ts
+++ b/plugins/mc-voice/src/recorder.ts
@@ -1,0 +1,71 @@
+import { spawn, execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { VoiceConfig } from "./config.js";
+
+function timestamp(): string {
+  return new Date().toISOString().replace(/[:.]/g, "-").replace("T", "_").slice(0, 19);
+}
+
+export function ensureSox(): void {
+  try {
+    execFileSync("sox", ["--version"], { encoding: "utf-8" });
+  } catch {
+    throw new Error("sox not found. Install with: brew install sox");
+  }
+}
+
+/**
+ * Record audio from the default microphone using sox.
+ * Returns the path to the recorded WAV file.
+ */
+export function record(
+  cfg: VoiceConfig,
+  opts?: { duration?: number; outputFile?: string },
+): string {
+  ensureSox();
+
+  fs.mkdirSync(cfg.recordingsDir, { recursive: true });
+
+  const outFile = opts?.outputFile
+    ?? path.join(cfg.recordingsDir, `recording-${timestamp()}.wav`);
+
+  const args = [
+    "-d",                  // default audio device
+    "-r", "16000",         // 16kHz sample rate (whisper.cpp expects this)
+    "-c", "1",             // mono
+    "-b", "16",            // 16-bit
+    outFile,
+  ];
+
+  if (opts?.duration) {
+    args.push("trim", "0", String(opts.duration));
+  }
+
+  console.log(`Recording to ${outFile} ...`);
+  console.log("Press Ctrl+C to stop recording.\n");
+
+  // Run rec (sox's recording alias) synchronously
+  try {
+    execFileSync("rec", args, {
+      stdio: "inherit",
+      timeout: opts?.duration ? (opts.duration + 5) * 1000 : 600_000, // 10 min max
+    });
+  } catch (err: any) {
+    // Ctrl+C triggers SIGINT which throws — that's the normal stop signal
+    if (err.status === null || err.signal === "SIGINT") {
+      // Normal termination via Ctrl+C
+    } else {
+      throw err;
+    }
+  }
+
+  if (!fs.existsSync(outFile)) {
+    throw new Error("Recording failed — no output file created.");
+  }
+
+  const stat = fs.statSync(outFile);
+  const durationSec = Math.round((stat.size - 44) / (16000 * 2)); // rough WAV duration
+  console.log(`\nRecorded: ${outFile} (~${durationSec}s)`);
+  return outFile;
+}

--- a/plugins/mc-voice/src/whisper.ts
+++ b/plugins/mc-voice/src/whisper.ts
@@ -1,0 +1,130 @@
+import { execFileSync, execFile } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as https from "node:https";
+import type { VoiceConfig, WhisperModel } from "./config.js";
+
+const MODEL_URLS: Record<WhisperModel, string> = {
+  tiny: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.en.bin",
+  base: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin",
+  small: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.en.bin",
+  medium: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.en.bin",
+  large: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large.bin",
+};
+
+function modelFileName(model: WhisperModel): string {
+  return model === "large" ? "ggml-large.bin" : `ggml-${model}.en.bin`;
+}
+
+export function modelPath(cfg: VoiceConfig, model?: WhisperModel): string {
+  return path.join(cfg.modelsDir, modelFileName(model ?? cfg.model));
+}
+
+export function modelExists(cfg: VoiceConfig, model?: WhisperModel): boolean {
+  return fs.existsSync(modelPath(cfg, model));
+}
+
+function followRedirects(url: string, dest: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const request = (u: string) => {
+      https.get(u, (res) => {
+        if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          request(res.headers.location);
+          return;
+        }
+        if (res.statusCode !== 200) {
+          reject(new Error(`Download failed: HTTP ${res.statusCode}`));
+          return;
+        }
+        const file = fs.createWriteStream(dest);
+        res.pipe(file);
+        file.on("finish", () => { file.close(); resolve(); });
+        file.on("error", reject);
+      }).on("error", reject);
+    };
+    request(url);
+  });
+}
+
+export async function downloadModel(cfg: VoiceConfig, model?: WhisperModel): Promise<string> {
+  const m = model ?? cfg.model;
+  const dest = modelPath(cfg, m);
+
+  if (fs.existsSync(dest)) return dest;
+
+  fs.mkdirSync(cfg.modelsDir, { recursive: true });
+
+  const url = MODEL_URLS[m];
+  const tmp = dest + ".tmp";
+  console.log(`Downloading whisper model ${m} ...`);
+  await followRedirects(url, tmp);
+  fs.renameSync(tmp, dest);
+  console.log(`Model saved: ${dest}`);
+  return dest;
+}
+
+export interface TranscribeResult {
+  text: string;
+  file: string;
+  model: WhisperModel;
+}
+
+export function transcribe(
+  cfg: VoiceConfig,
+  audioFile: string,
+  opts?: { model?: WhisperModel; language?: string },
+): TranscribeResult {
+  const m = opts?.model ?? cfg.model;
+  const lang = opts?.language ?? cfg.language;
+  const mPath = modelPath(cfg, m);
+
+  if (!fs.existsSync(mPath)) {
+    throw new Error(`Model not found: ${mPath}\nRun: mc mc-voice download-model --model ${m}`);
+  }
+
+  if (!fs.existsSync(audioFile)) {
+    throw new Error(`Audio file not found: ${audioFile}`);
+  }
+
+  // whisper.cpp main binary: expects 16kHz WAV input
+  // Use sox to convert to 16kHz mono WAV if needed
+  const wavFile = ensureWav16k(audioFile);
+
+  const args = [
+    "--model", mPath,
+    "--language", lang,
+    "--no-timestamps",
+    "--file", wavFile,
+  ];
+
+  const result = execFileSync(cfg.whisperBin, args, {
+    encoding: "utf-8",
+    timeout: 300_000, // 5 min max
+  });
+
+  // Clean up temp wav if we created one
+  if (wavFile !== audioFile && fs.existsSync(wavFile)) {
+    fs.unlinkSync(wavFile);
+  }
+
+  const text = result.trim();
+  return { text, file: audioFile, model: m };
+}
+
+function ensureWav16k(file: string): string {
+  const ext = path.extname(file).toLowerCase();
+
+  // If already a .wav, check if it needs conversion
+  // Always convert to be safe — sox is fast
+  const tmp = file + ".16k.wav";
+  try {
+    execFileSync("sox", [file, "-r", "16000", "-c", "1", "-b", "16", tmp], {
+      encoding: "utf-8",
+      timeout: 60_000,
+    });
+    return tmp;
+  } catch {
+    // If sox fails, assume the file is already correct format
+    return file;
+  }
+}

--- a/plugins/mc-voice/tools/definitions.ts
+++ b/plugins/mc-voice/tools/definitions.ts
@@ -1,0 +1,164 @@
+/**
+ * mc-voice — Agent tool definitions
+ *
+ * Gives the agent the ability to transcribe audio files using whisper.cpp.
+ */
+
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { AnyAgentTool } from "openclaw/plugin-sdk";
+import type { Logger } from "pino";
+import type { VoiceConfig, WhisperModel } from "../src/config.js";
+
+function schema(props: Record<string, unknown>, required?: string[]): unknown {
+  return {
+    type: "object",
+    properties: props,
+    required: required ?? [],
+    additionalProperties: false,
+  };
+}
+
+function str(description: string): unknown {
+  return { type: "string", description };
+}
+
+function optStr(description: string): unknown {
+  return { type: "string", description };
+}
+
+function ok(text: string) {
+  return { content: [{ type: "text" as const, text: text.trim() }], details: {} };
+}
+
+function toolErr(text: string) {
+  return {
+    content: [{ type: "text" as const, text: text.trim() }],
+    isError: true,
+    details: {},
+  };
+}
+
+function ensureWav16k(file: string): string {
+  const tmp = file + ".16k.wav";
+  try {
+    execFileSync("sox", [file, "-r", "16000", "-c", "1", "-b", "16", tmp], {
+      encoding: "utf-8",
+      timeout: 60_000,
+    });
+    return tmp;
+  } catch {
+    return file;
+  }
+}
+
+export function createVoiceTools(cfg: VoiceConfig, logger: Logger): AnyAgentTool[] {
+  return [
+    {
+      name: "voice_transcribe",
+      label: "Voice Transcribe",
+      description:
+        "Transcribe an audio file to text using whisper.cpp (local, offline). " +
+        "Accepts any audio format — WAV, MP3, M4A, OGG, FLAC, etc. " +
+        "Returns the transcribed text. Use this to read voice messages, " +
+        "audio notes, or any spoken content the user sends.",
+      parameters: schema(
+        {
+          file: str("Absolute path to the audio file"),
+          model: optStr("Whisper model: tiny, base (default), small, medium, large"),
+        },
+        ["file"],
+      ) as never,
+      execute: async (_toolCallId: string, input: { file: string; model?: WhisperModel }) => {
+        logger.debug(`mc-voice/tool voice_transcribe: file=${input.file}`);
+        try {
+          const audioFile = input.file;
+          if (!fs.existsSync(audioFile)) {
+            return toolErr(`Audio file not found: ${audioFile}`);
+          }
+
+          const model = input.model ?? cfg.model;
+          const modelFile = model === "large"
+            ? path.join(cfg.modelsDir, "ggml-large.bin")
+            : path.join(cfg.modelsDir, `ggml-${model}.en.bin`);
+
+          if (!fs.existsSync(modelFile)) {
+            return toolErr(`Model not found: ${modelFile}\nRun: mc mc-voice download-model --model ${model}`);
+          }
+
+          const wavFile = ensureWav16k(audioFile);
+
+          const result = execFileSync(cfg.whisperBin, [
+            "--model", modelFile,
+            "--language", cfg.language,
+            "--no-timestamps",
+            "--file", wavFile,
+          ], {
+            encoding: "utf-8",
+            timeout: 300_000,
+          });
+
+          // Clean up temp wav
+          if (wavFile !== audioFile && fs.existsSync(wavFile)) {
+            fs.unlinkSync(wavFile);
+          }
+
+          const text = result.trim();
+          if (!text) return ok("(no speech detected)");
+          return ok(text);
+        } catch (e: unknown) {
+          const msg = e instanceof Error ? e.message : String(e);
+          logger.error(`mc-voice/tool voice_transcribe error: ${msg}`);
+          return toolErr(`voice_transcribe failed: ${msg}`);
+        }
+      },
+    },
+
+    {
+      name: "voice_record",
+      label: "Voice Record",
+      description:
+        "Record audio from the system microphone using sox. " +
+        "Returns the path to the recorded WAV file (16kHz mono). " +
+        "Requires a duration — the recording stops automatically after the specified seconds.",
+      parameters: schema(
+        {
+          duration: str("Recording duration in seconds (required)"),
+        },
+        ["duration"],
+      ) as never,
+      execute: async (_toolCallId: string, input: { duration: string }) => {
+        logger.debug(`mc-voice/tool voice_record: duration=${input.duration}`);
+        try {
+          fs.mkdirSync(cfg.recordingsDir, { recursive: true });
+
+          const ts = new Date().toISOString().replace(/[:.]/g, "-").replace("T", "_").slice(0, 19);
+          const outFile = path.join(cfg.recordingsDir, `recording-${ts}.wav`);
+
+          execFileSync("rec", [
+            "-d",
+            "-r", "16000",
+            "-c", "1",
+            "-b", "16",
+            outFile,
+            "trim", "0", input.duration,
+          ], {
+            encoding: "utf-8",
+            timeout: (parseInt(input.duration, 10) + 10) * 1000,
+          });
+
+          if (!fs.existsSync(outFile)) {
+            return toolErr("Recording failed — no output file created.");
+          }
+
+          return ok(`Recorded: ${outFile}`);
+        } catch (e: unknown) {
+          const msg = e instanceof Error ? e.message : String(e);
+          logger.error(`mc-voice/tool voice_record error: ${msg}`);
+          return toolErr(`voice_record failed: ${msg}`);
+        }
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## Summary

- Adds `mc-voice` plugin using whisper.cpp (same engine as [whisper-hotkey](https://github.com/augmentedmike/whisper-hotkey)) for local, offline speech-to-text
- Agent tools (`voice_transcribe`, `voice_record`) so the agent can immediately read voice messages / audio files
- CLI commands: `transcribe`, `record`, `dictate`, `download-model`, `status`
- `SYSTEM/bin/transcribe` standalone tool matching TOOLS.md spec
- `install.sh` Step 2a: builds whisper.cpp from source, installs sox, downloads base.en model (~142MB)

## Plugin structure

```
plugins/mc-voice/
├── index.ts                 # plugin entry, registers CLI + agent tools
├── openclaw.plugin.json     # manifest
├── package.json
├── smoke.test.ts
├── cli/commands.ts          # mc mc-voice <cmd>
├── src/
│   ├── config.ts            # model, language, paths
│   ├── recorder.ts          # sox mic recording (16kHz mono WAV)
│   └── whisper.ts           # whisper.cpp transcription engine
└── tools/definitions.ts     # voice_transcribe, voice_record agent tools
```

## Test plan

- [ ] `./install.sh` builds whisper.cpp and downloads base.en model
- [ ] `transcribe <audio_file>` works from SYSTEM/bin
- [ ] `mc mc-voice status` shows whisper-cpp + model + sox status
- [ ] `mc mc-voice transcribe <file>` transcribes audio
- [ ] `mc mc-voice record -d 5` records 5s of audio
- [ ] Agent can call `voice_transcribe` tool on audio files
- [ ] Smoke test passes: `bun test plugins/mc-voice/smoke.test.ts`

Fixes #116

[Claude Coder]