### PR TITLE
fix: board worker must skip blocked and hold cards

### DIFF
--- a/plugins/mc-board/agent-runner/runner.mjs
+++ b/plugins/mc-board/agent-runner/runner.mjs
@@ -155,7 +155,7 @@ function claimPending(db) {
        LEFT JOIN cards c ON c.id = q.card_id
        WHERE q.status = 'pending'
          AND q.col = ?
-         AND (c.tags IS NULL OR c.tags NOT LIKE '%"hold"%')
+         AND (c.tags IS NULL OR (c.tags NOT LIKE '%"hold"%' AND c.tags NOT LIKE '%"blocked"%'))
        ORDER BY
          CASE WHEN c.tags LIKE '%"focus"%' THEN 0 ELSE 1 END ASC,
          CASE c.priority

--- a/plugins/mc-board/cli/commands.test.ts
+++ b/plugins/mc-board/cli/commands.test.ts
@@ -191,6 +191,39 @@ describe("brain list", () => {
     await run("mc-board", "list");
     expect(lastOut()).toContain("[foo, bar]");
   });
+
+  it("--skip-hold filters out cards tagged 'hold'", async () => {
+    const card1 = await createCard("Active card");
+    const card2 = await createCard("Held card");
+    store.update(card2.id, { tags: ["hold"] });
+    stdoutSpy.mockClear();
+    await run("mc-board", "list", "--skip-hold");
+    const out = allOut();
+    expect(out).toContain("Active card");
+    expect(out).not.toContain("Held card");
+  });
+
+  it("--skip-hold filters out cards tagged 'blocked'", async () => {
+    const card1 = await createCard("Active card");
+    const card2 = await createCard("Blocked card");
+    store.update(card2.id, { tags: ["blocked"] });
+    stdoutSpy.mockClear();
+    await run("mc-board", "list", "--skip-hold");
+    const out = allOut();
+    expect(out).toContain("Active card");
+    expect(out).not.toContain("Blocked card");
+  });
+
+  it("--skip-hold filters cards with both 'hold' and other tags", async () => {
+    const card1 = await createCard("Normal card");
+    const card2 = await createCard("Card with hold and tags");
+    store.update(card2.id, { tags: ["hold", "waiting"] });
+    stdoutSpy.mockClear();
+    await run("mc-board", "list", "--skip-hold");
+    const out = allOut();
+    expect(out).toContain("Normal card");
+    expect(out).not.toContain("Card with hold and tags");
+  });
 });
 
 // ---- brain show ----

--- a/plugins/mc-board/cli/commands.ts
+++ b/plugins/mc-board/cli/commands.ts
@@ -158,7 +158,7 @@ Examples:
       }
       let cards = store.list(opts.column as Column | undefined);
       if (opts.project) cards = cards.filter(c => c.project_id === opts.project);
-      if (opts.skipHold) cards = cards.filter(c => !c.tags.includes("on-hold"));
+      if (opts.skipHold) cards = cards.filter(c => !c.tags.includes("hold") && !c.tags.includes("blocked"));
       if (cards.length === 0) {
         console.log("No cards.");
         return;
@@ -200,7 +200,7 @@ Examples:
         process.exit(1);
       }
       let cards = store.list(opts.column as Column);
-      if (opts.skipHold) cards = cards.filter(c => !c.tags.includes("on-hold"));
+      if (opts.skipHold) cards = cards.filter(c => !c.tags.includes("hold") && !c.tags.includes("blocked"));
       const filterTags = opts.tags ? opts.tags.split(",").map(t => t.trim()).filter(Boolean) : undefined;
       const allProjects = projects.list();
       console.log(renderColumnContext(opts.column as Column, cards, allProjects, filterTags));

--- a/plugins/mc-board/web/src/app/api/cron/tick/route.ts
+++ b/plugins/mc-board/web/src/app/api/cron/tick/route.ts
@@ -142,6 +142,7 @@ export async function GET(req: Request) {
       c.column === "backlog" &&
       c.depends_on.length > 0 &&
       c.depends_on.every(dep => shippedIds.has(dep)) &&
+      !c.tags.includes("blocked") &&
       !activeIds.has(c.id) &&
       !agentStillRunning(c.id, "backlog") &&
       !recentlyProcessed(c.id, "backlog", MIN_COOLDOWN_MS)
@@ -198,6 +199,7 @@ export async function GET(req: Request) {
         if (c.column !== column) return false;
         if (projectId && c.project_id !== projectId) return false;
         if (c.tags.includes("hold")) return false;
+        if (c.tags.includes("blocked")) return false;
         if (activeIds.has(c.id)) return false;
         if (agentStillRunning(c.id, column)) return false;
         if (recentlyProcessed(c.id, column, cooldownMs)) return false;


### PR DESCRIPTION
## Problem
Board worker cron keeps re-picking cards tagged as `hold` or `blocked` and attempts to work on them repeatedly. When a card is blocked (e.g., waiting for human screenshots), the worker finds it can't complete the work and drops it without progress, wasting tokens and platform resources.

Example: crd_8ccc02e3 has 5/6 criteria checked but the last requires human screenshots. Worker re-picks it repeatedly.

## Solution
Add filtering for both `hold` and `blocked` tags across all three layers:

### Changes
1. **runner.mjs** (SQL layer): Updated card query to exclude cards with `blocked` tag alongside existing `hold` check
2. **route.ts** (reactive tick): Main card filtering loop and newlyUnblocked filter now skip cards with `blocked` tag
3. **commands.ts** (CLI): `--skip-hold` flag now filters both `hold` and `blocked` tags
4. **commands.test.ts**: Added 3 new tests for `--skip-hold` filtering

## Testing
- All 216 existing tests pass
- 3 new tests added for blocked/held card filtering

## Impact
- Eliminates token waste on impossible work
- Improves board worker efficiency
- Allows explicit block state without worker interference