### PR TITLE
feat(mc-queue): model routing — Haiku for chat, Sonnet for planning, Opus for coding

### DIFF
--- a/plugins/mc-queue/__tests__/model-routing.test.ts
+++ b/plugins/mc-queue/__tests__/model-routing.test.ts
@@ -1,0 +1,132 @@
+/**
+ * model-routing.test.ts
+ *
+ * Unit tests for the before_model_resolve hook's session-type routing.
+ * Verifies: messaging → Haiku, board-worker → Opus, other cron → Sonnet.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import register from "../index";
+
+type HookHandler = (event: unknown, ctx: Record<string, unknown>) => Promise<unknown>;
+
+function createMockApi(pluginConfig: Record<string, unknown> = {}) {
+  const hooks = new Map<string, { handler: HookHandler; opts?: { priority?: number } }>();
+
+  const api = {
+    pluginConfig,
+    config: {},
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+    on: vi.fn((hookName: string, handler: HookHandler, opts?: { priority?: number }) => {
+      hooks.set(hookName, { handler, opts });
+    }),
+    registerCommand: vi.fn(),
+  };
+
+  return { api, hooks };
+}
+
+describe("model routing — before_model_resolve", () => {
+  let hooks: Map<string, { handler: HookHandler; opts?: { priority?: number } }>;
+  let resolveModel: HookHandler;
+
+  beforeEach(() => {
+    const mock = createMockApi();
+    register(mock.api as any);
+    hooks = mock.hooks;
+    const entry = hooks.get("before_model_resolve");
+    if (!entry) throw new Error("before_model_resolve hook not registered");
+    resolveModel = entry.handler;
+  });
+
+  it("routes TG DM sessions to Haiku", async () => {
+    const result = await resolveModel({}, {
+      sessionKey: "agent:main:telegram:direct:8755232806",
+    });
+    expect(result).toEqual({ model: "claude-haiku-4-5-20251001" });
+  });
+
+  it("routes TG group sessions to Haiku", async () => {
+    const result = await resolveModel({}, {
+      sessionKey: "agent:main:telegram:group:-5144217613",
+    });
+    expect(result).toEqual({ model: "claude-haiku-4-5-20251001" });
+  });
+
+  it("routes Discord sessions to Haiku", async () => {
+    const result = await resolveModel({}, {
+      sessionKey: "agent:main:discord:direct:12345",
+    });
+    expect(result).toEqual({ model: "claude-haiku-4-5-20251001" });
+  });
+
+  it("routes board-worker cron sessions to Opus", async () => {
+    const result = await resolveModel({}, {
+      sessionKey: "agent:main:cron:board-worker:abc-123",
+    });
+    expect(result).toEqual({ model: "claude-opus-4-6-20260315" });
+  });
+
+  it("routes non-board-worker cron sessions to Sonnet", async () => {
+    const result = await resolveModel({}, {
+      sessionKey: "agent:main:cron:71130727-triage",
+    });
+    expect(result).toEqual({ model: "claude-sonnet-4-6-20260315" });
+  });
+
+  it("returns undefined for main/CLI sessions (use default)", async () => {
+    const result = await resolveModel({}, {
+      sessionKey: "agent:main:main",
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined for heartbeat sessions (use default)", async () => {
+    const result = await resolveModel({}, {
+      sessionKey: "agent:main:heartbeat:check",
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("sets hook priority to 50", () => {
+    const entry = hooks.get("before_model_resolve");
+    expect(entry?.opts?.priority).toBe(50);
+  });
+});
+
+describe("model routing — custom model overrides via config", () => {
+  it("uses custom model IDs from pluginConfig", async () => {
+    const mock = createMockApi({
+      haikuModel: "custom-haiku",
+      sonnetModel: "custom-sonnet",
+      opusModel: "custom-opus",
+    });
+    register(mock.api as any);
+
+    const entry = mock.hooks.get("before_model_resolve");
+    if (!entry) throw new Error("hook not registered");
+    const resolveModel = entry.handler;
+
+    // Chat → custom haiku
+    const chat = await resolveModel({}, {
+      sessionKey: "agent:main:telegram:direct:123",
+    });
+    expect(chat).toEqual({ model: "custom-haiku" });
+
+    // Board worker → custom opus
+    const coding = await resolveModel({}, {
+      sessionKey: "agent:main:cron:board-worker:xyz",
+    });
+    expect(coding).toEqual({ model: "custom-opus" });
+
+    // Cron → custom sonnet
+    const planning = await resolveModel({}, {
+      sessionKey: "agent:main:cron:some-triage-task",
+    });
+    expect(planning).toEqual({ model: "custom-sonnet" });
+  });
+});

--- a/plugins/mc-queue/index.ts
+++ b/plugins/mc-queue/index.ts
@@ -82,6 +82,11 @@ function isCronSession(sessionKey?: string): boolean {
   return sessionKey.includes(":cron:");
 }
 
+function isBoardWorkerSession(sessionKey?: string): boolean {
+  if (!sessionKey) return false;
+  return sessionKey.includes(":cron:board-worker:");
+}
+
 function isLogChannelSession(sessionKey: string, logChatId: string): boolean {
   if (!logChatId) return false;
   return sessionKey.includes(logChatId);
@@ -199,6 +204,8 @@ export default function register(api: OpenClawPluginApi) {
   const cfg = (api.pluginConfig ?? {}) as {
     enabled?: boolean;
     haikuModel?: string;
+    sonnetModel?: string;
+    opusModel?: string;
     maxToolCallsPerTurn?: number;
     applyToChannels?: boolean;
     applyToDMs?: boolean;
@@ -209,6 +216,8 @@ export default function register(api: OpenClawPluginApi) {
 
   const enabled = cfg.enabled ?? true;
   const haikuModel = cfg.haikuModel ?? "claude-haiku-4-5-20251001";
+  const sonnetModel = cfg.sonnetModel ?? "claude-sonnet-4-6-20260315";
+  const opusModel = cfg.opusModel ?? "claude-opus-4-6-20260315";
   const maxToolCallsPerTurn = cfg.maxToolCallsPerTurn ?? 3;
   const applyToChannels = cfg.applyToChannels ?? true;
   const applyToDMs = cfg.applyToDMs ?? true;
@@ -234,19 +243,29 @@ export default function register(api: OpenClawPluginApi) {
   }
 
   api.logger.info(
-    `mc-queue loaded (model=${haikuModel}, maxTools=${maxToolCallsPerTurn}, channels=${applyToChannels}, dms=${applyToDMs}, tgLog=${tgLogChatId ? "enabled" : "disabled"})`,
+    `mc-queue loaded (haiku=${haikuModel}, sonnet=${sonnetModel}, opus=${opusModel}, maxTools=${maxToolCallsPerTurn}, channels=${applyToChannels}, dms=${applyToDMs}, tgLog=${tgLogChatId ? "enabled" : "disabled"})`,
   );
 
   // Per-turn tool call counter keyed by runId
   const toolCallCounts = new Map<string, number>();
 
-  // ---- 1. Switch messaging sessions to Haiku ----
+  // ---- 1. Route models by session type ----
+  // Messaging → Haiku (fast chat), Board workers → Opus (coding), Other cron → Sonnet (planning)
   api.on("before_model_resolve", async (_event, ctx) => {
     const sessionKey = ctx.sessionKey ?? "";
-    if (!isMessagingSession(sessionKey)) return;
 
-    return { model: haikuModel };
-  });
+    if (isMessagingSession(sessionKey)) {
+      return { model: haikuModel };
+    }
+
+    if (isBoardWorkerSession(sessionKey)) {
+      return { model: opusModel };
+    }
+
+    if (isCronSession(sessionKey)) {
+      return { model: sonnetModel };
+    }
+  }, { priority: 50 });
 
   // ---- 2. Inject triage instructions into system prompt ----
   api.on("before_prompt_build", async (_event, ctx) => {
@@ -368,7 +387,9 @@ export default function register(api: OpenClawPluginApi) {
       text:
         `*mc-queue status*\n` +
         `Enabled: ${enabled}\n` +
-        `Model: ${haikuModel}\n` +
+        `Chat model (Haiku): ${haikuModel}\n` +
+        `Planning model (Sonnet): ${sonnetModel}\n` +
+        `Coding model (Opus): ${opusModel}\n` +
         `Max tool calls/turn: ${maxToolCallsPerTurn}\n` +
         `Apply to channels: ${applyToChannels}\n` +
         `Apply to DMs: ${applyToDMs}\n` +

--- a/plugins/mc-queue/openclaw.plugin.json
+++ b/plugins/mc-queue/openclaw.plugin.json
@@ -10,6 +10,8 @@
       "applyToChannels":     { "type": "boolean" },
       "applyToDMs":          { "type": "boolean" },
       "haikuModel":          { "type": "string" },
+      "sonnetModel":         { "type": "string" },
+      "opusModel":           { "type": "string" },
       "maxToolCallsPerTurn": { "type": "number" },
       "tgLogChatId":         { "type": "string" },
       "tgBotName":           { "type": "string" },

--- a/plugins/mc-queue/vitest.config.ts
+++ b/plugins/mc-queue/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+const openclaw = path.resolve(process.env.OPENCLAW_STATE_DIR ?? require("node:os").homedir() + "/.openclaw", "projects/openclaw");
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "openclaw/plugin-sdk": path.join(openclaw, "dist/plugin-sdk/index.js"),
+    },
+  },
+  test: {
+    globals: true,
+    include: ["**/*.test.ts"],
+    exclude: ["**/node_modules/**"],
+  },
+});


### PR DESCRIPTION
## Summary
- Routes models by session type in mc-queue's `before_model_resolve` hook: messaging sessions → Haiku (fast/cheap chat), board-worker crons → Opus (coding/implementation), other crons → Sonnet (planning/triage)
- Adds `isBoardWorkerSession()` classifier and configurable `opusModel`/`sonnetModel` plugin config keys
- Sets explicit hook priority (50) to avoid conflicts with mc-oauth-guard (priority 100)

## Changes
- `plugins/mc-queue/index.ts` — expanded model routing, new classifier, config keys
- `plugins/mc-queue/openclaw.plugin.json` — added `sonnetModel` and `opusModel` to config schema
- `plugins/mc-queue/__tests__/model-routing.test.ts` — 9 unit tests covering all routing paths
- `plugins/mc-queue/vitest.config.ts` — test runner config

## Test plan
- [x] 9 unit tests pass covering: TG DM → Haiku, TG group → Haiku, Discord → Haiku, board-worker → Opus, other cron → Sonnet, main/CLI → default, heartbeat → default, hook priority = 50, custom model config overrides
- [ ] Integration test with live TG message (requires running instance)
- [ ] Gateway logs confirm correct model per session type

Card: crd_db9b4199