### PR TITLE
feat: show version next to alert bell in board top bar

### DIFF
--- a/plugins/mc-board/web/src/app/api/health/route.ts
+++ b/plugins/mc-board/web/src/app/api/health/route.ts
@@ -1,7 +1,19 @@
 import { NextResponse } from "next/server";
+import * as fs from "node:fs";
+import * as path from "node:path";
 
 export const dynamic = "force-dynamic";
 
+function getVersion(): string {
+  const stateDir = process.env.OPENCLAW_STATE_DIR || path.join(process.env.HOME || "", ".openclaw");
+  try {
+    const manifest = JSON.parse(fs.readFileSync(path.join(stateDir, "miniclaw", "MANIFEST.json"), "utf-8"));
+    return manifest.version || "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
 export function GET() {
-  return NextResponse.json({ ok: true, time: new Date().toISOString() });
+  return NextResponse.json({ ok: true, version: getVersion(), time: new Date().toISOString() });
 }

--- a/plugins/mc-board/web/src/components/app-shell.tsx
+++ b/plugins/mc-board/web/src/components/app-shell.tsx
@@ -75,6 +75,7 @@ export function AppShell({ initialTab, initialCardId, initialProjectId }: { init
   const [assistantName, setAssistantName] = useState("Am");
   const { data: rolodexCount } = useSWR<{ count: number }>("/api/rolodex/count", fetcher, { refreshInterval: 60000 });
   const { data: memoryStats } = useSWR<{ memoryFiles: number; kbEntries: number; total: number }>("/api/memory/stats", fetcher, { refreshInterval: 60000 });
+  const { data: health } = useSWR<{ version: string }>("/api/health", fetcher, { refreshInterval: 300000 });
 
   // Fetch assistant name for empty-state message
   useEffect(() => {
@@ -281,6 +282,11 @@ export function AppShell({ initialTab, initialCardId, initialProjectId }: { init
               fill="currentColor" />
           </svg>
         </button>
+        {health?.version && (
+          <span className="flex items-center px-3 border-l border-zinc-800 text-zinc-500 text-xs font-mono shrink-0 h-full">
+            v{health.version}
+          </span>
+        )}
       </div>
 
       {/* Main content + Chat panel flex row */}


### PR DESCRIPTION
## Summary

- Adds version display (e.g. `v0.1.7`) to the right of the alert bell in the top bar
- Version read from MANIFEST.json via `/api/health` endpoint
- Mono font, zinc-500, subtle — doesn't compete with other UI elements

Fixes #169