### PR TITLE
fix(mc-voice): fallback whisper binary resolution when bundled binary has broken rpath

### DIFF
--- a/plugins/mc-voice/src/config.ts
+++ b/plugins/mc-voice/src/config.ts
@@ -1,7 +1,7 @@
 import * as path from "node:path";
 import * as os from "node:os";
 import * as fs from "node:fs";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 
 const STATE_DIR = process.env.OPENCLAW_STATE_DIR ?? path.join(os.homedir(), ".openclaw");
 
@@ -21,34 +21,27 @@ const VALID_MODELS: WhisperModel[] = ["tiny", "base", "small", "medium", "large"
  * Resolve a working whisper binary.
  * Priority:
  *   1. Bundled whisper-cpp (SYSTEM/bin/whisper-cpp) — if it loads successfully
- *   2. whisper-cli in PATH (e.g. installed via Homebrew)
- *   3. whisper-cpp in PATH
- * Returns the first binary that can be executed, or the bundled path as fallback.
+ *   2. /opt/homebrew/bin/whisper-cli (Homebrew on macOS ARM/Intel)
+ *   3. /usr/local/bin/whisper-cli
+ *   4. whisper-cpp variants in common locations
+ * Returns the first binary that actually loads, or the bundled path as fallback.
  */
 function resolveWhisperBin(bundledBin: string): string {
-  // Test if a binary is functional by running --version or --help
-  const testBin = (bin: string): boolean => {
-    if (!fs.existsSync(bin) && !bin.includes("/")) {
-      // For PATH lookups, skip existence check
-    } else if (!fs.existsSync(bin)) {
-      return false;
-    }
-    try {
-      execFileSync(bin, ["--help"], { timeout: 5000, stdio: "pipe" });
-      return true;
-    } catch {
-      // exit code 1 with output is still "working"
-      try {
-        execFileSync(bin, ["--version"], { timeout: 5000, stdio: "pipe" });
-        return true;
-      } catch (e: unknown) {
-        // If it fails with a real error (not just non-zero exit), check stderr
-        const err = e as { stderr?: Buffer; status?: number };
-        // dyld failures produce no useful stderr content — treat as broken
-        if (err.stderr && err.stderr.length > 10) return true;
-        return false;
-      }
-    }
+  /**
+   * Returns true if the binary exists and can be loaded by dyld.
+   * We use spawnSync so we can check the signal — dyld failures kill the
+   * process with a signal (SIGABRT/SIGKILL) before producing any meaningful
+   * output, whereas a working binary exits non-zero but stays alive.
+   */
+  const canLoad = (bin: string): boolean => {
+    if (!fs.existsSync(bin)) return false;
+    const result = spawnSync(bin, ["--help"], { timeout: 5000, encoding: "utf8" });
+    // dyld failures: process killed by signal or status null
+    if (result.signal !== null) return false;
+    // dyld stderr contains "Library not loaded" or "dyld"
+    const stderr = result.stderr ?? "";
+    if (stderr.includes("Library not loaded") || stderr.includes("dyld[")) return false;
+    return true;
   };
 
   const candidates = [
@@ -60,10 +53,10 @@ function resolveWhisperBin(bundledBin: string): string {
   ];
 
   for (const candidate of candidates) {
-    if (testBin(candidate)) return candidate;
+    if (canLoad(candidate)) return candidate;
   }
 
-  // No working binary found — return bundled path and let runtime surface the error
+  // No working binary found — return bundled path so runtime surfaces a clear error
   return bundledBin;
 }
 


### PR DESCRIPTION
## Problem

On a fresh MiniClaw install, the bundled `whisper-cpp` binary fails to load because its rpath references a temp build directory (`/tmp/whisper-cpp-build-XXXX/`) that no longer exists after installation. Fixes #142

## Solution

Added `resolveWhisperBin()` in `config.ts` that probes candidate binaries in order:
1. Bundled `SYSTEM/bin/whisper-cpp`
2. `/opt/homebrew/bin/whisper-cli` (Homebrew)
3. `/usr/local/bin/whisper-cli`
4. Homebrew/local `whisper-cpp`

## Testing
Verified `whisper-cli` from Homebrew transcribes .ogg voice messages using the existing ggml-base.en.bin model.