### PR TITLE
[Claude Coder] feat: add mc-calendar plugin — Apple Calendar via macOS EventKit

### DIFF
--- a/plugins/mc-calendar/Info.plist
+++ b/plugins/mc-calendar/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>com.miniclaw.calendar-helper</string>
+	<key>CFBundleName</key>
+	<string>MiniClaw Calendar</string>
+	<key>CFBundleExecutable</key>
+	<string>calendar-helper</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>MiniClaw needs calendar access so your agent can manage your schedule.</string>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>MiniClaw needs full calendar access so your agent can create, update, and delete events on your behalf.</string>
+</dict>
+</plist>

--- a/plugins/mc-calendar/calendar-helper.swift
+++ b/plugins/mc-calendar/calendar-helper.swift
@@ -1,0 +1,270 @@
+import EventKit
+import Foundation
+
+// MARK: - Helpers
+
+let store = EKEventStore()
+var outputPath: String? = nil
+
+func requestAccess() {
+    let sem = DispatchSemaphore(value: 0)
+    var granted = false
+    var requestError: Error?
+    store.requestFullAccessToEvents { g, err in
+        granted = g
+        requestError = err
+        sem.signal()
+    }
+    sem.wait()
+    if !granted {
+        if let requestError {
+            fail("Calendar access denied: \(requestError.localizedDescription)")
+        }
+        fail("Calendar access denied. Grant access in System Settings > Privacy & Security > Calendars.")
+    }
+}
+
+let dateFmt: DateFormatter = {
+    let f = DateFormatter()
+    f.dateFormat = "yyyy-MM-dd HH:mm"
+    f.locale = Locale(identifier: "en_US_POSIX")
+    return f
+}()
+
+let dayFmt: DateFormatter = {
+    let f = DateFormatter()
+    f.dateFormat = "yyyy-MM-dd"
+    f.locale = Locale(identifier: "en_US_POSIX")
+    return f
+}()
+
+func formatDate(_ d: Date) -> String {
+    dateFmt.string(from: d)
+}
+
+func parseDate(_ s: String) -> Date? {
+    dateFmt.date(from: s) ?? dayFmt.date(from: s)
+}
+
+func jsonString(_ obj: Any) -> String {
+    let data = try! JSONSerialization.data(withJSONObject: obj, options: [.prettyPrinted, .sortedKeys])
+    return String(data: data, encoding: .utf8)!
+}
+
+func emit(_ obj: Any) {
+    let out = jsonString(obj)
+    if let path = outputPath {
+        do {
+            try out.write(toFile: path, atomically: true, encoding: .utf8)
+            return
+        } catch {}
+    }
+    print(out)
+}
+
+func fail(_ msg: String) -> Never {
+    let obj: [String: Any] = ["error": msg]
+    emit(obj)
+    exit(0)
+}
+
+func eventDict(_ e: EKEvent, full: Bool = false) -> [String: Any] {
+    var d: [String: Any] = [
+        "uid": e.eventIdentifier ?? "",
+        "summary": e.title ?? "",
+        "start": formatDate(e.startDate),
+        "end": formatDate(e.endDate),
+        "allDay": e.isAllDay,
+        "location": e.location ?? NSNull(),
+        "calendar": e.calendar.title,
+    ]
+    if full {
+        d["description"] = (e.notes ?? "").isEmpty ? NSNull() : e.notes!
+        d["url"] = e.url?.absoluteString ?? NSNull()
+        if let rules = e.recurrenceRules, !rules.isEmpty {
+            d["recurrence"] = rules.map { $0.description }.joined(separator: "; ")
+        } else {
+            d["recurrence"] = NSNull()
+        }
+    }
+    return d
+}
+
+func findCalendar(_ name: String) -> EKCalendar? {
+    store.calendars(for: .event).first { $0.title == name }
+}
+
+func refreshStore() {
+    store.reset()
+}
+
+// MARK: - Operations
+
+func listCalendars() {
+    let cals = store.calendars(for: .event).map { cal -> [String: Any] in
+        ["name": cal.title, "writable": cal.allowsContentModifications]
+    }
+    emit(["result": cals])
+}
+
+func listEvents(daysAhead: Int, calendarName: String?) {
+    refreshStore()
+    let start = Calendar.current.startOfDay(for: Date())
+    guard let end = Calendar.current.date(byAdding: .day, value: daysAhead + 1, to: start) else {
+        fail("Invalid days_ahead value")
+    }
+
+    var calendars: [EKCalendar]? = nil
+    if let name = calendarName {
+        guard let cal = findCalendar(name) else { fail("Calendar '\(name)' not found") }
+        calendars = [cal]
+    }
+
+    let predicate = store.predicateForEvents(withStart: start, end: end, calendars: calendars)
+    let events = store.events(matching: predicate)
+    emit(["result": events.map { eventDict($0) }])
+}
+
+func searchEvents(query: String, daysAhead: Int, calendarName: String?) {
+    refreshStore()
+    let start = Calendar.current.startOfDay(for: Date())
+    guard let end = Calendar.current.date(byAdding: .day, value: daysAhead + 1, to: start) else {
+        fail("Invalid days_ahead value")
+    }
+
+    var calendars: [EKCalendar]? = nil
+    if let name = calendarName {
+        guard let cal = findCalendar(name) else { fail("Calendar '\(name)' not found") }
+        calendars = [cal]
+    }
+
+    let predicate = store.predicateForEvents(withStart: start, end: end, calendars: calendars)
+    let events = store.events(matching: predicate)
+    let q = query.lowercased()
+    let matched = events.filter { e in
+        (e.title ?? "").localizedCaseInsensitiveContains(q) ||
+        (e.location ?? "").localizedCaseInsensitiveContains(q) ||
+        (e.notes ?? "").localizedCaseInsensitiveContains(q)
+    }
+    emit(["result": matched.map { eventDict($0) }])
+}
+
+func readEvent(uid: String, calendarName: String?) {
+    refreshStore()
+    guard let event = store.event(withIdentifier: uid) else {
+        fail("Event with UID '\(uid)' not found")
+    }
+    if let name = calendarName, event.calendar.title != name {
+        fail("Event with UID '\(uid)' not found in calendar '\(name)'")
+    }
+    emit(["result": eventDict(event, full: true)])
+}
+
+func createEvent(calendarName: String, summary: String, startStr: String, endStr: String,
+                 location: String?, description: String?, allDay: Bool) {
+    guard let cal = findCalendar(calendarName) else { fail("Calendar '\(calendarName)' not found") }
+    guard cal.allowsContentModifications else { fail("Calendar '\(calendarName)' is read-only") }
+    guard let startDate = parseDate(startStr) else { fail("Invalid start_date: '\(startStr)'") }
+    guard let endDate = parseDate(endStr) else { fail("Invalid end_date: '\(endStr)'") }
+
+    let event = EKEvent(eventStore: store)
+    event.calendar = cal
+    event.title = summary
+    event.startDate = startDate
+    event.endDate = endDate
+    event.isAllDay = allDay
+    if let loc = location { event.location = loc }
+    if let desc = description { event.notes = desc }
+
+    do {
+        try store.save(event, span: .thisEvent, commit: true)
+        emit(["result": ["uid": event.eventIdentifier ?? "", "summary": summary, "calendar": calendarName]])
+    } catch {
+        fail("Failed to create event: \(error.localizedDescription)")
+    }
+}
+
+func updateEvent(uid: String, calendarName: String?, summary: String?, startStr: String?,
+                 endStr: String?, location: String?, description: String?, allDay: Bool?) {
+    refreshStore()
+    guard let event = store.event(withIdentifier: uid) else { fail("Event '\(uid)' not found") }
+    guard event.calendar.allowsContentModifications else { fail("Calendar '\(event.calendar.title)' is read-only") }
+
+    if let s = summary { event.title = s }
+    if let s = startStr, let d = parseDate(s) { event.startDate = d }
+    if let s = endStr, let d = parseDate(s) { event.endDate = d }
+    if let s = location { event.location = s }
+    if let s = description { event.notes = s }
+    if let a = allDay { event.isAllDay = a }
+
+    do {
+        try store.save(event, span: .thisEvent, commit: true)
+        emit(["result": ["uid": uid, "updated": true]])
+    } catch {
+        fail("Failed to update event: \(error.localizedDescription)")
+    }
+}
+
+func deleteEvent(uid: String) {
+    refreshStore()
+    guard let event = store.event(withIdentifier: uid) else { fail("Event '\(uid)' not found") }
+    guard event.calendar.allowsContentModifications else { fail("Calendar '\(event.calendar.title)' is read-only") }
+    let name = event.title ?? ""
+    do {
+        try store.remove(event, span: .thisEvent, commit: true)
+        emit(["result": ["uid": uid, "deleted": true, "summary": name]])
+    } catch {
+        fail("Failed to delete event: \(error.localizedDescription)")
+    }
+}
+
+// MARK: - Main
+
+let args = CommandLine.arguments
+guard args.count >= 2 else {
+    fail("Usage: calendar-helper <operation> [json-params] [output-file]")
+}
+
+let operation = args[1]
+var params: [String: Any] = [:]
+if args.count >= 3, let data = args[2].data(using: .utf8) {
+    params = (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+}
+if args.count >= 4 {
+    outputPath = args[3]
+}
+
+requestAccess()
+
+switch operation {
+case "list":
+    listCalendars()
+case "events":
+    let daysAhead = (params["days_ahead"] as? Int) ?? 0
+    listEvents(daysAhead: daysAhead, calendarName: params["calendar"] as? String)
+case "search":
+    guard let query = params["query"] as? String else { fail("Missing 'query'") }
+    searchEvents(query: query, daysAhead: (params["days_ahead"] as? Int) ?? 30, calendarName: params["calendar"] as? String)
+case "read":
+    guard let uid = params["event_uid"] as? String else { fail("Missing 'event_uid'") }
+    readEvent(uid: uid, calendarName: params["calendar"] as? String)
+case "create":
+    guard let cal = params["calendar"] as? String else { fail("Missing 'calendar'") }
+    guard let summary = params["summary"] as? String else { fail("Missing 'summary'") }
+    guard let startDate = params["start_date"] as? String else { fail("Missing 'start_date'") }
+    guard let endDate = params["end_date"] as? String else { fail("Missing 'end_date'") }
+    createEvent(calendarName: cal, summary: summary, startStr: startDate, endStr: endDate,
+                location: params["location"] as? String, description: params["description"] as? String,
+                allDay: params["all_day"] as? Bool ?? false)
+case "update":
+    guard let uid = params["event_uid"] as? String else { fail("Missing 'event_uid'") }
+    updateEvent(uid: uid, calendarName: params["calendar"] as? String,
+                summary: params["summary"] as? String, startStr: params["start_date"] as? String,
+                endStr: params["end_date"] as? String, location: params["location"] as? String,
+                description: params["description"] as? String, allDay: params["all_day"] as? Bool)
+case "delete":
+    guard let uid = params["event_uid"] as? String else { fail("Missing 'event_uid'") }
+    deleteEvent(uid: uid)
+default:
+    fail("Unknown operation: \(operation)")
+}

--- a/plugins/mc-calendar/cli/commands.ts
+++ b/plugins/mc-calendar/cli/commands.ts
@@ -1,0 +1,156 @@
+import type { Command } from "commander";
+import type { Logger } from "openclaw/plugin-sdk";
+import type { CalendarConfig } from "../src/config.js";
+import { calHelperSync, ensureHelper } from "../src/helper.js";
+
+interface Ctx {
+  program: Command;
+  cfg: CalendarConfig;
+  logger: Logger;
+}
+
+export function registerCalendarCommands(ctx: Ctx): void {
+  const { program, cfg } = ctx;
+
+  const sub = program
+    .command("mc-calendar")
+    .description("Apple Calendar — list, create, search, and manage events");
+
+  // ---- list ----
+  sub
+    .command("list")
+    .description("List all calendars")
+    .action(() => {
+      const res = calHelperSync(cfg, "list");
+      if (res.error) { console.error(res.error); process.exit(1); }
+      for (const cal of res.result) {
+        const rw = cal.writable ? "rw" : "ro";
+        console.log(`  [${rw}] ${cal.name}`);
+      }
+    });
+
+  // ---- events ----
+  sub
+    .command("events")
+    .description("List upcoming events")
+    .option("-d, --days <n>", "Days ahead (default 7)", "7")
+    .option("-c, --calendar <name>", "Filter by calendar name")
+    .action((opts: { days: string; calendar?: string }) => {
+      const res = calHelperSync(cfg, "events", {
+        days_ahead: parseInt(opts.days, 10),
+        calendar: opts.calendar,
+      });
+      if (res.error) { console.error(res.error); process.exit(1); }
+      if (!res.result.length) { console.log("No events found."); return; }
+      for (const ev of res.result) {
+        const time = ev.allDay ? "all-day" : `${ev.start} — ${ev.end}`;
+        console.log(`  ${time}  ${ev.summary}`);
+        if (ev.location) console.log(`    📍 ${ev.location}`);
+        console.log(`    [${ev.calendar}] ${ev.uid}`);
+        console.log();
+      }
+    });
+
+  // ---- search ----
+  sub
+    .command("search <query>")
+    .description("Search events by text")
+    .option("-d, --days <n>", "Days ahead to search (default 30)", "30")
+    .option("-c, --calendar <name>", "Filter by calendar name")
+    .action((query: string, opts: { days: string; calendar?: string }) => {
+      const res = calHelperSync(cfg, "search", {
+        query,
+        days_ahead: parseInt(opts.days, 10),
+        calendar: opts.calendar,
+      });
+      if (res.error) { console.error(res.error); process.exit(1); }
+      if (!res.result.length) { console.log("No events found."); return; }
+      for (const ev of res.result) {
+        console.log(`  ${ev.start}  ${ev.summary}  [${ev.calendar}]`);
+      }
+    });
+
+  // ---- read ----
+  sub
+    .command("read <uid>")
+    .description("Read full event details by UID")
+    .action((uid: string) => {
+      const res = calHelperSync(cfg, "read", { event_uid: uid });
+      if (res.error) { console.error(res.error); process.exit(1); }
+      const ev = res.result;
+      console.log(`UID:       ${ev.uid}`);
+      console.log(`Summary:   ${ev.summary}`);
+      console.log(`Calendar:  ${ev.calendar}`);
+      console.log(`Start:     ${ev.start}`);
+      console.log(`End:       ${ev.end}`);
+      console.log(`All-day:   ${ev.allDay}`);
+      if (ev.location) console.log(`Location:  ${ev.location}`);
+      if (ev.description) console.log(`Notes:     ${ev.description}`);
+      if (ev.url) console.log(`URL:       ${ev.url}`);
+      if (ev.recurrence) console.log(`Recurrence: ${ev.recurrence}`);
+    });
+
+  // ---- create ----
+  sub
+    .command("create")
+    .description("Create a new event")
+    .requiredOption("-c, --calendar <name>", "Calendar name")
+    .requiredOption("-s, --summary <text>", "Event title")
+    .requiredOption("--start <datetime>", "Start (YYYY-MM-DD HH:MM)")
+    .requiredOption("--end <datetime>", "End (YYYY-MM-DD HH:MM)")
+    .option("-l, --location <text>", "Location")
+    .option("-n, --notes <text>", "Notes/description")
+    .option("--all-day", "All-day event")
+    .action((opts: {
+      calendar: string; summary: string; start: string; end: string;
+      location?: string; notes?: string; allDay?: boolean;
+    }) => {
+      const res = calHelperSync(cfg, "create", {
+        calendar: opts.calendar,
+        summary: opts.summary,
+        start_date: opts.start,
+        end_date: opts.end,
+        location: opts.location,
+        description: opts.notes,
+        all_day: opts.allDay ?? false,
+      });
+      if (res.error) { console.error(res.error); process.exit(1); }
+      console.log(`Created: ${res.result.summary} (${res.result.uid})`);
+    });
+
+  // ---- delete ----
+  sub
+    .command("delete <uid>")
+    .description("Delete an event by UID")
+    .action((uid: string) => {
+      const res = calHelperSync(cfg, "delete", { event_uid: uid });
+      if (res.error) { console.error(res.error); process.exit(1); }
+      console.log(`Deleted: ${res.result.summary} (${uid})`);
+    });
+
+  // ---- status ----
+  sub
+    .command("status")
+    .description("Check EventKit access and list calendars")
+    .action(() => {
+      console.log(`Helper binary: ${cfg.helperBin}`);
+      try {
+        ensureHelper(cfg);
+        console.log("  Status: compiled");
+      } catch (e: any) {
+        console.log(`  Status: NOT COMPILED — ${e.message}`);
+        return;
+      }
+      try {
+        const res = calHelperSync(cfg, "list");
+        if (res.error) { console.log(`  EventKit: ${res.error}`); return; }
+        console.log(`  EventKit: access granted`);
+        console.log(`  Calendars: ${res.result.length}`);
+        for (const cal of res.result) {
+          console.log(`    [${cal.writable ? "rw" : "ro"}] ${cal.name}`);
+        }
+      } catch (e: any) {
+        console.log(`  EventKit: error — ${e.message}`);
+      }
+    });
+}

--- a/plugins/mc-calendar/index.ts
+++ b/plugins/mc-calendar/index.ts
@@ -1,0 +1,22 @@
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { resolveConfig } from "./src/config.js";
+import { registerCalendarCommands } from "./cli/commands.js";
+import { createCalendarTools } from "./tools/definitions.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default function register(api: OpenClawPluginApi): void {
+  const cfg = resolveConfig((api.pluginConfig ?? {}) as Record<string, unknown>, __dirname);
+
+  api.logger.info(`mc-calendar loaded (defaultCalendar=${cfg.defaultCalendar || "(auto)"})`);
+
+  api.registerCli((ctx) => {
+    registerCalendarCommands({ program: ctx.program, cfg, logger: api.logger });
+  });
+
+  for (const tool of createCalendarTools(cfg, api.logger)) {
+    api.registerTool(tool);
+  }
+}

