### PR TITLE
feat(mc-board): pickup limits, auto-correction, and TG alerts

### DIFF
--- a/plugins/mc-board/src/active-work.ts
+++ b/plugins/mc-board/src/active-work.ts
@@ -58,6 +58,10 @@ export class ActiveWorkStore {
       `INSERT INTO pickup_log (card_id, project_id, title, worker, col, action, at)
        VALUES (?, ?, ?, ?, ?, 'pickup', ?)`,
     ).run(entry.cardId, entry.projectId ?? null, entry.title, entry.worker, entry.column, now);
+    // Atomically increment pickup_count on the card
+    this.db.prepare(
+      `UPDATE cards SET pickup_count = pickup_count + 1 WHERE id = ?`,
+    ).run(entry.cardId);
     this._trimLog();
     return { ...entry, pickedUpAt: now };
   }

--- a/plugins/mc-board/src/board.ts
+++ b/plugins/mc-board/src/board.ts
@@ -144,6 +144,8 @@ export function renderCardDetail(card: Card): string {
     `**Created:** ${card.created_at}`,
     `**Updated:** ${card.updated_at}`,
     `project_id: ${card.project_id ?? ""}`,
+    `**Pickup count:** ${card.pickup_count ?? 0}`,
+    `**Correction count:** ${card.correction_count ?? 0}`,
     ``,
     `## Problem Description`,
     card.problem_description || "(empty)",

--- a/plugins/mc-board/src/card.ts
+++ b/plugins/mc-board/src/card.ts
@@ -32,6 +32,10 @@ export interface Card {
   research: string;
   verify_url: string;
   work_log: WorkLogEntry[];
+  // Pickup tracking — incremented each time an agent picks up this card
+  pickup_count: number;
+  // Correction tracking — incremented each time auto-correction is triggered
+  correction_count: number;
 }
 
 export interface WorkLogEntry {

--- a/plugins/mc-board/src/db.ts
+++ b/plugins/mc-board/src/db.ts
@@ -30,7 +30,9 @@ const SCHEMA = /* sql */ `
     notes            TEXT NOT NULL DEFAULT '',
     review_notes     TEXT NOT NULL DEFAULT '',
     research         TEXT NOT NULL DEFAULT '',
-    work_log         TEXT NOT NULL DEFAULT '[]'
+    work_log         TEXT NOT NULL DEFAULT '[]',
+    pickup_count     INTEGER NOT NULL DEFAULT 0,
+    correction_count INTEGER NOT NULL DEFAULT 0
   );
 
   CREATE TABLE IF NOT EXISTS card_history (
@@ -91,6 +93,8 @@ export function openDb(stateDir: string): Database {
   try { db.exec(`ALTER TABLE projects ADD COLUMN github_repo TEXT NOT NULL DEFAULT ''`); } catch { /* already exists */ }
   try { db.exec(`ALTER TABLE projects ADD COLUMN build_command TEXT NOT NULL DEFAULT ''`); } catch { /* already exists */ }
   try { db.exec(`ALTER TABLE cards ADD COLUMN depends_on TEXT NOT NULL DEFAULT '[]'`); } catch { /* already exists */ }
+  try { db.exec(`ALTER TABLE cards ADD COLUMN pickup_count INTEGER NOT NULL DEFAULT 0`); } catch { /* already exists */ }
+  try { db.exec(`ALTER TABLE cards ADD COLUMN correction_count INTEGER NOT NULL DEFAULT 0`); } catch { /* already exists */ }
   // Agent run token usage columns
   try { db.exec(`ALTER TABLE agent_runs ADD COLUMN input_tokens INTEGER DEFAULT 0`); } catch { /* already exists */ }
   try { db.exec(`ALTER TABLE agent_runs ADD COLUMN output_tokens INTEGER DEFAULT 0`); } catch { /* already exists */ }

--- a/plugins/mc-board/src/pickup-limits.test.ts
+++ b/plugins/mc-board/src/pickup-limits.test.ts
@@ -1,0 +1,332 @@
+/**
+ * pickup-limits.test.ts
+ *
+ * Tests for:
+ *  1. isOverLimit() — returns true when pickup_count >= max for column
+ *  2. autoCorrect() — moves stuck cards forward, updates notes, increments correction_count
+ *  3. incrementGlobalCorrections() — daily counter, auto-resets
+ *  4. Integration: pickup_count increments on each pickup
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as fs from "node:fs";
+import Database from "better-sqlite3";
+import { isOverLimit, MAX_PICKUPS, autoCorrect, readCorrectionState, incrementGlobalCorrections, resetCorrectionState } from "./pickup-limits.js";
+import type { Card, Column } from "./card.js";
+
+// ---- DB helpers ----
+
+function createTestDb() {
+  const db = new Database(":memory:");
+  db.exec("PRAGMA foreign_keys = ON");
+  db.exec(`
+    CREATE TABLE cards (
+      id               TEXT PRIMARY KEY,
+      title            TEXT NOT NULL,
+      col              TEXT NOT NULL DEFAULT 'backlog',
+      priority         TEXT NOT NULL DEFAULT 'medium',
+      tags             TEXT NOT NULL DEFAULT '[]',
+      project_id       TEXT,
+      work_type        TEXT,
+      linked_card_id   TEXT,
+      depends_on       TEXT NOT NULL DEFAULT '[]',
+      created_at       TEXT NOT NULL,
+      updated_at       TEXT NOT NULL,
+      problem_description  TEXT NOT NULL DEFAULT '',
+      implementation_plan  TEXT NOT NULL DEFAULT '',
+      acceptance_criteria  TEXT NOT NULL DEFAULT '',
+      notes            TEXT NOT NULL DEFAULT '',
+      review_notes     TEXT NOT NULL DEFAULT '',
+      research         TEXT NOT NULL DEFAULT '',
+      verify_url       TEXT NOT NULL DEFAULT '',
+      work_log         TEXT NOT NULL DEFAULT '[]',
+      pickup_count     INTEGER NOT NULL DEFAULT 0,
+      correction_count INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE card_history (
+      id      INTEGER PRIMARY KEY AUTOINCREMENT,
+      card_id TEXT NOT NULL REFERENCES cards(id) ON DELETE CASCADE,
+      col     TEXT NOT NULL,
+      moved_at TEXT NOT NULL
+    );
+    CREATE TABLE active_work (
+      card_id      TEXT PRIMARY KEY,
+      project_id   TEXT,
+      title        TEXT NOT NULL,
+      worker       TEXT NOT NULL,
+      col          TEXT NOT NULL,
+      picked_up_at TEXT NOT NULL
+    );
+    CREATE TABLE pickup_log (
+      id         INTEGER PRIMARY KEY AUTOINCREMENT,
+      card_id    TEXT NOT NULL,
+      project_id TEXT,
+      title      TEXT NOT NULL DEFAULT '',
+      worker     TEXT NOT NULL,
+      col        TEXT NOT NULL DEFAULT '',
+      action     TEXT NOT NULL,
+      at         TEXT NOT NULL
+    );
+  `);
+  return db;
+}
+
+function insertCard(
+  db: InstanceType<typeof Database>,
+  id: string,
+  col: Column,
+  pickupCount = 0,
+  tags: string[] = [],
+): Card {
+  const now = new Date().toISOString();
+  db.prepare(`
+    INSERT INTO cards (id, title, col, priority, tags, created_at, updated_at, pickup_count, correction_count)
+    VALUES (?, ?, ?, 'medium', ?, ?, ?, ?, 0)
+  `).run(id, `Card ${id}`, col, JSON.stringify(tags), now, now, pickupCount);
+  db.prepare(`INSERT INTO card_history (card_id, col, moved_at) VALUES (?, ?, ?)`).run(id, col, now);
+  return {
+    id,
+    title: `Card ${id}`,
+    column: col,
+    priority: "medium",
+    tags,
+    created_at: now,
+    updated_at: now,
+    history: [{ column: col, moved_at: now }],
+    problem_description: "",
+    implementation_plan: "",
+    acceptance_criteria: "",
+    notes: "",
+    review_notes: "",
+    research: "",
+    verify_url: "",
+    work_log: [],
+    pickup_count: pickupCount,
+    correction_count: 0,
+  };
+}
+
+// ---- Minimal CardStore stub for tests ----
+import { CardStore } from "./store.js";
+import { openDb } from "./db.js";
+
+function createTestStore(tmpDir: string) {
+  const db = openDb(tmpDir);
+  return new CardStore(db);
+}
+
+// ---- Tests: isOverLimit ----
+
+describe("isOverLimit()", () => {
+  it("returns false when pickup_count is below max", () => {
+    const card = { pickup_count: 2 } as Card;
+    expect(isOverLimit(card, "backlog")).toBe(false); // max=3
+  });
+
+  it("returns true when pickup_count equals max (backlog=3)", () => {
+    const card = { pickup_count: 3 } as Card;
+    expect(isOverLimit(card, "backlog")).toBe(true);
+  });
+
+  it("returns true when pickup_count exceeds max", () => {
+    const card = { pickup_count: 5 } as Card;
+    expect(isOverLimit(card, "backlog")).toBe(true);
+  });
+
+  it("uses correct max for in-progress (max=10)", () => {
+    expect(isOverLimit({ pickup_count: 9 } as Card, "in-progress")).toBe(false);
+    expect(isOverLimit({ pickup_count: 10 } as Card, "in-progress")).toBe(true);
+  });
+
+  it("uses correct max for in-review (max=2)", () => {
+    expect(isOverLimit({ pickup_count: 1 } as Card, "in-review")).toBe(false);
+    expect(isOverLimit({ pickup_count: 2 } as Card, "in-review")).toBe(true);
+  });
+
+  it("returns false for shipped (no limit)", () => {
+    expect(isOverLimit({ pickup_count: 999 } as Card, "shipped")).toBe(false);
+  });
+
+  it("treats undefined pickup_count as 0 (safe default)", () => {
+    const card = {} as Card; // pickup_count undefined
+    expect(isOverLimit(card, "backlog")).toBe(false);
+  });
+});
+
+// ---- Tests: MAX_PICKUPS values ----
+
+describe("MAX_PICKUPS constants", () => {
+  it("backlog = 3", () => expect(MAX_PICKUPS.backlog).toBe(3));
+  it("in-progress = 10", () => expect(MAX_PICKUPS["in-progress"]).toBe(10));
+  it("in-review = 2", () => expect(MAX_PICKUPS["in-review"]).toBe(2));
+  it("shipped = Infinity", () => expect(MAX_PICKUPS.shipped).toBe(Infinity));
+});
+
+// ---- Tests: autoCorrect() with real store ----
+
+describe("autoCorrect()", () => {
+  let tmpDir: string;
+  let store: CardStore;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mc-board-test-"));
+    store = createTestStore(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("moves backlog → in-progress", () => {
+    const card = store.create({ title: "Stuck backlog card", tags: [] });
+    // Simulate pickup count
+    store["db"].prepare("UPDATE cards SET pickup_count = 3 WHERE id = ?").run(card.id);
+    const stuckCard = store.findById(card.id);
+    const result = autoCorrect(stuckCard, "backlog", store);
+    expect(result).not.toBeNull();
+    expect(result!.toColumn).toBe("in-progress");
+    expect(result!.holdTagAdded).toBe(false);
+    const updated = store.findById(card.id);
+    expect(updated.column).toBe("in-progress");
+    expect(updated.correction_count).toBe(1);
+    expect(updated.notes).toContain("AUTO-CORRECTED");
+  });
+
+  it("moves in-progress → in-review", () => {
+    const card = store.create({ title: "Stuck in-progress card" });
+    store["db"].prepare("UPDATE cards SET col = 'in-progress', pickup_count = 10 WHERE id = ?").run(card.id);
+    const stuckCard = store.findById(card.id);
+    const result = autoCorrect(stuckCard, "in-progress", store);
+    expect(result).not.toBeNull();
+    expect(result!.toColumn).toBe("in-review");
+    const updated = store.findById(card.id);
+    expect(updated.column).toBe("in-review");
+  });
+
+  it("moves in-review → backlog with hold tag", () => {
+    const card = store.create({ title: "Stuck in-review card" });
+    store["db"].prepare("UPDATE cards SET col = 'in-review', pickup_count = 2 WHERE id = ?").run(card.id);
+    const stuckCard = store.findById(card.id);
+    const result = autoCorrect(stuckCard, "in-review", store);
+    expect(result).not.toBeNull();
+    expect(result!.toColumn).toBe("backlog");
+    expect(result!.holdTagAdded).toBe(true);
+    const updated = store.findById(card.id);
+    expect(updated.column).toBe("backlog");
+    expect(updated.tags).toContain("hold");
+  });
+
+  it("returns null for shipped cards (no correction path)", () => {
+    const card = store.create({ title: "Shipped card" });
+    store["db"].prepare("UPDATE cards SET col = 'shipped' WHERE id = ?").run(card.id);
+    const shippedCard = store.findById(card.id);
+    const result = autoCorrect(shippedCard, "shipped", store);
+    expect(result).toBeNull();
+  });
+
+  it("does not add hold tag twice", () => {
+    const card = store.create({ title: "Already hold card", tags: ["hold"] });
+    store["db"].prepare("UPDATE cards SET col = 'in-review', pickup_count = 2 WHERE id = ?").run(card.id);
+    const stuckCard = store.findById(card.id);
+    autoCorrect(stuckCard, "in-review", store);
+    const updated = store.findById(card.id);
+    const holdCount = updated.tags.filter(t => t === "hold").length;
+    expect(holdCount).toBe(1);
+  });
+
+  it("appends to existing notes without overwriting them", () => {
+    const card = store.create({ title: "Card with notes", notes: "Original note." });
+    store["db"].prepare("UPDATE cards SET pickup_count = 3 WHERE id = ?").run(card.id);
+    const stuckCard = store.findById(card.id);
+    autoCorrect(stuckCard, "backlog", store);
+    const updated = store.findById(card.id);
+    expect(updated.notes).toContain("Original note.");
+    expect(updated.notes).toContain("AUTO-CORRECTED");
+  });
+});
+
+// ---- Tests: global correction counter ----
+
+describe("incrementGlobalCorrections()", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mc-board-corrections-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("starts at 0 if no state file exists", () => {
+    const state = readCorrectionState(tmpDir);
+    expect(state.count).toBe(0);
+  });
+
+  it("increments count on each call", () => {
+    let state = incrementGlobalCorrections(tmpDir);
+    expect(state.count).toBe(1);
+    state = incrementGlobalCorrections(tmpDir);
+    expect(state.count).toBe(2);
+    state = incrementGlobalCorrections(tmpDir);
+    expect(state.count).toBe(3);
+  });
+
+  it("resets daily when date changes", () => {
+    // Write a state with yesterday's date
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    const stateFile = path.join(tmpDir, "USER", "brain", "correction-state.json");
+    fs.mkdirSync(path.dirname(stateFile), { recursive: true });
+    fs.writeFileSync(stateFile, JSON.stringify({ count: 99, lastResetAt: yesterday.toISOString() }));
+
+    const state = incrementGlobalCorrections(tmpDir);
+    expect(state.count).toBe(1); // reset to 1 (new day, first correction)
+  });
+
+  it("resetCorrectionState sets count to 0", () => {
+    incrementGlobalCorrections(tmpDir);
+    incrementGlobalCorrections(tmpDir);
+    resetCorrectionState(tmpDir);
+    const state = readCorrectionState(tmpDir);
+    expect(state.count).toBe(0);
+  });
+});
+
+// ---- Tests: pickup_count increments via ActiveWorkStore ----
+
+describe("pickup_count increments on pickup", () => {
+  let tmpDir: string;
+  let store: CardStore;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mc-board-active-"));
+    store = createTestStore(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("increments pickup_count each time a card is picked up", async () => {
+    const { ActiveWorkStore } = await import("./active-work.js");
+    const activeWork = new ActiveWorkStore(tmpDir);
+    const card = store.create({ title: "Track pickups" });
+
+    activeWork.pickup({ cardId: card.id, title: card.title, worker: "w1", column: "backlog" });
+    expect(store.findById(card.id).pickup_count).toBe(1);
+
+    activeWork.release(card.id, "w1");
+    activeWork.pickup({ cardId: card.id, title: card.title, worker: "w2", column: "backlog" });
+    expect(store.findById(card.id).pickup_count).toBe(2);
+
+    activeWork.release(card.id, "w2");
+    activeWork.pickup({ cardId: card.id, title: card.title, worker: "w3", column: "backlog" });
+    expect(store.findById(card.id).pickup_count).toBe(3);
+
+    // Now over the limit
+    expect(isOverLimit(store.findById(card.id), "backlog")).toBe(true);
+  });
+});

--- a/plugins/mc-board/src/pickup-limits.ts
+++ b/plugins/mc-board/src/pickup-limits.ts
@@ -1,0 +1,211 @@
+/**
+ * pickup-limits.ts — max pickup limits, auto-correction, and human alerts.
+ *
+ * Problem: Cards get picked up and dropped repeatedly without progressing.
+ * Fix:
+ *   - Track pickup_count per card (incremented in ActiveWorkStore.pickup())
+ *   - Enforce per-column max limits
+ *   - Auto-correct stuck cards by moving them forward
+ *   - Alert human via TG when global correction threshold is hit
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import type { Card, Column } from "./card.js";
+import type { CardStore } from "./store.js";
+
+// ---- Max pickup limits per column ----
+
+export const MAX_PICKUPS: Record<Column, number> = {
+  backlog: 3,
+  "in-progress": 10,
+  "in-review": 2,
+  shipped: Infinity, // shipped cards are never picked up again
+};
+
+// Correction threshold — alert human when this many corrections happen
+const CORRECTION_ALERT_THRESHOLD = 3;
+
+// ---- State file for global correction counter ----
+
+const DEFAULT_STATE_DIR =
+  (process.env.OPENCLAW_STATE_DIR ?? "").trim() ||
+  path.join(os.homedir(), ".openclaw");
+
+interface CorrectionState {
+  count: number;
+  lastResetAt: string;
+  lastAlertAt?: string;
+}
+
+function getCorrectionStatePath(stateDir: string): string {
+  return path.join(stateDir, "USER", "brain", "correction-state.json");
+}
+
+export function readCorrectionState(stateDir = DEFAULT_STATE_DIR): CorrectionState {
+  const p = getCorrectionStatePath(stateDir);
+  try {
+    return JSON.parse(fs.readFileSync(p, "utf8")) as CorrectionState;
+  } catch {
+    return { count: 0, lastResetAt: new Date().toISOString() };
+  }
+}
+
+export function writeCorrectionState(state: CorrectionState, stateDir = DEFAULT_STATE_DIR): void {
+  const p = getCorrectionStatePath(stateDir);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(state, null, 2), "utf8");
+}
+
+export function incrementGlobalCorrections(stateDir = DEFAULT_STATE_DIR): CorrectionState {
+  const state = readCorrectionState(stateDir);
+
+  // Auto-reset daily
+  const lastReset = new Date(state.lastResetAt);
+  const now = new Date();
+  if (
+    now.getFullYear() !== lastReset.getFullYear() ||
+    now.getMonth() !== lastReset.getMonth() ||
+    now.getDate() !== lastReset.getDate()
+  ) {
+    const fresh: CorrectionState = { count: 1, lastResetAt: now.toISOString() };
+    writeCorrectionState(fresh, stateDir);
+    return fresh;
+  }
+
+  const updated: CorrectionState = { ...state, count: state.count + 1 };
+  writeCorrectionState(updated, stateDir);
+  return updated;
+}
+
+export function resetCorrectionState(stateDir = DEFAULT_STATE_DIR): void {
+  writeCorrectionState(
+    { count: 0, lastResetAt: new Date().toISOString() },
+    stateDir,
+  );
+}
+
+// ---- Limit checks ----
+
+/** Returns true if the card has exceeded the max pickup limit for its column. */
+export function isOverLimit(card: Card, column: Column): boolean {
+  const max = MAX_PICKUPS[column];
+  if (!isFinite(max)) return false;
+  return (card.pickup_count ?? 0) >= max;
+}
+
+// ---- Auto-correction ----
+
+/** Correction transitions: where does a stuck card in each column go? */
+const CORRECTION_MOVES: Partial<Record<Column, { target: Column; addHoldTag?: boolean }>> = {
+  backlog: { target: "in-progress" },
+  "in-progress": { target: "in-review" },
+  "in-review": { target: "backlog", addHoldTag: true },
+};
+
+export interface AutoCorrectionResult {
+  cardId: string;
+  title: string;
+  fromColumn: Column;
+  toColumn: Column;
+  holdTagAdded: boolean;
+  note: string;
+}
+
+/**
+ * Auto-correct a stuck card by moving it forward (or back to backlog+hold
+ * if it's stuck in in-review). Also increments correction_count.
+ * Returns the correction result or null if no correction path exists.
+ */
+export function autoCorrect(
+  card: Card,
+  column: Column,
+  store: CardStore,
+): AutoCorrectionResult | null {
+  const move = CORRECTION_MOVES[column];
+  if (!move) return null;
+
+  const { target, addHoldTag } = move;
+  const now = new Date().toISOString();
+
+  // Move card to target column
+  store.move(card, target);
+
+  // Add hold tag if needed (stuck in-review → backlog + hold)
+  const tags = [...(card.tags ?? [])];
+  if (addHoldTag && !tags.includes("hold")) {
+    tags.push("hold");
+    store.update(card.id, { tags });
+  }
+
+  // Increment correction_count
+  store.incrementCorrectionCount(card.id);
+
+  // Append correction note to card notes
+  const correctionNote =
+    `[AUTO-CORRECTED ${now}] Card stuck in ${column} after ${card.pickup_count} pickups. ` +
+    `Moved to ${target}${addHoldTag ? " + hold tag added" : ""}.`;
+  const existingNotes = card.notes?.trim() ?? "";
+  store.update(card.id, {
+    notes: existingNotes ? `${existingNotes}\n\n${correctionNote}` : correctionNote,
+  });
+
+  return {
+    cardId: card.id,
+    title: card.title,
+    fromColumn: column,
+    toColumn: target,
+    holdTagAdded: addHoldTag ?? false,
+    note: correctionNote,
+  };
+}
+
+// ---- TG alert ----
+
+/**
+ * Send a TG alert when the correction threshold is hit.
+ * Uses the Telegram bot token from env.
+ */
+export async function maybeSendCorrectionAlert(
+  correctionState: CorrectionState,
+  botToken: string,
+  chatId: string,
+  stateDir = DEFAULT_STATE_DIR,
+): Promise<boolean> {
+  if (!botToken || !chatId) return false;
+  if (correctionState.count < CORRECTION_ALERT_THRESHOLD) return false;
+
+  // Throttle: don't alert more than once per hour
+  if (correctionState.lastAlertAt) {
+    const lastAlert = new Date(correctionState.lastAlertAt).getTime();
+    if (Date.now() - lastAlert < 60 * 60 * 1000) return false;
+  }
+
+  const text =
+    `⚠️ <b>Board auto-correction threshold hit</b>\n` +
+    `${correctionState.count} corrections today. Cards may be stuck.\n` +
+    `Please review the board and check stuck cards.`;
+
+  try {
+    const res = await fetch(
+      `https://api.telegram.org/bot${botToken}/sendMessage`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ chat_id: chatId, text, parse_mode: "HTML" }),
+      },
+    );
+    if (res.ok) {
+      // Record that we sent an alert
+      writeCorrectionState(
+        { ...correctionState, lastAlertAt: new Date().toISOString() },
+        stateDir,
+      );
+      return true;
+    }
+  } catch {
+    // Non-fatal — alert failed but correction still happened
+  }
+  return false;
+}

