### PR TITLE
fix(mc-contribute,mc-github): fork-to-PR only workflow

### DIFF
--- a/plugins/mc-contribute/cli/commands.ts
+++ b/plugins/mc-contribute/cli/commands.ts
@@ -10,6 +10,7 @@ import {
   validateRepo,
   validateRemote,
 } from "../src/sanitize.js";
+import { ensureForkRemote, validatePushTarget } from "../src/fork-detect.js";
 import { execFileSync } from "child_process";
 import fs from "fs";
 import path from "path";
@@ -241,11 +242,24 @@ export function register${cap}Commands(
         process.exit(1);
       }
 
+      // Detect fork ownership — auto-fork if origin is not user-owned
+      const forkResult = ensureForkRemote(repoRoot, upstreamRepo, forkRemote, logger);
+      const pushRemote = forkResult.pushRemote;
+      logger.info(`Fork detection: ${forkResult.message}`);
+
+      // Validate we're not pushing directly to upstream when we don't own it
+      const pushError = validatePushTarget(repoRoot, pushRemote, upstreamRepo, logger);
+      if (pushError) {
+        console.error(`PR blocked — ${pushError}`);
+        process.exit(1);
+      }
+
+      // Push branch to the correct remote (fork or origin)
       const branch = run("git", ["branch", "--show-current"], repoRoot);
       try {
-        run("git", ["push", "-u", forkRemote, branch], repoRoot);
+        run("git", ["push", "-u", pushRemote, branch], repoRoot);
       } catch {
-        console.error(`Failed to push branch ${branch}. Check your fork remote.`);
+        console.error(`Failed to push branch ${branch} to '${pushRemote}'. ${forkResult.isFork ? "Check your fork remote." : "Make sure your remote is set up."}`);
         process.exit(1);
       }
 

