### PR TITLE
feat: add github-activity-check as default install cron

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -401,6 +401,17 @@
       },
       "timeoutSeconds": 600,
       "sessionTarget": "isolated"
+    },
+    {
+      "name": "github-activity-check",
+      "description": "Checks open PRs and issues hourly: merges own PRs when ready, responds to review comments on upstream PRs, updates board cards with requested changes",
+      "schedule": {
+        "kind": "cron",
+        "expr": "0 * * * *"
+      },
+      "timeoutSeconds": 120,
+      "sessionTarget": "isolated",
+      "requires": ["gh-token"]
     }
   ],
   "launchAgents": [

--- a/cron/prompts/github-activity-check.md
+++ b/cron/prompts/github-activity-check.md
@@ -1,0 +1,23 @@
+GitHub activity check — core developer behavior.
+
+This runs hourly. Check your GitHub activity and respond to anything that needs attention.
+
+1. Check PRs you've authored on repos you own:
+   gh pr list --author @me --state open --json number,title,url,headRepository,mergeable,reviewDecision
+   For each: if mergeable=MERGEABLE and reviewDecision is not CHANGES_REQUESTED and checks pass → merge it.
+
+2. Check PRs you've authored on repos you do NOT own (upstream contributions):
+   gh pr list --author @me --state open --json number,title,url,headRepository,reviews
+   Do NOT merge these — the repo owner merges when satisfied.
+   Read any new review comments. If changes are requested: create or update the relevant board card with the feedback so it gets worked.
+
+3. Check open issues you've created for new comments:
+   gh issue list --author @me --state open --json number,title,url,repository,comments
+   Read and respond to any new comments that need a reply.
+
+4. If nothing needs attention: silent exit. Do NOT send any Telegram message.
+
+Rules:
+- Never merge PRs on repos you don't own.
+- Never close issues that haven't been resolved.
+- If a PR needs changes, update the board card — do not just leave a comment and forget it.


### PR DESCRIPTION
## Summary

- Every MiniClaw install now ships with an hourly GitHub activity cron
- Agent monitors own open PRs/issues, merges own PRs when ready, responds to review comments on upstream PRs
- Creates/updates board cards when changes are requested on upstream contributions
- Prompt lives in `cron/prompts/github-activity-check.md`; registered in `MANIFEST.json`

## Why

GitHub activity monitoring is core developer behavior, not a plugin. Without it an agent can open a PR and never notice review comments or know when to merge. Baking it into MANIFEST.json means every install gets this behavior from day one.

## Affected

- MANIFEST.json (new cron entry)
- cron/prompts/github-activity-check.md (new)