--- a/plugins/mc-board/src/store.ts
+++ b/plugins/mc-board/src/store.ts
@@ -55,6 +55,8 @@ interface CardRow {
   research: string;
   verify_url: string;
   work_log: string;
+  pickup_count: number;
+  correction_count: number;
 }
 
 interface HistoryRow {
@@ -86,6 +88,8 @@ function rowToCard(row: CardRow, history: HistoryRow[]): Card {
     research: row.research,
     verify_url: row.verify_url ?? "",
     work_log: (() => { try { return JSON.parse(row.work_log || "[]"); } catch { return []; } })(),
+    pickup_count: row.pickup_count ?? 0,
+    correction_count: row.correction_count ?? 0,
   };
 }
 
@@ -226,6 +230,10 @@ export class CardStore {
   countByColumn(column: Column): number {
     const row = this.db.prepare(`SELECT COUNT(*) as cnt FROM cards WHERE col = ?`).get(column) as { cnt: number };
     return row.cnt;
+  }
+
+  incrementCorrectionCount(id: string): void {
+    this.db.prepare(`UPDATE cards SET correction_count = correction_count + 1 WHERE id = ?`).run(id);
   }
 
   delete(id: string): void {

--- a/plugins/mc-board/web/src/app/api/cron/tick/route.ts
+++ b/plugins/mc-board/web/src/app/api/cron/tick/route.ts
@@ -6,6 +6,7 @@ import { listCronJobs, updateCronJob } from "@/lib/cron";
 import { listCards, getActiveWork, getRunningByCol } from "@/lib/data";
 import { releaseCard } from "@/lib/actions";
 import { sortCards } from "@/lib/sort";
+import { isOverLimit, autoCorrectCard, incrementGlobalCorrections, maybeSendCorrectionAlert } from "@/lib/pickup-limits";
 
 export const dynamic = "force-dynamic";
 
@@ -162,6 +163,35 @@ export async function GET(req: Request) {
 
   const fired: string[] = [];
   const skipped: string[] = [];
+  const corrected: string[] = [];
+
+  // ---- Auto-correct stuck cards (over pickup limit) before scheduling ----
+  // Runs every tick regardless of job schedule. Checks all non-shipped columns.
+  {
+    const allCardsForCorrection = listCards();
+    for (const card of allCardsForCorrection) {
+      const col = card.column;
+      if (col === "shipped") continue;
+      if (isOverLimit(card, col)) {
+        const result = autoCorrectCard(card, col);
+        if (result) {
+          corrected.push(`${card.id}: ${col} → ${result.toColumn}${result.holdTagAdded ? "+hold" : ""}`);
+          // Release from active_work if it was active
+          if (activeIds.has(card.id)) {
+            try { releaseCard(card.id, "tick-auto-correct"); } catch {}
+            activeIds.delete(card.id);
+          }
+          const correctionState = incrementGlobalCorrections();
+          // Fire TG alert if threshold hit — read bot token + chat ID from env/vault
+          const botToken = process.env.TELEGRAM_BOT_TOKEN ?? "";
+          const chatId = process.env.TELEGRAM_HUMAN_CHAT_ID ?? "";
+          if (botToken && chatId) {
+            maybeSendCorrectionAlert(correctionState, botToken, chatId).catch(() => {});
+          }
+        }
+      }
+    }
+  }
 
   for (const job of jobs) {
     const parsed = parseJobId(job.id);
@@ -205,6 +235,8 @@ export async function GET(req: Request) {
         if (recentlyProcessed(c.id, column, cooldownMs)) return false;
         // Block if any dependency is not yet shipped
         if (c.depends_on.some(dep => !shippedIds.has(dep))) return false;
+        // Block if over the pickup limit (auto-correction handles these separately)
+        if (isOverLimit(c, column)) return false;
         return true;
       }), activeIds)
       .slice(0, availableSlots);
@@ -230,5 +262,5 @@ export async function GET(req: Request) {
     }
   }
 
-  return NextResponse.json({ ok: true, fired, skipped, released, reactivelyFired, ts: new Date(now).toISOString() });
+  return NextResponse.json({ ok: true, fired, skipped, released, reactivelyFired, corrected, ts: new Date(now).toISOString() });
 }

