### PR TITLE
fix: respect focus tag in suggestNext and renderColumnContext

### DIFF
--- a/plugins/mc-board/src/board.ts
+++ b/plugins/mc-board/src/board.ts
@@ -278,6 +278,11 @@ export function suggestNext(cards: Card[]): Card | null {
   if (active.length === 0) return null;
 
   return active.sort((a, b) => {
+    // Focus-tagged cards always come first
+    const aF = a.tags.includes("focus") ? 1 : 0;
+    const bF = b.tags.includes("focus") ? 1 : 0;
+    if (aF !== bF) return bF - aF;
+
     const colDiff = columnScore[b.column] - columnScore[a.column];
     if (colDiff !== 0) return colDiff;
     return (priorityScore[b.priority] ?? 0) - (priorityScore[a.priority] ?? 0);
@@ -303,6 +308,11 @@ export function renderColumnContext(col: Column, cards: Card[], projects: Projec
   const priorityScore: Record<string, number> = { critical: 4, high: 3, medium: 2, low: 1 };
   const sortCards = (list: Card[]) =>
     [...list].sort((a, b) => {
+      // Focus-tagged cards always come first
+      const aF = a.tags.includes("focus") ? 1 : 0;
+      const bF = b.tags.includes("focus") ? 1 : 0;
+      if (aF !== bF) return bF - aF;
+
       const pd = (priorityScore[b.priority] ?? 0) - (priorityScore[a.priority] ?? 0);
       if (pd !== 0) return pd;
       return a.created_at.localeCompare(b.created_at);

--- a/plugins/mc-board/tools/definitions.ts
+++ b/plugins/mc-board/tools/definitions.ts
@@ -177,7 +177,8 @@ export const brainTools: AnyAgentTool[] = [
     label: "Brain Next Task",
     description:
       "Get the highest-priority actionable card to work on next. " +
-      "Prefers in-progress > in-review > backlog, then high > medium > low priority.",
+      "Focus-tagged cards always come first. Then prefers in-progress > in-review > backlog, " +
+      "then critical > high > medium > low priority.",
     parameters: schema({}) as never,
     execute: async () => {
       const { stdout, stderr, exitCode } = runBrain(["next"]);


### PR DESCRIPTION
## Summary

- `suggestNext()` ignored the `focus` tag — FOCUS+CRITICAL cards were skipped in favor of non-focus MEDIUM cards
- `renderColumnContext()`'s inner sort also ignored `focus` — cron workers saw focus cards in the wrong order
- Both now check for `focus` tag first, matching the canonical `sortCards()` in `card.ts`
- Updated `brain_next_task` tool description to mention focus priority

## Root cause

`card.ts:sortCards()` correctly puts focus first:
```ts
const aF = a.tags.includes("focus") ? 0 : 1;
```

But `board.ts:suggestNext()` and `renderColumnContext()` had their own sort logic that skipped this check.

## Test plan

- [ ] Tag a CRITICAL card with `focus`, have MEDIUM cards in same column
- [ ] `mc brain next` returns the focus card
- [ ] Cron worker `brain_column_context` lists focus cards first
- [ ] Non-focus cards still sort by priority then age

Fixes #126