### PR TITLE
fix: pass worker prompt as --system-prompt for reliable Haiku execution

### DIFF
--- a/plugins/mc-board/agent-runner/runner.mjs
+++ b/plugins/mc-board/agent-runner/runner.mjs
@@ -287,7 +287,8 @@ function spawnFullAgent(row, card, project) {
   }
 
   const cardMd = card ? cardToMarkdown(card) : `Card ${row.card_id} (details unavailable)`;
-  const fullPrompt = row.prompt.replace("{{CARD}}", cardMd).replace(/\{\{CARD_ID\}\}/g, row.card_id);
+  const systemPrompt = row.prompt.replace("{{CARD}}", "").replace(/\{\{CARD_ID\}\}/g, row.card_id).trim();
+  const userPrompt = `Here is the card to work on:\n\n${cardMd}\n\nCard ID: ${row.card_id}\n\nExecute the instructions in your system prompt now. Do not ask questions. Do not summarize. Use tools immediately.`;
   const agentCwd = (project?.work_dir && fs.existsSync(project.work_dir)) ? project.work_dir : runDir;
 
   fs.writeFileSync(path.join(runDir, "CLAUDE.md"), [
@@ -307,7 +308,9 @@ function spawnFullAgent(row, card, project) {
     "Plugin repo (public, backport target): ~/.openclaw/projects/miniclaw-os/",
     `Live state dir: ${STATE_DIR}`,
     "",
-    "You are a full autonomous agent. Use tools freely to do the actual work.",
+    "You are a non-interactive automation agent. Execute your instructions immediately using tool calls.",
+    "NEVER ask questions. NEVER generate conversational responses. NEVER summarize the board state.",
+    "If you cannot proceed, exit silently. Do not explain why.",
     "Update the card via: openclaw mc-board update / move / release",
     "",
     "## Available CLI tools (use via Bash)",
@@ -348,7 +351,8 @@ function spawnFullAgent(row, card, project) {
   const proc = spawn("stdbuf", [
     "-oL",
     CLAUDE_BIN,
-    "-p", fullPrompt,
+    "--system-prompt", systemPrompt,
+    "-p", userPrompt,
     "--output-format", "stream-json",
     "--include-partial-messages",
     "--verbose",


### PR DESCRIPTION
## Summary
- Splits `runner.mjs` agent spawn: worker instructions go to `--system-prompt`, card data goes to `-p`
- Adds anti-chat directives to the CLAUDE.md written into each agent's runDir
- Haiku now receives behavioral instructions in the system role where it reliably follows them

## Root cause
Worker prompt was passed via `-p` (user message). Haiku treats user messages as conversation starters and responds with "What would you like me to focus on?" instead of executing tool calls. Sonnet/Opus follow instructions regardless of message role, but Haiku does not.

## Changes
- `plugins/mc-board/agent-runner/runner.mjs`: split `fullPrompt` into `systemPrompt` + `userPrompt`, pass via `--system-prompt` and `-p` respectively
- CLAUDE.md template: replaced "You are a full autonomous agent" with explicit non-interactive directives

Fixes #131

## Test plan
- [ ] Deploy updated runner.mjs to live install
- [ ] Wait for backlog worker cron to fire (5 min)
- [ ] Verify worker executes mc-board commands (check cron runs output)
- [ ] Verify backlog cards get triaged and moved to in-progress
- [ ] Confirm no conversational responses in worker output