### PR TITLE
fix(mc-board): Board tab badge shows only in-progress count

### DIFF
--- a/plugins/mc-board/web/src/components/app-shell.tsx
+++ b/plugins/mc-board/web/src/components/app-shell.tsx
@@ -156,7 +156,7 @@ export function AppShell({ initialTab, initialCardId, initialProjectId }: { init
           <div className="brand">MiniClaw Brain</div>
           <div className="tab-bar">
             {(["board", "memory", "rolodex", "settings"] as Tab[]).map(t => {
-              const activeCount = t === "board" && counts ? counts.inProgress + counts.inReview : 0;
+              const activeCount = t === "board" && counts ? counts.inProgress : 0;
               const memoryCount = t === "memory" && memoryStats ? memoryStats.total : 0;
               const badgeCount = t === "rolodex" && rolodexCount ? rolodexCount.count : t === "memory" ? memoryCount : activeCount;
               return (


### PR DESCRIPTION
## Summary
- Board tab badge was displaying `inProgress + inReview` count (e.g. 3+1=4), which users interpreted as the in-progress count alone
- Changed `app-shell.tsx:159` to show only `counts.inProgress` in the badge
- Stat pills (lines 262-263) continue to show separate in-progress and in-review counts correctly

## Test plan
- [ ] Verify Board tab badge shows only in-progress card count
- [ ] Verify stat pills still show separate in-progress and in-review counts
- [ ] CI passes

Fixes crd_7d64b366

🤖 Generated with [Claude Code](https://claude.com/claude-code)