### PR TITLE
fix(cron): backlog worker must move cards to in-progress

### DIFF
--- a/cron/prompts/board-worker-backlog.md
+++ b/cron/prompts/board-worker-backlog.md
@@ -1,18 +1,28 @@
-Board worker — BACKLOG triage.
+Board worker — BACKLOG triage and advance.
 
-MAX_CONCURRENT_COLUMN_TASKS=3.
+1. Get max_concurrency: openclaw mc-board wip-limit in-progress → call this MAX
+2. Get ACTIVE count: openclaw mc-board active
+   Count actively worked cards → ACTIVE_COUNT.
+   Available slots = MAX - ACTIVE_COUNT.
+   If available slots ≤ 0: STOP. Silent exit.
 
-0. INTEGRITY CHECK: openclaw mc-board check-dupes --fix
-   (removes stale duplicate card files before any work begins)
+3. Get backlog cards: openclaw mc-board context --column backlog --skip-hold
+   If 0 cards: STOP. Silent exit.
 
-1. Check what is already being worked: openclaw mc-board active
-2. Get full column context (excludes on-hold cards): openclaw mc-board context --column backlog --skip-hold
-3. Group cards by project. For each project pick at most 1 card — highest priority, then oldest. Skip any card already in the active list.
-   If 0 cards available: Stop here. Silent exit. Do NOT send any Telegram message.
-4. For each selected card:
-   a. Register pickup: openclaw mc-board pickup <id> --worker board-worker-backlog
-   b. Read full detail: openclaw mc-board show <id>
-   c. Fill any missing fields (problem, plan, criteria) — research what is needed
-   d. Move to in-progress: openclaw mc-board move <id> in-progress
-   e. Release: openclaw mc-board release <id> --worker board-worker-backlog
-5. Done. Silent exit.
+4. Select up to [available slots] cards: highest priority first, then oldest.
+
+5. For each selected card:
+   a. openclaw mc-board pickup <id> --worker board-worker-backlog
+   b. openclaw mc-board show <id>
+   c. If missing problem, plan, or criteria: fill them in. Research what is needed.
+   d. Move to in-progress: openclaw mc-board move <id> in-progress --force
+   e. If move fails: release and STOP.
+   f. openclaw mc-board release <id> --worker board-worker-backlog
+
+6. Silent exit.
+
+CRITICAL RULES:
+- Every card you pick up MUST be moved to in-progress before you release it.
+- If a card is blocked or needs human action: put on hold (openclaw mc-board update <id> --hold "reason") and SKIP it. Do NOT pick it up.
+- NEVER pick up a card, do work, and leave it in backlog. That is a bug.
+- NEVER re-triage an already-triaged card. If it has problem+plan+criteria, just move it.


### PR DESCRIPTION
Backlog worker triaged cards but left them in backlog. Now uses --force on move, puts blocked cards on hold. Fixes #203