--- a/plugins/mc-calendar/openclaw.plugin.json
+++ b/plugins/mc-calendar/openclaw.plugin.json
@@ -1,0 +1,12 @@
+{
+  "id": "mc-calendar",
+  "name": "Miniclaw Calendar",
+  "description": "Apple Calendar integration via macOS EventKit — list, create, update, delete, and search events.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "defaultCalendar": { "type": "string" }
+    }
+  }
+}

--- a/plugins/mc-calendar/package.json
+++ b/plugins/mc-calendar/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "mc-calendar",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "index.ts",
+  "description": "Apple Calendar integration via macOS EventKit — list, create, update, delete, and search events",
+  "os": ["darwin"],
+  "dependencies": {},
+  "devDependencies": {
+    "openclaw": "npm:@miniclaw_official/openclaw@^2026.3.8"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/plugins/mc-calendar/smoke.test.ts
+++ b/plugins/mc-calendar/smoke.test.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "vitest";
+import register from "./index.js";
+import { createCalendarTools } from "./tools/definitions.js";
+
+test("register is a default-exported function", () => {
+  expect(typeof register).toBe("function");
+});
+
+test("createCalendarTools returns an array of tools", () => {
+  const cfg = {
+    defaultCalendar: "",
+    helperBin: "/tmp/calendar-helper",
+    pluginDir: "/tmp/mc-calendar",
+  };
+  const tools = createCalendarTools(cfg, { info() {}, warn() {}, error() {}, debug() {} } as any);
+  expect(Array.isArray(tools)).toBe(true);
+  expect(tools.length).toBe(7);
+  for (const t of tools) {
+    expect(typeof t.name).toBe("string");
+    expect(t.name).toMatch(/^calendar_/);
+  }
+});

--- a/plugins/mc-calendar/src/config.ts
+++ b/plugins/mc-calendar/src/config.ts
@@ -1,0 +1,18 @@
+import * as path from "node:path";
+import * as os from "node:os";
+
+const STATE_DIR = process.env.OPENCLAW_STATE_DIR ?? path.join(os.homedir(), ".openclaw");
+
+export interface CalendarConfig {
+  defaultCalendar: string;
+  helperBin: string;
+  pluginDir: string;
+}
+
+export function resolveConfig(raw: Record<string, unknown>, pluginDir: string): CalendarConfig {
+  return {
+    defaultCalendar: (raw.defaultCalendar as string) || "",
+    helperBin: path.join(pluginDir, "calendar-helper.app", "Contents", "MacOS", "calendar-helper"),
+    pluginDir,
+  };
+}

--- a/plugins/mc-calendar/src/helper.ts
+++ b/plugins/mc-calendar/src/helper.ts
@@ -1,0 +1,93 @@
+import { execFileSync, execFile } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { promisify } from "node:util";
+import type { CalendarConfig } from "./config.js";
+
+const execFileAsync = promisify(execFile);
+
+export function ensureHelper(cfg: CalendarConfig): void {
+  const swiftSrc = path.join(cfg.pluginDir, "calendar-helper.swift");
+  const infoPlist = path.join(cfg.pluginDir, "Info.plist");
+  const appBundle = path.join(cfg.pluginDir, "calendar-helper.app");
+  const binDir = path.join(appBundle, "Contents", "MacOS");
+  const bin = cfg.helperBin;
+
+  const needsCompile =
+    !fs.existsSync(bin) ||
+    fs.statSync(swiftSrc).mtimeMs > fs.statSync(bin).mtimeMs ||
+    fs.statSync(infoPlist).mtimeMs > fs.statSync(bin).mtimeMs;
+
+  if (!needsCompile) return;
+
+  fs.mkdirSync(binDir, { recursive: true });
+  execFileSync("swiftc", ["-O", swiftSrc, "-o", bin], {
+    encoding: "utf-8",
+    timeout: 60_000,
+  });
+  fs.copyFileSync(infoPlist, path.join(appBundle, "Contents", "Info.plist"));
+  execFileSync("codesign", [
+    "-s", "-", "--identifier", "com.miniclaw.calendar-helper",
+    "--force", appBundle,
+  ], {
+    encoding: "utf-8",
+    timeout: 10_000,
+  });
+}
+
+export async function calHelper(
+  cfg: CalendarConfig,
+  operation: string,
+  params: Record<string, unknown> = {},
+): Promise<{ result?: any; error?: string }> {
+  ensureHelper(cfg);
+
+  const payload = JSON.stringify(params);
+  const appBundle = path.join(cfg.pluginDir, "calendar-helper.app");
+
+  // Try launching as .app first (gets proper EventKit permissions),
+  // fall back to direct binary execution
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mc-calendar-"));
+  const outputFile = path.join(tmpDir, "result.json");
+
+  try {
+    try {
+      await execFileAsync("open", ["-W", "-n", appBundle, "--args", operation, payload, outputFile], {
+        encoding: "utf-8",
+        timeout: 30_000,
+      });
+    } catch {
+      // App launch failed — try direct binary
+      const { stdout } = await execFileAsync(cfg.helperBin, [operation, payload], {
+        encoding: "utf-8",
+        maxBuffer: 10 * 1024 * 1024,
+      });
+      return JSON.parse(stdout.trim());
+    }
+
+    if (!fs.existsSync(outputFile)) {
+      throw new Error("Calendar helper did not return a result file");
+    }
+    const output = fs.readFileSync(outputFile, "utf-8").trim();
+    if (!output) throw new Error("Calendar helper returned empty output");
+    return JSON.parse(output);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+export function calHelperSync(
+  cfg: CalendarConfig,
+  operation: string,
+  params: Record<string, unknown> = {},
+): { result?: any; error?: string } {
+  ensureHelper(cfg);
+  const payload = JSON.stringify(params);
+  const stdout = execFileSync(cfg.helperBin, [operation, payload], {
+    encoding: "utf-8",
+    maxBuffer: 10 * 1024 * 1024,
+    timeout: 30_000,
+  });
+  return JSON.parse(stdout.trim());
+}

--- a/plugins/mc-calendar/tools/definitions.ts
+++ b/plugins/mc-calendar/tools/definitions.ts
@@ -1,0 +1,198 @@
+import type { AnyAgentTool } from "openclaw/plugin-sdk";
+import type { Logger } from "pino";
+import type { CalendarConfig } from "../src/config.js";
+import { calHelper } from "../src/helper.js";
+
+function schema(props: Record<string, unknown>, required?: string[]): unknown {
+  return { type: "object", properties: props, required: required ?? [], additionalProperties: false };
+}
+function str(description: string): unknown { return { type: "string", description }; }
+function optStr(description: string): unknown { return { type: "string", description }; }
+function optNum(description: string): unknown { return { type: "number", description }; }
+function optBool(description: string): unknown { return { type: "boolean", description }; }
+
+function ok(data: unknown) {
+  const text = typeof data === "string" ? data : JSON.stringify(data, null, 2);
+  return { content: [{ type: "text" as const, text }], details: {} };
+}
+function toolErr(text: string) {
+  return { content: [{ type: "text" as const, text }], isError: true, details: {} };
+}
+
+export function createCalendarTools(cfg: CalendarConfig, logger: Logger): AnyAgentTool[] {
+  return [
+    {
+      name: "calendar_list",
+      label: "Calendar List",
+      description: "List all calendars on this Mac with name and writable status.",
+      parameters: schema({}) as never,
+      execute: async () => {
+        try {
+          const res = await calHelper(cfg, "list");
+          if (res.error) return toolErr(res.error);
+          return ok(res.result);
+        } catch (e: unknown) {
+          return toolErr(`calendar_list failed: ${e instanceof Error ? e.message : e}`);
+        }
+      },
+    },
+
+    {
+      name: "calendar_events",
+      label: "Calendar Events",
+      description:
+        "List upcoming calendar events. Returns events from today through days_ahead. " +
+        "Use this to check the schedule before creating new events.",
+      parameters: schema({
+        days_ahead: optNum("Days ahead to include (0 = today only, default 7)"),
+        calendar: optStr("Calendar name to filter by (omit for all calendars)"),
+      }) as never,
+      execute: async (_id: string, input: { days_ahead?: number; calendar?: string }) => {
+        try {
+          const res = await calHelper(cfg, "events", {
+            days_ahead: input.days_ahead ?? 7,
+            calendar: input.calendar,
+          });
+          if (res.error) return toolErr(res.error);
+          return ok(res.result);
+        } catch (e: unknown) {
+          return toolErr(`calendar_events failed: ${e instanceof Error ? e.message : e}`);
+        }
+      },
+    },
+
+    {
+      name: "calendar_search",
+      label: "Calendar Search",
+      description:
+        "Search events by text (case-insensitive match against title, location, and notes).",
+      parameters: schema({
+        query: str("Search text"),
+        days_ahead: optNum("Days ahead to search (default 30)"),
+        calendar: optStr("Calendar name to filter by"),
+      }, ["query"]) as never,
+      execute: async (_id: string, input: { query: string; days_ahead?: number; calendar?: string }) => {
+        try {
+          const res = await calHelper(cfg, "search", {
+            query: input.query,
+            days_ahead: input.days_ahead ?? 30,
+            calendar: input.calendar,
+          });
+          if (res.error) return toolErr(res.error);
+          return ok(res.result);
+        } catch (e: unknown) {
+          return toolErr(`calendar_search failed: ${e instanceof Error ? e.message : e}`);
+        }
+      },
+    },
+
+    {
+      name: "calendar_read",
+      label: "Calendar Read",
+      description: "Read full details of a single event by UID (includes notes, URL, recurrence).",
+      parameters: schema({
+        event_uid: str("The event UID"),
+        calendar: optStr("Calendar name (optional, narrows search)"),
+      }, ["event_uid"]) as never,
+      execute: async (_id: string, input: { event_uid: string; calendar?: string }) => {
+        try {
+          const res = await calHelper(cfg, "read", {
+            event_uid: input.event_uid,
+            calendar: input.calendar,
+          });
+          if (res.error) return toolErr(res.error);
+          return ok(res.result);
+        } catch (e: unknown) {
+          return toolErr(`calendar_read failed: ${e instanceof Error ? e.message : e}`);
+        }
+      },
+    },
+
+    {
+      name: "calendar_create",
+      label: "Calendar Create",
+      description:
+        "Create a new calendar event. Dates use 'YYYY-MM-DD HH:MM' for timed events " +
+        "or 'YYYY-MM-DD' for all-day events.",
+      parameters: schema({
+        calendar: str("Calendar name (must be writable)"),
+        summary: str("Event title"),
+        start_date: str("Start date — 'YYYY-MM-DD HH:MM' or 'YYYY-MM-DD' for all-day"),
+        end_date: str("End date — 'YYYY-MM-DD HH:MM' or 'YYYY-MM-DD' for all-day"),
+        location: optStr("Event location"),
+        description: optStr("Event notes/description"),
+        all_day: optBool("Whether this is an all-day event (default false)"),
+      }, ["calendar", "summary", "start_date", "end_date"]) as never,
+      execute: async (_id: string, input: {
+        calendar: string; summary: string; start_date: string; end_date: string;
+        location?: string; description?: string; all_day?: boolean;
+      }) => {
+        logger.info(`mc-calendar: creating event "${input.summary}" on ${input.calendar}`);
+        try {
+          const res = await calHelper(cfg, "create", {
+            calendar: input.calendar,
+            summary: input.summary,
+            start_date: input.start_date,
+            end_date: input.end_date,
+            location: input.location,
+            description: input.description,
+            all_day: input.all_day,
+          });
+          if (res.error) return toolErr(res.error);
+          return ok(res.result);
+        } catch (e: unknown) {
+          return toolErr(`calendar_create failed: ${e instanceof Error ? e.message : e}`);
+        }
+      },
+    },
+
+    {
+      name: "calendar_update",
+      label: "Calendar Update",
+      description: "Update an existing event's properties by UID.",
+      parameters: schema({
+        event_uid: str("The event UID to update"),
+        calendar: optStr("Calendar name (narrows search)"),
+        summary: optStr("New title"),
+        start_date: optStr("New start date"),
+        end_date: optStr("New end date"),
+        location: optStr("New location"),
+        description: optStr("New notes"),
+        all_day: optBool("Set all-day status"),
+      }, ["event_uid"]) as never,
+      execute: async (_id: string, input: {
+        event_uid: string; calendar?: string; summary?: string;
+        start_date?: string; end_date?: string; location?: string;
+        description?: string; all_day?: boolean;
+      }) => {
+        logger.info(`mc-calendar: updating event ${input.event_uid}`);
+        try {
+          const res = await calHelper(cfg, "update", input);
+          if (res.error) return toolErr(res.error);
+          return ok(res.result);
+        } catch (e: unknown) {
+          return toolErr(`calendar_update failed: ${e instanceof Error ? e.message : e}`);
+        }
+      },
+    },
+
+    {
+      name: "calendar_delete",
+      label: "Calendar Delete",
+      description: "Delete an event by UID.",
+      parameters: schema({
+        event_uid: str("The event UID to delete"),
+      }, ["event_uid"]) as never,
+      execute: async (_id: string, input: { event_uid: string }) => {
+        logger.info(`mc-calendar: deleting event ${input.event_uid}`);
+        try {
+          const res = await calHelper(cfg, "delete", { event_uid: input.event_uid });
+          if (res.error) return toolErr(res.error);
+          return ok(res.result);
+        } catch (e: unknown) {
+          return toolErr(`calendar_delete failed: ${e instanceof Error ? e.message : e}`);
+        }
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## Summary

- Native macOS Calendar.app integration via EventKit — no Google dependency, no UI
- Swift helper binary compiles at install time, communicates via JSON
- Reads/writes the same store as Calendar.app — iCloud, Google, Exchange just work
- 7 agent tools: `calendar_list`, `calendar_events`, `calendar_search`, `calendar_read`, `calendar_create`, `calendar_update`, `calendar_delete`
- Full CLI: `mc mc-calendar list/events/search/read/create/delete/status`
- Adapted from [openclaw-apple-calendar](https://www.npmjs.com/package/openclaw-apple-calendar) (MIT) into mc-* conventions

## Plugin structure

```
plugins/mc-calendar/
├── index.ts                  # registers CLI + 7 agent tools
├── calendar-helper.swift     # EventKit Swift binary (compiles at install)
├── Info.plist                # .app bundle for EventKit permissions
├── openclaw.plugin.json
├── package.json
├── smoke.test.ts
├── cli/commands.ts           # mc mc-calendar <cmd>
├── src/
│   ├── config.ts
│   └── helper.ts             # Swift helper compile + invoke
└── tools/definitions.ts      # 7 agent tools
```

## Test plan

- [ ] `mc mc-calendar status` compiles Swift helper and shows calendars
- [ ] `mc mc-calendar list` shows all calendars with rw/ro status
- [ ] `mc mc-calendar events --days 7` lists upcoming events
- [ ] `mc mc-calendar create -c "Home" -s "Test" --start "2026-03-20 15:00" --end "2026-03-20 16:00"` creates event
- [ ] Agent can call `calendar_events` and `calendar_create` tools
- [ ] Smoke test passes: `bun test plugins/mc-calendar/smoke.test.ts`

Fixes #123

[Claude Coder]