### PR TITLE
fix(mc-email): parse multipart MIME bodies using mailparser

### DIFF
--- a/plugins/mc-email/cli/commands.ts
+++ b/plugins/mc-email/cli/commands.ts
@@ -91,7 +91,10 @@ export function registerEmailCommands(ctx: Ctx): void {
       console.log(`Date:    ${msg.date}`);
       console.log(`Subject: ${msg.subject}`);
       console.log(`Flags:   ${msg.labelIds.join(", ")}`);
-      if (msg.snippet) {
+      if (msg.body) {
+        console.log();
+        console.log(msg.body);
+      } else if (msg.snippet) {
         console.log();
         console.log(msg.snippet);
       }

--- a/plugins/mc-email/package.json
+++ b/plugins/mc-email/package.json
@@ -8,6 +8,7 @@
     "google-auth-library": "^9.0.0",
     "googleapis": "^144.0.0",
     "imapflow": "^1.2.12",
+    "mailparser": "^3.9.4",
     "nodemailer": "^8.0.1"
   },
   "devDependencies": {

--- a/plugins/mc-email/src/client.ts
+++ b/plugins/mc-email/src/client.ts
@@ -1,5 +1,6 @@
 import { ImapFlow } from "imapflow";
 import nodemailer from "nodemailer";
+import { simpleParser } from "mailparser";
 import type { EmailConfig } from "./config.js";
 import { getAppPassword } from "./vault.js";
 import type { EmailMessage, SendEmailOptions } from "./types.js";
@@ -74,11 +75,30 @@ export class GmailClient {
     try {
       await client.mailboxOpen("INBOX");
       let found: EmailMessage | null = null;
+
       for await (const msg of client.fetch(
         { uid: parseInt(id, 10) },
-        { uid: true, envelope: true, flags: true, bodyStructure: true },
+        {
+          uid: true,
+          envelope: true,
+          flags: true,
+          source: true,
+        },
         { uid: true }
       )) {
+        let body = "";
+        let snippet = "";
+
+        if (msg.source) {
+          const parsed = await simpleParser(msg.source);
+          body = parsed.text ?? "";
+          if (!body && parsed.html) {
+            // Strip HTML tags as fallback when no plain-text part exists
+            body = parsed.html.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+          }
+          snippet = body.substring(0, 500);
+        }
+
         found = {
           id: String(msg.uid),
           threadId: String(msg.uid),
@@ -88,13 +108,15 @@ export class GmailClient {
             : "",
           to: msg.envelope?.to?.[0]?.address ?? "",
           date: msg.envelope?.date?.toISOString() ?? "",
-          snippet: "",
+          snippet,
+          body,
           labelIds: msg.flags ? Array.from(msg.flags) : [],
         };
         break;
       }
       return found;
-    } catch {
+    } catch (err) {
+      console.error("Error fetching message:", err);
       return null;
     } finally {
       await client.logout();


### PR DESCRIPTION
## Summary
- `getMessage()` now fetches full RFC822 source and parses with `mailparser`'s `simpleParser` instead of naive body extraction
- Correctly handles multipart/mixed, forwarded messages, base64, and quoted-printable encodings
- CLI `read` command prints full body content instead of just snippet

## Test plan
- [x] Tested against UID 92 (forwarded multipart/mixed email)
- [x] Tested against UID 95 (GitHub notification)
- [x] Verified backport matches live plugin

Fixes: crd_d05de939

🤖 Generated with [Claude Code](https://claude.com/claude-code)