### PR TITLE
fix(mc-board): pickup enforces column matching for workers

### DIFF
--- a/plugins/mc-board/cli/commands.ts
+++ b/plugins/mc-board/cli/commands.ts
@@ -801,6 +801,17 @@ Examples:
     .action((id: string, opts: { worker: string; column?: string }) => {
       try {
         const card = store.findById(id);
+        // Enforce column matching: worker name must match card's column
+        const workerColumnMap: Record<string, string> = {
+          "board-worker-backlog": "backlog",
+          "board-worker-in-progress": "in-progress",
+          "board-worker-in-review": "in-review",
+        };
+        const expectedColumn = workerColumnMap[opts.worker];
+        if (expectedColumn && card.column !== expectedColumn) {
+          console.error(`COLUMN MISMATCH: ${opts.worker} cannot pick up card ${id} — card is in "${card.column}", worker expects "${expectedColumn}".`);
+          process.exit(1);
+        }
         const entry = activeWork.pickup({
           cardId: card.id,
           projectId: card.project_id,


### PR DESCRIPTION
## Summary
- `pickup` allowed any worker to pick up cards from any column
- During API overload, workers hallucinated and picked up wrong-column cards
- Now rejects with column mismatch error if worker name doesn't match card column

Fixes #204