### PR TITLE
feat: hold/focus anti-states + bright yellow hold indicator (#199)

### DIFF
--- a/plugins/mc-board/web/src/components/board.tsx
+++ b/plugins/mc-board/web/src/components/board.tsx
@@ -171,7 +171,7 @@ export function Board({ selectedProject, initialCardId, onToast, notifsEnabled, 
         cards: current.cards.map(c => {
           if (c.id !== cardId) return c;
           const newTags = setFocused
-            ? [...c.tags.filter(t => t !== "focus"), "focus"]
+            ? [...c.tags.filter(t => t !== "focus" && t !== "hold"), "focus"]
             : c.tags.filter(t => t !== "focus");
           return { ...c, tags: newTags };
         }),
@@ -180,7 +180,7 @@ export function Board({ selectedProject, initialCardId, onToast, notifsEnabled, 
 
     // Use add-tags/remove-tags for atomic CLI operation (avoids full tag replacement from stale cache)
     const updateBody = setFocused
-      ? { action: "update", cardId, "add-tags": "focus" }
+      ? { action: "update", cardId, "add-tags": "focus", "remove-tags": "hold" }
       : { action: "update", cardId, "remove-tags": "focus" };
 
     fetch("/api/board/action", {
@@ -201,7 +201,7 @@ export function Board({ selectedProject, initialCardId, onToast, notifsEnabled, 
           if (c.id !== cardId) return c;
           const isHeld = c.tags.includes("hold");
           wasHeld = isHeld;
-          const newTags = isHeld ? c.tags.filter(t => t !== "hold") : [...c.tags.filter(t => t !== "hold"), "hold"];
+          const newTags = isHeld ? c.tags.filter(t => t !== "hold") : [...c.tags.filter(t => t !== "hold" && t !== "focus"), "hold"];
           return { ...c, tags: newTags };
         }),
       };
@@ -210,7 +210,9 @@ export function Board({ selectedProject, initialCardId, onToast, notifsEnabled, 
     fetch("/api/board/action", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ action: "update", cardId, [wasHeld ? "remove-tags" : "add-tags"]: "hold" }),
+      body: JSON.stringify(wasHeld
+        ? { action: "update", cardId, "remove-tags": "hold" }
+        : { action: "update", cardId, "add-tags": "hold", "remove-tags": "focus" }),
     }).then(() => mutate()).catch(() => mutate());
   }, [mutate]);
 

--- a/plugins/mc-board/web/src/components/card-item.tsx
+++ b/plugins/mc-board/web/src/components/card-item.tsx
@@ -9,9 +9,9 @@ function HoldBadge({ held, onToggle }: { held: boolean; onToggle?: (e: React.Mou
     fontSize: 10, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em",
     padding: "2px 6px", borderRadius: 3, cursor: onToggle ? "pointer" : "default",
     transition: "background 0.1s, color 0.1s",
-    background: held ? "#1c1917" : hovered ? "#1c1917" : "#27272a",
-    color: held ? "#fbbf24" : hovered ? "#a8a29e" : "#52525b",
-    border: held ? "1px solid #d97706" : hovered ? "1px solid #78716c" : "1px solid transparent",
+    background: held ? "#fbbf24" : hovered ? "#1c1917" : "#27272a",
+    color: held ? "#1c1917" : hovered ? "#a8a29e" : "#52525b",
+    border: held ? "1px solid #f59e0b" : hovered ? "1px solid #78716c" : "1px solid transparent",
   };
   return (
     <span style={style} onClick={onToggle}

--- a/plugins/mc-board/web/src/components/card-modal.tsx
+++ b/plugins/mc-board/web/src/components/card-modal.tsx
@@ -449,9 +449,10 @@ export function CardModal({ cardId, projects, activeIds, onClose, onOpenLog, onT
                     onClick={() => onHold(card.id)}
                     title={held ? "Remove hold" : "Put on hold"}
                     style={{
-                      fontSize: 11, padding: "3px 10px", borderRadius: 6,
-                      background: "#1c1917", border: `1px solid ${held ? "#d97706" : "#78716c"}`,
-                      color: held ? "#fbbf24" : "#a8a29e", cursor: "pointer",
+                      fontSize: 11, padding: "3px 10px", borderRadius: 6, fontWeight: 600,
+                      background: held ? "#fbbf24" : "#1c1917",
+                      border: `1px solid ${held ? "#f59e0b" : "#78716c"}`,
+                      color: held ? "#1c1917" : "#a8a29e", cursor: "pointer",
                     }}
                   >
                     {held ? "↩ Unhold" : "⏸ Hold"}


### PR DESCRIPTION
## Summary

- **Hold badge is bright yellow** (`#fbbf24`) when active — both card item and detail modal
- **Focus and hold are anti-states** — toggling one removes the other (can't be focused AND held)
- Both API calls send `add-tags` + `remove-tags` atomically

## What changed

| File | Change |
|------|--------|
| `card-item.tsx` | Hold badge: bright yellow bg when held |
| `card-modal.tsx` | Hold button: bright yellow bg + bold when held |
| `board.tsx` | Focus toggle removes hold, hold toggle removes focus |

## Test plan

- [ ] Click hold on a card → badge turns bright yellow
- [ ] Click focus on a held card → hold is removed, focus is set
- [ ] Click hold on a focused card → focus is removed, hold is set
- [ ] Held cards are not picked up by cron workers
- [ ] All tests pass (`npx vitest run` — 832/832, mc-memory failure is pre-existing)

Fixes #199