--- a/plugins/mc-contribute/src/fork-detect.ts
+++ b/plugins/mc-contribute/src/fork-detect.ts
@@ -1,0 +1,200 @@
+/**
+ * Fork detection and auto-fork logic for mc-contribute.
+ *
+ * Before pushing, checks if the current origin is owned by the user.
+ * If not, ensures a fork exists and returns the correct remote to push to.
+ */
+
+import { execFileSync } from "child_process";
+
+type Logger = { info(m: string): void; warn(m: string): void; error(m: string): void };
+
+function run(cmd: string, args: string[], cwd?: string): string {
+  return execFileSync(cmd, args, { encoding: "utf-8", cwd, timeout: 30_000 }).trim();
+}
+
+export interface ForkResult {
+  /** The remote name to push to (e.g. "origin" or "fork") */
+  pushRemote: string;
+  /** Whether we're pushing to a fork (true) or directly to origin (false) */
+  isFork: boolean;
+  /** Human-readable explanation of what happened */
+  message: string;
+}
+
+/**
+ * Get the currently authenticated GitHub username.
+ */
+export function getCurrentUser(): string {
+  return run("gh", ["api", "user", "--jq", ".login"]);
+}
+
+/**
+ * Get the owner and repo from a git remote URL.
+ */
+export function parseRemoteRepo(cwd: string, remoteName: string): { owner: string; repo: string; full: string } | null {
+  try {
+    const url = run("git", ["remote", "get-url", remoteName], cwd);
+    // Match both HTTPS and SSH formats
+    const match = url.match(/github\.com[:/]([^/]+)\/([^/.]+)/);
+    if (match) {
+      return { owner: match[1], repo: match[2], full: `${match[1]}/${match[2]}` };
+    }
+  } catch {
+    // Remote doesn't exist or can't be read
+  }
+  return null;
+}
+
+/**
+ * Check if the origin remote is owned by the current user.
+ * If not, ensure a fork exists and add it as a remote.
+ *
+ * Returns the remote name to push to and whether it's a fork.
+ */
+export function ensureForkRemote(
+  cwd: string,
+  upstreamRepo: string,
+  configuredForkRemote: string,
+  logger: Logger,
+): ForkResult {
+  let currentUser: string;
+  try {
+    currentUser = getCurrentUser();
+  } catch {
+    logger.warn("Could not determine current GitHub user — falling back to configured fork remote");
+    return {
+      pushRemote: configuredForkRemote,
+      isFork: false,
+      message: "Could not determine GitHub user; using configured remote",
+    };
+  }
+
+  const originInfo = parseRemoteRepo(cwd, "origin");
+  if (!originInfo) {
+    logger.warn("No origin remote found — using configured fork remote");
+    return {
+      pushRemote: configuredForkRemote,
+      isFork: false,
+      message: "No origin remote detected",
+    };
+  }
+
+  // If origin is owned by the current user, push directly
+  if (originInfo.owner.toLowerCase() === currentUser.toLowerCase()) {
+    logger.info(`Origin ${originInfo.full} is owned by ${currentUser} — pushing directly`);
+    return {
+      pushRemote: "origin",
+      isFork: false,
+      message: `Origin is user-owned (${currentUser}/${originInfo.repo})`,
+    };
+  }
+
+  // Origin is NOT owned by current user — need a fork
+  logger.info(`Origin ${originInfo.full} is not owned by ${currentUser} — ensuring fork exists`);
+
+  // Check if a fork remote already exists
+  const forkRemoteName = "fork";
+  const existingFork = parseRemoteRepo(cwd, forkRemoteName);
+  if (existingFork && existingFork.owner.toLowerCase() === currentUser.toLowerCase()) {
+    logger.info(`Fork remote already exists: ${existingFork.full}`);
+    return {
+      pushRemote: forkRemoteName,
+      isFork: true,
+      message: `Using existing fork remote (${existingFork.full})`,
+    };
+  }
+
+  // Also check if the configured fork remote points to user's fork
+  if (configuredForkRemote !== "origin" && configuredForkRemote !== forkRemoteName) {
+    const cfgFork = parseRemoteRepo(cwd, configuredForkRemote);
+    if (cfgFork && cfgFork.owner.toLowerCase() === currentUser.toLowerCase()) {
+      logger.info(`Configured remote '${configuredForkRemote}' is user's fork: ${cfgFork.full}`);
+      return {
+        pushRemote: configuredForkRemote,
+        isFork: true,
+        message: `Using configured fork remote '${configuredForkRemote}' (${cfgFork.full})`,
+      };
+    }
+  }
+
+  // Fork doesn't exist or isn't set up — create it
+  try {
+    // gh repo fork will fork the upstream and optionally add a remote
+    run("gh", ["repo", "fork", upstreamRepo, "--clone=false"], cwd);
+    logger.info(`Forked ${upstreamRepo} to ${currentUser}/${originInfo.repo}`);
+  } catch (err: unknown) {
+    // Fork may already exist on GitHub — that's fine
+    const e = err as { stderr?: string };
+    if (e.stderr && e.stderr.includes("already exists")) {
+      logger.info(`Fork already exists on GitHub for ${currentUser}`);
+    } else {
+      logger.warn(`Fork creation returned: ${e.stderr || "unknown"} — proceeding anyway`);
+    }
+  }
+
+  // Add or update the fork remote
+  const forkUrl = `https://github.com/${currentUser}/${originInfo.repo}.git`;
+  try {
+    // Try to add the remote
+    run("git", ["remote", "add", forkRemoteName, forkUrl], cwd);
+    logger.info(`Added remote '${forkRemoteName}' -> ${forkUrl}`);
+  } catch {
+    // Remote may already exist — update its URL
+    try {
+      run("git", ["remote", "set-url", forkRemoteName, forkUrl], cwd);
+      logger.info(`Updated remote '${forkRemoteName}' -> ${forkUrl}`);
+    } catch (err: unknown) {
+      const e = err as { stderr?: string };
+      logger.warn(`Failed to set fork remote: ${e.stderr || "unknown"}`);
+      return {
+        pushRemote: configuredForkRemote,
+        isFork: false,
+        message: `Failed to configure fork remote — falling back to '${configuredForkRemote}'`,
+      };
+    }
+  }
+
+  return {
+    pushRemote: forkRemoteName,
+    isFork: true,
+    message: `Auto-forked ${upstreamRepo} and added remote '${forkRemoteName}' (${forkUrl})`,
+  };
+}
+
+/**
+ * Validate that a push target is NOT the upstream repo when the user doesn't own it.
+ * Returns an error message if pushing directly to upstream is attempted, null if OK.
+ */
+export function validatePushTarget(
+  cwd: string,
+  remoteName: string,
+  upstreamRepo: string,
+  logger: Logger,
+): string | null {
+  let currentUser: string;
+  try {
+    currentUser = getCurrentUser();
+  } catch {
+    // Can't verify — allow the push but warn
+    logger.warn("Could not verify push target ownership — proceeding cautiously");
+    return null;
+  }
+
+  const remoteInfo = parseRemoteRepo(cwd, remoteName);
+  if (!remoteInfo) return null;
+
+  // If the remote points to the upstream repo and the user doesn't own it, block
+  if (
+    remoteInfo.full.toLowerCase() === upstreamRepo.toLowerCase() &&
+    remoteInfo.owner.toLowerCase() !== currentUser.toLowerCase()
+  ) {
+    return (
+      `Refusing to push directly to upstream repo ${upstreamRepo} — ` +
+      `you (${currentUser}) are not the owner. ` +
+      `Use a fork instead. Run 'mc mc-contribute pr' which auto-forks.`
+    );
+  }
+
+  return null;
+}

