### PR TITLE
fix(release): bundle workspace/ templates in installer zip

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -100,6 +100,16 @@ if [[ -d "$BUNDLED_PLUGINS" ]]; then
   mv "$BUNDLED_PLUGINS" "$PREBUILT_STAGING"
   echo "  ✓ Pre-built plugins staged"
 fi
+
+# Stage bundled workspace templates for install.sh to use (fallback if repo clone is slow/offline)
+BUNDLED_WORKSPACE="$EXTRACT_TMP/miniclaw-installer.app/Contents/Resources/workspace"
+WORKSPACE_TEMPLATES_STAGING="$STATE_DIR/.workspace-templates"
+rm -rf "$WORKSPACE_TEMPLATES_STAGING"
+if [[ -d "$BUNDLED_WORKSPACE" ]]; then
+  mv "$BUNDLED_WORKSPACE" "$WORKSPACE_TEMPLATES_STAGING"
+  echo "  ✓ Workspace templates staged"
+fi
+
 rm -rf "$EXTRACT_TMP"
 
 # ── Prep state dir ───────────────────────────────────────────────────────────

--- a/install.sh
+++ b/install.sh
@@ -1636,8 +1636,13 @@ step "Step 15e: Agent identity"
 
 WORKSPACE_DIR="$STATE_DIR/workspace"
 
-# Copy MiniClaw workspace templates (root + refs/) if they exist in the repo
+# Copy MiniClaw workspace templates (root + refs/) if they exist in the repo.
+# Prefer staged templates from the installer bundle (available offline/early),
+# fall back to the cloned repo's workspace/ directory.
 MC_WORKSPACE_TEMPLATES="$REPO_DIR/workspace"
+if [[ -d "${STATE_DIR}/.workspace-templates" ]]; then
+  MC_WORKSPACE_TEMPLATES="${STATE_DIR}/.workspace-templates"
+fi
 if [[ -d "$MC_WORKSPACE_TEMPLATES" ]]; then
   mkdir -p "$WORKSPACE_DIR" "$WORKSPACE_DIR/refs" "$WORKSPACE_DIR/memory"
   # Root files (always-loaded by the gateway)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -109,6 +109,14 @@ cp "$REPO_DIR/.node-version" "$APP/Contents/Resources/.node-version"
 cp -a "$DIST/miniclaw-web" "$APP/Contents/Resources/miniclaw-web"
 cp -a "$PLUGINS_PREBUILT" "$APP/Contents/Resources/plugins-prebuilt"
 
+# Bundle workspace templates so bootstrap.sh can stage them before install.sh runs
+if [[ -d "$REPO_DIR/workspace" ]]; then
+  cp -r "$REPO_DIR/workspace" "$APP/Contents/Resources/workspace"
+  echo "  ✓ Workspace templates bundled ($(find "$REPO_DIR/workspace" -name '*.md' | wc -l | tr -d ' ') files)"
+else
+  echo "  ⚠ workspace/ not found in repo — skipping template bundle"
+fi
+
 ZIP="$DIST/MiniClaw-Installer-$TAG.zip"
 (cd "$DIST" && zip -r -q "$ZIP" "miniclaw-installer.app")
 echo "  ✓ Packaged: $(du -h "$ZIP" | awk '{print $1}')"


### PR DESCRIPTION
## Problem

Closes #155

The `workspace/` directory (AGENTS.md, BOND.md, IDENTITY.md, USER.md, SOUL.md, REFERENCES.md, and `refs/*`) was added in commit 65121c6, but `scripts/release.sh` was never updated to include it in the dist bundle. As a result, fresh installs from the zip get an empty workspace and the gateway errors on template load.

## Changes

### `scripts/release.sh`
Added a step after bundling `plugins-prebuilt` to copy `$REPO_DIR/workspace` into `$APP/Contents/Resources/workspace`:
```bash
if [[ -d "$REPO_DIR/workspace" ]]; then
  cp -r "$REPO_DIR/workspace" "$APP/Contents/Resources/workspace"
  echo "  ✓ Workspace templates bundled ($(find ...) files)"
fi
```

### `bootstrap.sh`
Added extraction of bundled workspace templates alongside the existing plugins-prebuilt staging:
```bash
BUNDLED_WORKSPACE="$EXTRACT_TMP/.../Resources/workspace"
WORKSPACE_TEMPLATES_STAGING="$STATE_DIR/.workspace-templates"
if [[ -d "$BUNDLED_WORKSPACE" ]]; then
  mv "$BUNDLED_WORKSPACE" "$WORKSPACE_TEMPLATES_STAGING"
fi
```

### `install.sh`
Step 15e now prefers staged `.workspace-templates` (from the bundle, available offline and before the repo clone completes) and falls back to the cloned repo's `workspace/` directory:
```bash
if [[ -d "${STATE_DIR}/.workspace-templates" ]]; then
  MC_WORKSPACE_TEMPLATES="${STATE_DIR}/.workspace-templates"
fi
```

## Test Results

Ran a targeted packaging test (mocking the Next.js build/plugins stubs) to verify the zip contents:

```
Results: 13 passed, 0 failed
BUNDLE TEST PASSED ✓
```

Verified files present in extracted zip:
- `workspace/AGENTS.md` ✅
- `workspace/BOND.md` ✅
- `workspace/IDENTITY.md` ✅
- `workspace/SOUL.md` ✅
- `workspace/USER.md` ✅
- `workspace/REFERENCES.md` ✅
- `workspace/refs/` ✅ (10 ref files)