### PR TITLE
feat(mc-email): auto-generate email signature at runtime

### DIFF
--- a/plugins/mc-email/src/client.ts
+++ b/plugins/mc-email/src/client.ts
@@ -159,11 +159,12 @@ export class GmailClient {
         pass: password,
       },
     });
+    const body = `${opts.body}\n\n--\n${this.cfg.signature}`;
     const info = await transport.sendMail({
       from: opts.from ?? this.cfg.emailAddress,
       to: opts.to,
       subject: opts.subject,
-      text: opts.body,
+      text: body,
     });
     return info.messageId ?? "";
   }

--- a/plugins/mc-email/src/config.ts
+++ b/plugins/mc-email/src/config.ts
@@ -34,6 +34,13 @@ export function resolveConfig(raw: Record<string, unknown>): EmailConfig {
   const imapHost = (raw.imapHost as string) || (gmail ? "imap.gmail.com" : smtpHost.replace(/^smtp\./, "mail."));
   const imapPort = Number((raw.imapPort as string) || "993");
 
+  const agentName = (raw.agentName as string) || (setup.assistantName as string) || "";
+  const MINICLAW_BYLINE = "— Powered by MiniClaw - get your own FREE local AGI assistant at https://miniclaw.bot or buy the full hardware + agent at https://helloam.bot";
+  const personalPart = (raw.signature as string) ?? (agentName && emailAddress
+    ? `${agentName}\nAGI Assistant\n${emailAddress}`
+    : "");
+  const signature = personalPart ? `${personalPart}\n\n${MINICLAW_BYLINE}` : MINICLAW_BYLINE;
+
   return {
     vaultBin: (raw.vaultBin as string) || path.join(STATE_DIR, "miniclaw", "SYSTEM", "bin", "mc-vault"),
     emailAddress,
@@ -42,5 +49,6 @@ export function resolveConfig(raw: Record<string, unknown>): EmailConfig {
     smtpPort,
     imapHost,
     imapPort,
+    signature,
   };
 }


### PR DESCRIPTION
## Summary
- Auto-generates email signature from agent name + email address in setup-state.json at runtime
- Signature format: `{Agent Name}\nAGI Assistant\n{email}\n\n— Powered by MiniClaw...` with both miniclaw.bot and helloam.bot URLs
- Appends signature to all outbound emails via `--` separator in sendMessage

## Changed files
- `plugins/mc-email/src/config.ts` — Added `signature` field to EmailConfig, auto-generated from `assistantName` and `emailAddress` in setup-state.json
- `plugins/mc-email/src/client.ts` — Appends signature to email body in `sendMessage()`

## Test plan
- [ ] Verify signature resolves correctly when setup-state.json has assistantName and emailAddress
- [ ] Verify fallback to MiniClaw byline only when agent name/email not configured
- [ ] Send test email and confirm signature appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)