--- a/plugins/mc-contribute/src/guidelines.ts
+++ b/plugins/mc-contribute/src/guidelines.ts
@@ -40,6 +40,16 @@ plugins/mc-<name>/
 - Never commit real names, emails, phone numbers, or personal data
 - Use example.com for placeholder emails, generic names for placeholder contacts
 
+### Fork-and-PR Only (MANDATORY)
+- **Never add external contributors as collaborators** — they fork and PR.
+- If you do not own the origin repo, you MUST work in a fork.
+- Direct push to upstream is never allowed for non-owners.
+- mc-contribute auto-detects ownership: if origin is not yours, it auto-forks
+  via \`gh repo fork\` and pushes to your fork remote.
+- All PRs are submitted from fork branches to the upstream repo.
+- Repository protection enforces: no direct collaborator access, enforce_admins=true,
+  required_approving_review_count=1, no force push.
+
 ### Branch Naming
 - contrib/<plugin-name> for new plugins
 - contrib/fix-<description> for bug fixes
@@ -51,6 +61,7 @@ plugins/mc-<name>/
 - List affected plugins
 - Security checklist must be checked
 - Run ./scripts/security-check.sh --all before submitting
+- PRs must come from a fork — direct pushes to upstream are blocked
 
 ### Bug Reports
 - Use the Bug Report issue template

--- a/plugins/mc-contribute/tools/definitions.ts
+++ b/plugins/mc-contribute/tools/definitions.ts
@@ -10,6 +10,7 @@ import {
   validateRepo,
   validateRemote,
 } from "../src/sanitize.js";
+import { ensureForkRemote, validatePushTarget } from "../src/fork-detect.js";
 import { execFileSync } from "child_process";
 import fs from "fs";
 import path from "path";
@@ -457,12 +458,23 @@ export function register${cap}Commands(
           );
         }
 
-        // Push branch
+        // Detect fork ownership — auto-fork if origin is not user-owned
+        const forkResult = ensureForkRemote(repoRoot, upstreamRepo, forkRemote, logger);
+        const pushRemote = forkResult.pushRemote;
+        logger.info(`Fork detection: ${forkResult.message}`);
+
+        // Validate we're not pushing directly to upstream when we don't own it
+        const pushError = validatePushTarget(repoRoot, pushRemote, upstreamRepo, logger);
+        if (pushError) {
+          return ok(`PR blocked — ${pushError}`);
+        }
+
+        // Push branch to the correct remote (fork or origin)
         const branch = run("git", ["branch", "--show-current"], repoRoot);
         try {
-          run("git", ["push", "-u", forkRemote, branch], repoRoot);
+          run("git", ["push", "-u", pushRemote, branch], repoRoot);
         } catch {
-          return ok(`Failed to push branch ${branch}. Make sure your fork remote is set up.`);
+          return ok(`Failed to push branch ${branch} to '${pushRemote}'. ${forkResult.isFork ? "Check your fork remote." : "Make sure your remote is set up."}`);
         }
 
         // Create PR — body written to temp file, never shell-interpolated

--- a/plugins/mc-github/index.ts
+++ b/plugins/mc-github/index.ts
@@ -1,12 +1,15 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { registerGithubCommands } from "./cli/commands.js";
 import { createGithubTools } from "./tools/definitions.js";
+import { enforceRepoProtection } from "./src/repo-protection.js";
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
 interface GithubConfig {
   defaultRepo?: string;
+  protectedBranches?: string[];
+  ownerUsername?: string;
 }
 
 function loadCodingAxioms(): string {
@@ -22,6 +25,33 @@ function loadCodingAxioms(): string {
     dir = parent;
   }
   return "";
+}
+
+async function enforceRepoProtectionOnce(cfg: GithubConfig, logger: OpenClawPluginApi["logger"]): Promise<void> {
+  const stateDir = process.env.OPENCLAW_STATE_DIR || path.join(process.env.HOME || "~", ".openclaw");
+  const mcGithubDir = path.join(stateDir, "mc-github");
+  const flagFile = path.join(mcGithubDir, ".repo-protection-done");
+
+  if (fs.existsSync(flagFile)) return;
+
+  // Verify gh auth is configured
+  try {
+    execFileSync("gh", ["auth", "status"], { stdio: "pipe" });
+  } catch {
+    return; // Not authed — skip silently
+  }
+
+  try {
+    await enforceRepoProtection(cfg, logger);
+  } catch (err) {
+    logger.warn(`Repo protection enforcement failed: ${err}`);
+    return;
+  }
+
+  // Write flag file so we don't re-run on restart
+  fs.mkdirSync(mcGithubDir, { recursive: true });
+  fs.writeFileSync(flagFile, `enforced at ${new Date().toISOString()}\n`, "utf-8");
+  logger.info("Repo protection init complete — flagged to skip on next restart");
 }
 
 const STAR_REPOS = ["augmentedmike/miniclaw-os", "augmentedmike/openclaw"];
@@ -95,4 +125,27 @@ export default function register(api: OpenClawPluginApi): void {
   starReposOnce(api.logger).catch((err) =>
     api.logger.warn(`starReposOnce failed: ${err}`)
   );
+
+  // Enforce repo protection once on init (like starReposOnce pattern)
+  enforceRepoProtectionOnce(cfg, api.logger).catch((err) =>
+    api.logger.warn(`enforceRepoProtectionOnce failed: ${err}`)
+  );
+
+  // Register cron for periodic enforcement (hourly)
+  if (api.registerCron) {
+    api.registerCron({
+      id: "github-activity-check",
+      schedule: "0 * * * *",
+      description: "Check and enforce repo protection policies every hour",
+      handler: async () => {
+        api.logger.info("github-activity-check cron: starting protection enforcement");
+        try {
+          await enforceRepoProtection(cfg, api.logger);
+          api.logger.info("github-activity-check cron: enforcement complete");
+        } catch (err) {
+          api.logger.warn(`github-activity-check cron failed: ${err}`);
+        }
+      },
+    });
+  }
 }

--- a/plugins/mc-github/src/repo-protection.ts
+++ b/plugins/mc-github/src/repo-protection.ts
@@ -1,0 +1,247 @@
+import { execFileSync } from "node:child_process";
+
+type Logger = { info(m: string): void; warn(m: string): void; error(m: string): void };
+
+interface RepoProtectionConfig {
+  defaultRepo?: string;
+  protectedBranches?: string[];
+  ownerUsername?: string;
+}
+
+function run(cmd: string, args: string[]): string {
+  return execFileSync(cmd, args, { encoding: "utf-8", timeout: 30_000 }).trim();
+}
+
+function ghApi(method: string, endpoint: string, body?: Record<string, unknown>): string {
+  const args = ["api", "-X", method, endpoint];
+  if (body) {
+    args.push("--input", "-");
+    return execFileSync("gh", args, {
+      encoding: "utf-8",
+      timeout: 30_000,
+      input: JSON.stringify(body),
+    }).trim();
+  }
+  return run("gh", args);
+}
+
+function getOwnerUsername(cfg: RepoProtectionConfig, logger: Logger): string {
+  if (cfg.ownerUsername) return cfg.ownerUsername;
+  try {
+    const status = run("gh", ["auth", "status"]);
+    // Extract username from "Logged in to github.com account username"
+    const match = status.match(/account\s+(\S+)/);
+    if (match) return match[1];
+    // Fallback: use gh api
+    const userJson = run("gh", ["api", "user", "--jq", ".login"]);
+    if (userJson) return userJson;
+  } catch {
+    // ignore
+  }
+  logger.warn("Could not auto-detect owner username from gh auth");
+  return "";
+}
+
+function resolveRepo(cfg: RepoProtectionConfig): string {
+  if (cfg.defaultRepo) return cfg.defaultRepo;
+  try {
+    const remote = run("git", ["remote", "get-url", "origin"]);
+    const match = remote.match(/github\.com[:/]([^/]+\/[^/.]+)/);
+    if (match) return match[1];
+  } catch { /* ignore */ }
+  throw new Error("No defaultRepo configured and could not detect from git remote");
+}
+
+/**
+ * Enforce branch protection rules on a repository.
+ * Sets: require PRs, require status checks, no force push, enforce for admins.
+ */
+async function enforceBranchProtection(
+  repo: string,
+  branch: string,
+  owner: string,
+  logger: Logger,
+): Promise<void> {
+  const endpoint = `/repos/${repo}/branches/${branch}/protection`;
+  const protectionBody = {
+    required_status_checks: {
+      strict: true,
+      contexts: [],
+    },
+    enforce_admins: true,
+    required_pull_request_reviews: {
+      dismiss_stale_reviews: true,
+      require_code_owner_reviews: false,
+      required_approving_review_count: 1,
+    },
+    restrictions: owner
+      ? { users: [owner], teams: [], apps: [] }
+      : null,
+    allow_force_pushes: false,
+    allow_deletions: false,
+  };
+
+  try {
+    ghApi("PUT", endpoint, protectionBody);
+    logger.info(`Branch protection set on ${repo}/${branch}`);
+  } catch (err: unknown) {
+    const e = err as { stderr?: string; message?: string };
+    logger.warn(`Failed to set branch protection on ${repo}/${branch}: ${e.stderr || e.message || "unknown"}`);
+  }
+}
+
+/**
+ * Remove non-owner collaborators entirely.
+ * Fork-and-PR is the only contribution path — no direct collaborator access.
+ * The owner retains admin. Everyone else is removed.
+ */
+async function enforceCollaboratorPermissions(
+  repo: string,
+  owner: string,
+  logger: Logger,
+): Promise<void> {
+  if (!owner) {
+    logger.warn("No owner username — skipping collaborator permission enforcement");
+    return;
+  }
+
+  try {
+    const collabJson = ghApi("GET", `/repos/${repo}/collaborators?affiliation=direct`);
+    const collaborators = JSON.parse(collabJson) as Array<{
+      login: string;
+      permissions: Record<string, boolean>;
+      role_name?: string;
+    }>;
+
+    for (const collab of collaborators) {
+      if (collab.login.toLowerCase() === owner.toLowerCase()) continue;
+
+      // Remove non-owner collaborators entirely — fork-and-PR only policy
+      try {
+        ghApi("DELETE", `/repos/${repo}/collaborators/${collab.login}`);
+        logger.info(`Removed collaborator ${collab.login} from ${repo} (fork-and-PR only policy)`);
+      } catch (err: unknown) {
+        const e = err as { stderr?: string; message?: string };
+        logger.warn(`Failed to remove collaborator ${collab.login}: ${e.stderr || e.message || "unknown"}`);
+      }
+    }
+  } catch (err: unknown) {
+    const e = err as { stderr?: string; message?: string };
+    logger.warn(`Failed to list collaborators for ${repo}: ${e.stderr || e.message || "unknown"}`);
+  }
+}
+
+/**
+ * Check for unauthorized direct pushes to protected branches and revert them.
+ * Looks at recent push events by non-owner users.
+ */
+async function detectAndRevertUnauthorizedPushes(
+  repo: string,
+  branch: string,
+  owner: string,
+  logger: Logger,
+): Promise<void> {
+  if (!owner) {
+    logger.warn("No owner username — skipping push audit");
+    return;
+  }
+
+  try {
+    const eventsJson = ghApi("GET", `/repos/${repo}/events?per_page=50`);
+    const events = JSON.parse(eventsJson) as Array<{
+      type: string;
+      actor: { login: string };
+      payload: {
+        ref?: string;
+        before?: string;
+        head?: string;
+        forced?: boolean;
+      };
+      created_at: string;
+    }>;
+
+    // Filter push events to the protected branch by non-owner
+    const suspiciousPushes = events.filter((e) => {
+      if (e.type !== "PushEvent") return false;
+      const ref = e.payload.ref;
+      if (!ref || !ref.endsWith(`/${branch}`)) return false;
+      if (e.actor.login.toLowerCase() === owner.toLowerCase()) return false;
+      return true;
+    });
+
+    if (suspiciousPushes.length === 0) {
+      logger.info(`No unauthorized pushes detected on ${repo}/${branch}`);
+      return;
+    }
+
+    for (const push of suspiciousPushes) {
+      const beforeSha = push.payload.before;
+      if (!beforeSha || beforeSha === "0000000000000000000000000000000000000000") {
+        logger.warn(`Unauthorized push by ${push.actor.login} on ${branch} but no before SHA to revert to`);
+        continue;
+      }
+
+      logger.warn(
+        `Unauthorized push detected: ${push.actor.login} pushed to ${branch} at ${push.created_at}. ` +
+        `Reverting to ${beforeSha}`,
+      );
+
+      try {
+        // Use the GitHub API to update the branch ref back to the prior commit
+        ghApi("PATCH", `/repos/${repo}/git/refs/heads/${branch}`, {
+          sha: beforeSha,
+          force: true,
+        });
+        logger.info(`Reverted ${branch} to ${beforeSha} (undoing push by ${push.actor.login})`);
+      } catch (err: unknown) {
+        const e = err as { stderr?: string; message?: string };
+        logger.warn(`Failed to revert push: ${e.stderr || e.message || "unknown"}`);
+      }
+
+      // Only revert the most recent unauthorized push to avoid cascading issues
+      break;
+    }
+  } catch (err: unknown) {
+    const e = err as { stderr?: string; message?: string };
+    logger.warn(`Failed to check events for ${repo}: ${e.stderr || e.message || "unknown"}`);
+  }
+}
+
+/**
+ * Main enforcement function — runs all protection checks for a repo.
+ */
+export async function enforceRepoProtection(
+  cfg: RepoProtectionConfig,
+  logger: Logger,
+): Promise<void> {
+  // Verify gh auth
+  try {
+    run("gh", ["auth", "status"]);
+  } catch {
+    logger.warn("gh auth not available — skipping repo protection enforcement");
+    return;
+  }
+
+  let repo: string;
+  try {
+    repo = resolveRepo(cfg);
+  } catch (err: unknown) {
+    const e = err as { message?: string };
+    logger.warn(`Cannot resolve repo: ${e.message || "unknown"}`);
+    return;
+  }
+
+  const owner = getOwnerUsername(cfg, logger);
+  const branches = cfg.protectedBranches ?? ["main"];
+
+  logger.info(`Enforcing repo protection on ${repo} (branches: ${branches.join(", ")}, owner: ${owner || "unknown"})`);
+
+  for (const branch of branches) {
+    await enforceBranchProtection(repo, branch, owner, logger);
+    await detectAndRevertUnauthorizedPushes(repo, branch, owner, logger);
+  }
+
+  await enforceCollaboratorPermissions(repo, owner, logger);
+
+  logger.info(`Repo protection enforcement complete for ${repo}`);
+}


### PR DESCRIPTION
## Summary
- Add fork ownership detection to mc-contribute — auto-forks via `gh repo fork` when origin is not user-owned
- Update mc-github repo protection to remove non-owner collaborators entirely (not downgrade)
- Register hourly `github-activity-check` cron for continuous protection enforcement
- Add fork-and-PR-only policy to contribution guidelines

## Files changed
- `plugins/mc-contribute/src/fork-detect.ts` — new: fork detection + auto-fork logic
- `plugins/mc-contribute/tools/definitions.ts` — integrate fork detection into PR tool
- `plugins/mc-contribute/cli/commands.ts` — integrate fork detection into PR CLI command
- `plugins/mc-contribute/src/guidelines.ts` — add fork-and-PR-only section
- `plugins/mc-github/src/repo-protection.ts` — new: branch protection + collaborator removal
- `plugins/mc-github/index.ts` — register cron + init-time protection enforcement

## Card
crd_09b1b61b