### PR TITLE
feat(mc-board): add Show/Hide held cards toggle

### DIFF
--- a/plugins/mc-board/web/src/components/board.tsx
+++ b/plugins/mc-board/web/src/components/board.tsx
@@ -50,7 +50,9 @@ export function Board({ selectedProject, initialCardId, onToast, notifsEnabled, 
   const [watchCardId, setWatchCardId] = useState<string | null>(null);
   const [logOpen, setLogOpen] = useState(false);
   const [shippedOpen, setShippedOpen] = useState(false);
-  const [showHeld, setShowHeld] = useState(false);
+  const [showHeld, setShowHeld] = useState(() => {
+    try { return localStorage.getItem("mc-board:show-held") === "true"; } catch { return false; }
+  });
   const [showSummary, setShowSummary] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [searchOpen, setSearchOpen] = useState(false);
@@ -256,15 +258,23 @@ export function Board({ selectedProject, initialCardId, onToast, notifsEnabled, 
               transition: "background 0.15s ease, border-color 0.15s ease",
             }}
           />
-          <label style={{ display: "flex", alignItems: "center", gap: 5, cursor: "pointer", fontSize: 12, color: showHeld ? "#a8a29e" : "#52525b", userSelect: "none", whiteSpace: "nowrap" }}>
-            <input
-              type="checkbox"
-              checked={showHeld}
-              onChange={e => setShowHeld(e.target.checked)}
-              style={{ accentColor: "#d97706", cursor: "pointer" }}
-            />
-            show held
-          </label>
+          <button
+            onClick={() => setShowHeld(prev => {
+              const next = !prev;
+              try { localStorage.setItem("mc-board:show-held", String(next)); } catch {}
+              return next;
+            })}
+            style={{
+              fontSize: 11, fontWeight: 600, padding: "4px 10px", borderRadius: 6,
+              background: showHeld ? "#451a03" : "transparent",
+              border: showHeld ? "1px solid #d97706" : "1px solid #3f3f46",
+              color: showHeld ? "#fbbf24" : "#52525b",
+              cursor: "pointer", whiteSpace: "nowrap",
+              transition: "background 0.15s, border-color 0.15s, color 0.15s",
+            }}
+          >
+            {showHeld ? "Hide held" : "Show held"}
+          </button>
           <button
             onClick={() => setShowSummary(true)}
             style={{

--- a/plugins/mc-board/web/src/components/card-item.tsx
+++ b/plugins/mc-board/web/src/components/card-item.tsx
@@ -97,6 +97,7 @@ export const CardItem = memo(function CardItem({ card, projectName, isActive, wo
       onClick={() => onClick(card.id)}
       onContextMenu={handleContextMenu}
       className={`card${isActive ? " card--active" : ""}${held ? " card--held" : ""}`}
+      style={held ? { opacity: 0.5, filter: "saturate(0.3)" } : undefined}
     >
       {/* Worker strip — click opens live log */}
       <div


### PR DESCRIPTION
## Summary
- Adds a toggle button in the board toolbar that flips between "Show held" / "Hide held"
- Held cards render with distinct visual treatment (opacity 0.5, desaturated, `card--held` CSS class)
- Toggle state persists in localStorage (`mc-board:show-held`)
- Works across all columns (backlog, in-progress, in-review, shipped)

Closes crd_8272c05e

## Test plan
- [ ] Click "Show held" button — held cards appear with muted styling
- [ ] Click "Hide held" — held cards disappear
- [ ] Refresh page — toggle state persists
- [ ] Verify across all 4 columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)