### PR TITLE
feat(mc-board): add memory stats pill to dashboard top bar

### DIFF
--- a/plugins/mc-board/web/src/app/api/memory/stats/route.ts
+++ b/plugins/mc-board/web/src/app/api/memory/stats/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from "next/server";
+import { getMemoryStats } from "@/lib/memory-stats";
+
+export async function GET() {
+  return NextResponse.json(getMemoryStats());
+}

--- a/plugins/mc-board/web/src/components/app-shell.tsx
+++ b/plugins/mc-board/web/src/components/app-shell.tsx
@@ -73,6 +73,7 @@ export function AppShell({ initialTab, initialCardId, initialProjectId }: { init
   const { showWelcome, dismissWelcome } = useWelcomeWizard();
   const [assistantName, setAssistantName] = useState("Am");
   const { data: rolodexCount } = useSWR<{ count: number }>("/api/rolodex/count", fetcher, { refreshInterval: 60000 });
+  const { data: memoryStats } = useSWR<{ memoryFiles: number; kbEntries: number; total: number }>("/api/memory/stats", fetcher, { refreshInterval: 60000 });
 
   // Fetch assistant name for empty-state message
   useEffect(() => {
@@ -156,7 +157,8 @@ export function AppShell({ initialTab, initialCardId, initialProjectId }: { init
           <div className="tab-bar">
             {(["board", "memory", "rolodex", "settings"] as Tab[]).map(t => {
               const activeCount = t === "board" && counts ? counts.inProgress + counts.inReview : 0;
-              const badgeCount = t === "rolodex" && rolodexCount ? rolodexCount.count : activeCount;
+              const memoryCount = t === "memory" && memoryStats ? memoryStats.total : 0;
+              const badgeCount = t === "rolodex" && rolodexCount ? rolodexCount.count : t === "memory" ? memoryCount : activeCount;
               return (
                 <button key={t} onClick={() => switchTab(t)}
                   className={`tab-btn${tab === t ? " active" : ""}`}
@@ -261,6 +263,11 @@ export function AppShell({ initialTab, initialCardId, initialProjectId }: { init
             <span className="stat-pill">in&nbsp;review<b>{counts.inReview}</b></span>
             <span className="stat-pill">shipped<b>{counts.shipped}</b></span>
             <DailyStats />
+            {memoryStats && (
+              <span className="stat-pill" title={`${memoryStats.memoryFiles} memory files, ${memoryStats.kbEntries} KB entries`}>
+                memory<b>{memoryStats.memoryFiles}&thinsp;/&thinsp;{memoryStats.kbEntries}</b>
+              </span>
+            )}
           </div>
         )}
 

--- a/plugins/mc-board/web/src/lib/memory-stats.ts
+++ b/plugins/mc-board/web/src/lib/memory-stats.ts
@@ -1,0 +1,43 @@
+import Database from "better-sqlite3";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+const _STATE = process.env.OPENCLAW_STATE_DIR ?? path.join(os.homedir(), ".openclaw");
+
+function walkMd(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const results: string[] = [];
+  for (const f of fs.readdirSync(dir)) {
+    const full = path.join(dir, f);
+    if (fs.statSync(full).isDirectory()) results.push(...walkMd(full));
+    else if (f.endsWith(".md")) results.push(full);
+  }
+  return results;
+}
+
+export interface MemoryStats {
+  memoryFiles: number;
+  kbEntries: number;
+  total: number;
+}
+
+export function getMemoryStats(): MemoryStats {
+  // Count .md files in USER/memory/ and workspace/memory/
+  const userMemDir = path.join(_STATE, "USER", "memory");
+  const wsMemDir = path.join(_STATE, "workspace", "memory");
+  const memoryFiles = walkMd(userMemDir).length + walkMd(wsMemDir).length;
+
+  // Count KB entries via SQL
+  let kbEntries = 0;
+  const kbPath = process.env.BOARD_KB_DB ?? path.join(_STATE, "USER", "kb", "kb.db");
+  if (fs.existsSync(kbPath)) {
+    try {
+      const db = new Database(kbPath, { readonly: true });
+      kbEntries = (db.prepare("SELECT COUNT(*) as n FROM entries").get() as { n: number }).n;
+      db.close();
+    } catch { /* non-fatal */ }
+  }
+
+  return { memoryFiles, kbEntries, total: memoryFiles + kbEntries };
+}


### PR DESCRIPTION
## Summary
- Adds `lib/memory-stats.ts` with `getMemoryStats()` — counts memory `.md` files (short-term) and KB entries (long-term)
- Adds `/api/memory/stats` GET endpoint returning `{memoryFiles, kbEntries, total}`
- Adds memory stat pill to dashboard top bar showing `memoryFiles / kbEntries` with tooltip, SWR refreshing every 60s
- Adds badge count on Memory tab

Follows existing rolodex count pattern. Closes #136.

## Test plan
- [ ] Verify `/api/memory/stats` returns correct counts
- [ ] Verify memory pill appears in dashboard top bar
- [ ] Verify Memory tab badge shows total count

🤖 Generated with [Claude Code](https://claude.com/claude-code)