--- a/plugins/mc-board/web/src/lib/actions.ts
+++ b/plugins/mc-board/web/src/lib/actions.ts
@@ -19,6 +19,8 @@ export function pickupCard(id: string, worker: string): string {
   const now = new Date().toISOString();
   db().prepare("INSERT OR REPLACE INTO active_work (card_id, project_id, title, worker, col, picked_up_at) VALUES (?, ?, ?, ?, ?, ?)").run(id, card.project_id, card.title, worker, card.col, now);
   db().prepare("INSERT INTO pickup_log (card_id, project_id, title, worker, col, action, at) VALUES (?, ?, ?, ?, ?, ?, ?)").run(id, card.project_id, card.title, worker, card.col, "pickup", now);
+  // Increment pickup_count so the pickup-limits system can track stuck cards
+  db().prepare("UPDATE cards SET pickup_count = pickup_count + 1 WHERE id = ?").run(id);
   return `Picked up ${id}`;
 }
 

--- a/plugins/mc-board/web/src/lib/data.ts
+++ b/plugins/mc-board/web/src/lib/data.ts
@@ -63,6 +63,8 @@ interface CardRow {
   work_log: string;
   depends_on: string;
   attachments: string;
+  pickup_count: number;
+  correction_count: number;
 }
 
 interface HistoryRow {
@@ -143,6 +145,8 @@ function rowToCard(row: CardRow, history: HistoryRow[]): Card {
     verify_url: row.verify_url ?? "",
     depends_on: (() => { try { return JSON.parse(row.depends_on || "[]") as string[]; } catch { return []; } })(),
     attachments: (() => { try { return JSON.parse(row.attachments || "[]") as import("./types").Attachment[]; } catch { return []; } })(),
+    pickup_count: row.pickup_count ?? 0,
+    correction_count: row.correction_count ?? 0,
     work_log: (() => {
       try {
         const raw = JSON.parse(row.work_log || "[]") as Array<Record<string, unknown>>;

--- a/plugins/mc-board/web/src/lib/pickup-limits.ts
+++ b/plugins/mc-board/web/src/lib/pickup-limits.ts
@@ -1,0 +1,203 @@
+/**
+ * pickup-limits.ts — max pickup limits, auto-correction, and human alerts.
+ * Web app (Next.js) variant — uses direct SQLite via getDb().
+ *
+ * Problem: Cards get picked up and dropped repeatedly without progressing.
+ * Fix:
+ *   - Check pickup_count per card before firing
+ *   - Auto-correct stuck cards by moving them forward
+ *   - Alert human via TG when global correction threshold is hit
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { getDb } from "@/lib/data";
+import type { Card, Column } from "@/lib/types";
+
+// ---- Max pickup limits per column ----
+
+export const MAX_PICKUPS: Record<string, number> = {
+  backlog: 3,
+  "in-progress": 10,
+  "in-review": 2,
+};
+
+// Correction threshold — alert human when this many corrections happen
+const CORRECTION_ALERT_THRESHOLD = 3;
+
+const STATE_DIR =
+  (process.env.OPENCLAW_STATE_DIR ?? "").trim() ||
+  path.join(os.homedir(), ".openclaw");
+
+// ---- Limit check ----
+
+/** Returns true if the card has exceeded the max pickup limit for its column. */
+export function isOverLimit(card: Card, column: string): boolean {
+  const max = MAX_PICKUPS[column];
+  if (max === undefined) return false;
+  return (card.pickup_count ?? 0) >= max;
+}
+
+// ---- Auto-correction (direct SQL, no CardStore dependency) ----
+
+/** Correction transitions per column. */
+const CORRECTION_MOVES: Record<string, { target: Column; addHoldTag?: boolean }> = {
+  backlog: { target: "in-progress" },
+  "in-progress": { target: "in-review" },
+  "in-review": { target: "backlog", addHoldTag: true },
+};
+
+export interface AutoCorrectionResult {
+  cardId: string;
+  title: string;
+  fromColumn: Column;
+  toColumn: Column;
+  holdTagAdded: boolean;
+  note: string;
+}
+
+/**
+ * Auto-correct a stuck card. Moves it forward in the column flow.
+ * in-review → backlog+hold (last resort, needs human review).
+ */
+export function autoCorrectCard(card: Card, column: string): AutoCorrectionResult | null {
+  const move = CORRECTION_MOVES[column];
+  if (!move) return null;
+
+  const db = getDb();
+  if (!db) return null;
+
+  const { target, addHoldTag } = move;
+  const now = new Date().toISOString();
+
+  // Move card to target column
+  db.prepare("UPDATE cards SET col = ?, updated_at = ? WHERE id = ?").run(target, now, card.id);
+  db.prepare("INSERT INTO card_history (card_id, col, moved_at) VALUES (?, ?, ?)").run(card.id, target, now);
+
+  // Add hold tag if needed
+  let holdTagAdded = false;
+  if (addHoldTag) {
+    const row = db.prepare("SELECT tags FROM cards WHERE id = ?").get(card.id) as { tags: string } | undefined;
+    let tags: string[] = [];
+    try { tags = JSON.parse(row?.tags ?? "[]"); } catch { /* empty */ }
+    if (!tags.includes("hold")) {
+      tags.push("hold");
+      db.prepare("UPDATE cards SET tags = ? WHERE id = ?").run(JSON.stringify(tags), card.id);
+      holdTagAdded = true;
+    }
+  }
+
+  // Increment correction_count
+  db.prepare("UPDATE cards SET correction_count = correction_count + 1 WHERE id = ?").run(card.id);
+
+  // Append correction note
+  const correctionNote =
+    `[AUTO-CORRECTED ${now}] Stuck in ${column} after ${card.pickup_count} pickups. ` +
+    `Moved to ${target}${holdTagAdded ? " + hold tag added" : ""}.`;
+  const existingNotes = (card.notes ?? "").trim();
+  const newNotes = existingNotes ? `${existingNotes}\n\n${correctionNote}` : correctionNote;
+  db.prepare("UPDATE cards SET notes = ? WHERE id = ?").run(newNotes, card.id);
+
+  return {
+    cardId: card.id,
+    title: card.title,
+    fromColumn: column as Column,
+    toColumn: target,
+    holdTagAdded,
+    note: correctionNote,
+  };
+}
+
+// ---- Global correction counter ----
+
+interface CorrectionState {
+  count: number;
+  lastResetAt: string;
+  lastAlertAt?: string;
+}
+
+function getCorrectionStatePath(): string {
+  return path.join(STATE_DIR, "USER", "brain", "correction-state.json");
+}
+
+export function readCorrectionState(): CorrectionState {
+  const p = getCorrectionStatePath();
+  try {
+    return JSON.parse(fs.readFileSync(p, "utf8")) as CorrectionState;
+  } catch {
+    return { count: 0, lastResetAt: new Date().toISOString() };
+  }
+}
+
+function writeCorrectionState(state: CorrectionState): void {
+  const p = getCorrectionStatePath();
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(state, null, 2), "utf8");
+}
+
+export function incrementGlobalCorrections(): CorrectionState {
+  const state = readCorrectionState();
+
+  // Auto-reset daily
+  const lastReset = new Date(state.lastResetAt);
+  const now = new Date();
+  if (
+    now.getFullYear() !== lastReset.getFullYear() ||
+    now.getMonth() !== lastReset.getMonth() ||
+    now.getDate() !== lastReset.getDate()
+  ) {
+    const fresh: CorrectionState = { count: 1, lastResetAt: now.toISOString() };
+    writeCorrectionState(fresh);
+    return fresh;
+  }
+
+  const updated: CorrectionState = { ...state, count: state.count + 1 };
+  writeCorrectionState(updated);
+  return updated;
+}
+
+export function resetCorrectionState(): void {
+  writeCorrectionState({ count: 0, lastResetAt: new Date().toISOString() });
+}
+
+// ---- TG alert ----
+
+/** Send a TG alert when correction threshold is hit. */
+export async function maybeSendCorrectionAlert(
+  correctionState: CorrectionState,
+  botToken: string,
+  chatId: string,
+): Promise<boolean> {
+  if (!botToken || !chatId) return false;
+  if (correctionState.count < CORRECTION_ALERT_THRESHOLD) return false;
+
+  // Throttle: don't alert more than once per hour
+  if (correctionState.lastAlertAt) {
+    const lastAlert = new Date(correctionState.lastAlertAt).getTime();
+    if (Date.now() - lastAlert < 60 * 60 * 1000) return false;
+  }
+
+  const text =
+    `⚠️ <b>Board auto-correction threshold hit</b>\n` +
+    `${correctionState.count} corrections today. Cards may be stuck.\n` +
+    `Please review the board and check stuck cards.`;
+
+  try {
+    const res = await fetch(
+      `https://api.telegram.org/bot${botToken}/sendMessage`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ chat_id: chatId, text, parse_mode: "HTML" }),
+      },
+    );
+    if (res.ok) {
+      writeCorrectionState({ ...correctionState, lastAlertAt: new Date().toISOString() });
+      return true;
+    }
+  } catch {
+    // Non-fatal
+  }
+  return false;
+}

--- a/plugins/mc-board/web/src/lib/types.ts
+++ b/plugins/mc-board/web/src/lib/types.ts
@@ -28,6 +28,8 @@ export interface Card {
   work_log: WorkLogEntry[];
   depends_on: string[];
   attachments: Attachment[];
+  pickup_count: number;
+  correction_count: number;
 }
 
 export interface Attachment {


### PR DESCRIPTION
## Summary
- Add `pickup_count` and `correction_count` columns to cards DB schema with migration for existing DBs
- Enforce per-column max pickup limits (backlog=3, in-progress=10, in-review=2) — cards exceeding limits are auto-corrected
- Auto-correction moves stuck cards forward (backlog→in-progress, in-progress→in-review, in-review→backlog+hold)
- Telegram alerts fire when daily correction count hits threshold (≥3), throttled to 1/hour
- 22 new tests covering all limit checks, correction paths, and counter logic; 242 mc-board tests pass

## Files changed
- `src/db.ts` — schema + ALTER TABLE migration
- `src/card.ts` — Card interface
- `src/store.ts` — CardRow, rowToCard, incrementCorrectionCount
- `src/active-work.ts` — pickup_count increment on CLI pickup
- `src/board.ts` — display in renderCardDetail
- `src/pickup-limits.ts` — NEW: limits, auto-correct, global counter, TG alert
- `src/pickup-limits.test.ts` — NEW: 22 tests
- `web/src/lib/types.ts` — Card type
- `web/src/lib/data.ts` — CardRow, rowToCard
- `web/src/lib/actions.ts` — pickup_count increment on web pickup
- `web/src/lib/pickup-limits.ts` — NEW: web/Next.js variant
- `web/src/app/api/cron/tick/route.ts` — auto-correct before scheduling + isOverLimit filter

## Test plan
- [x] 22 new pickup-limits tests pass
- [x] 242 total mc-board tests pass
- [x] Rebase onto latest main succeeds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)