### PR TITLE
[Claude Coder] feat: clickable card deep links in Telegram messages

### DIFF
--- a/plugins/mc-queue/index.ts
+++ b/plugins/mc-queue/index.ts
@@ -214,7 +214,13 @@ export default function register(api: OpenClawPluginApi) {
   const applyToDMs = cfg.applyToDMs ?? true;
   const tgLogChatId = cfg.tgLogChatId ?? "";
   const tgBotName = cfg.tgBotName ?? "";
-  const boardUrl = process.env.MINICLAW_BOARD_URL ?? cfg.boardUrl ?? "";
+
+  // Board URL: env var → plugin config → gateway.externalUrl from openclaw.json
+  const gatewayExternalUrl =
+    (api.config as Record<string, unknown> & {
+      gateway?: { externalUrl?: string };
+    })?.gateway?.externalUrl ?? "";
+  const boardUrl = process.env.MINICLAW_BOARD_URL ?? cfg.boardUrl ?? gatewayExternalUrl;
 
   // Read bot token from OpenClaw's telegram channel config
   const tgBotToken =
@@ -264,8 +270,22 @@ export default function register(api: OpenClawPluginApi) {
       ? `[WHO YOU ARE]\n${SOUL_CONTEXT}\n\n`
       : "";
 
-    const telegramInstructions = TELEGRAM_INSTRUCTIONS
+    let telegramInstructions = TELEGRAM_INSTRUCTIONS
       || "You are a helpful assistant handling Telegram messages. Be direct, concise, and honest.";
+
+    // Inject dynamic board URL so the agent constructs clickable card deep links.
+    // Replaces any hardcoded localhost URL in the workspace template.
+    if (boardUrl) {
+      const baseUrl = boardUrl.replace(/\/$/, "");
+      telegramInstructions = telegramInstructions
+        .replace(/http:\/\/myam\.localhost:4220/g, baseUrl)
+        .replace(/\{board_url\}/g, baseUrl);
+      telegramInstructions +=
+        `\n\n## Card links\n` +
+        `When referencing a board card, always include a clickable link.\n` +
+        `Format: ${baseUrl}/board/{project_id}/{card_id}\n` +
+        `If you don't know the project_id, use: ${baseUrl}/board/{card_id}`;
+    }
 
     return {
       prependContext: `${soulSection}[TELEGRAM — mc-queue plugin]\n${telegramInstructions}`,

--- a/workspace/refs/telegram.md
+++ b/workspace/refs/telegram.md
@@ -15,7 +15,7 @@ Needs a tool call to look something up.
 ## TASK
 Research, building, writing, deploying, anything multi-step.
 - Use `brain_create_card` to create a HIGH priority board card with the full task context
-- Acknowledge naturally and share the card link: "On it — [title](http://myam.localhost:4220/board/c/{card_id})"
+- Acknowledge naturally and share the card link: "On it — [title]({board_url}/board/{card_id})"
 - STOP. Do NOT do the work here. The board runner picks it up automatically.
 
 ## Available tools


### PR DESCRIPTION
## Summary

- `boardUrl` now falls back to `gateway.externalUrl` from `openclaw.json` (Tailscale IP set during install), so card links work from mobile off the local network
- mc-queue dynamically injects the board URL into the Telegram prompt, replacing the hardcoded `myam.localhost:4220`
- Agent is instructed to always include clickable deep links when referencing board cards
- `telegram.md` template uses `{board_url}` placeholder instead of hardcoded URL

## URL resolution chain

`MINICLAW_BOARD_URL` env → `mc-queue.boardUrl` config → `gateway.externalUrl` → (empty)

## Test plan

- [ ] Set `gateway.externalUrl` in `openclaw.json` (e.g. `http://100.x.x.x:4220`)
- [ ] Send a Telegram message that triggers a TASK classification
- [ ] Agent responds with clickable card link using Tailscale URL, not localhost
- [ ] Log channel ship/human_needed messages also use the correct URL
- [ ] Deep link opens the correct card in the web UI

Fixes #73

[Claude Coder]