### PR TITLE
fix(mc-pixel-office): active layout loading, cron sync, canvas margin

### DIFF
--- a/plugins/mc-board/web/src/app/api/cron/tick/route.ts
+++ b/plugins/mc-board/web/src/app/api/cron/tick/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
-import { listCronJobs, updateCronJob } from "@/lib/cron";
+import { listCronJobs, updateCronJob, syncManifestCrons } from "@/lib/cron";
 import { listCards, getActiveWork, getRunningByCol } from "@/lib/data";
 import { releaseCard } from "@/lib/actions";
 import { sortCards } from "@/lib/sort";
@@ -112,6 +112,7 @@ function recentlyProcessed(cardId: string, column: string, cooldownMs: number): 
 }
 
 export async function GET(req: Request) {
+  syncManifestCrons(); // Sync MANIFEST crons on first tick
   const base = new URL(req.url).origin;
   const now = Date.now();
   const jobs = listCronJobs();

--- a/plugins/mc-board/web/src/components/pixel-office-tab.tsx
+++ b/plugins/mc-board/web/src/components/pixel-office-tab.tsx
@@ -62,7 +62,9 @@ export function PixelOfficeTab({ onSwitchToBoard }: Props) {
     ? boardData.cards.filter((c) => c.column !== "shipped").length
     : -1;
 
-  // Initialize office
+  const [reloadKey, setReloadKey] = useState(0);
+
+  // Initialize office (re-runs when reloadKey changes)
   useEffect(() => {
     let cancelled = false;
     async function init() {
@@ -73,9 +75,12 @@ export function PixelOfficeTab({ onSwitchToBoard }: Props) {
           const ar = await fetch("/api/office/layouts/active");
           if (ar.ok) {
             const ad = await ar.json();
-            if (ad.active && ad.active !== "default") {
+            if (ad.active) {
               const lr = await fetch(`/api/office/layouts/${encodeURIComponent(ad.active)}`);
-              if (lr.ok) layout = await lr.json();
+              if (lr.ok) {
+                const ld = await lr.json();
+                layout = ld.layout ?? ld; // unwrap if nested
+              }
             }
           }
         } catch {}
@@ -106,7 +111,7 @@ export function PixelOfficeTab({ onSwitchToBoard }: Props) {
     }
     init();
     return () => { cancelled = true; };
-  }, []);
+  }, [reloadKey]);
 
   // Sync board cards → characters
   useEffect(() => {
@@ -211,7 +216,7 @@ export function PixelOfficeTab({ onSwitchToBoard }: Props) {
   }
 
   if (showPlanner) {
-    return <OfficePlanner onClose={() => setShowPlanner(false)} />;
+    return <OfficePlanner onClose={() => { setShowPlanner(false); setReloadKey(k => k + 1); }} />;
   }
 
   if (error) {

--- a/plugins/mc-board/web/src/lib/cron.ts
+++ b/plugins/mc-board/web/src/lib/cron.ts
@@ -104,3 +104,42 @@ export function listCronRuns(limit = 20): CronRun[] {
     }));
   } catch { return []; }
 }
+
+/** Sync MANIFEST.json crons into board-cron.json if missing. Called once on first tick. */
+let _manifestSynced = false;
+export function syncManifestCrons(): void {
+  if (_manifestSynced) return;
+  _manifestSynced = true;
+
+  const stateDir = process.env.OPENCLAW_STATE_DIR ?? path.join(require("node:os").homedir(), ".openclaw", "miniclaw");
+  const manifestPath = path.join(stateDir, "MANIFEST.json");
+  if (!fs.existsSync(manifestPath)) return;
+
+  try {
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+    const existingIds = new Set(listCronJobs().map(j => j.id));
+
+    for (const cron of manifest.crons ?? []) {
+      if (existingIds.has(cron.name)) continue;
+      const schedule = typeof cron.schedule === "string" ? cron.schedule : cron.schedule?.expr;
+      if (!schedule) continue;
+
+      // Check requires — skip if vault secret missing
+      if (cron.requires?.length) {
+        const vaultDir = path.join(stateDir, "SYSTEM", "vault", "secrets");
+        const missing = (cron.requires as string[]).some((r: string) => !fs.existsSync(path.join(vaultDir, `${r}.age`)));
+        if (missing) continue;
+      }
+
+      upsertCronJob({
+        id: cron.name,
+        name: cron.description ?? cron.name,
+        schedule,
+        enabled: !cron.optional,
+        payload: { messageFile: `cron/prompts/${cron.name}.md` },
+      });
+    }
+  } catch (e) {
+    console.warn("[cron] MANIFEST sync failed:", e);
+  }
+}

--- a/plugins/mc-board/web/src/lib/pixel-office/engine.ts
+++ b/plugins/mc-board/web/src/lib/pixel-office/engine.ts
@@ -1115,7 +1115,7 @@ export function centerView(
 
   const scaledW = contentW * state.zoom;
   const scaledH = contentH * state.zoom;
-  const TOP_MARGIN = 60;
+  const TOP_MARGIN = 120;
   state.offsetX = Math.round((canvasWidth - scaledW) / 2) - minC * TILE_SIZE * state.zoom;
   state.offsetY = Math.max(TOP_MARGIN, Math.round((canvasHeight - scaledH) / 2)) - minR * TILE_SIZE * state.zoom;
 }


### PR DESCRIPTION
## Summary
- Office tab loads active layout from API, unwraps nested format
- Re-inits office when closing planner
- MANIFEST crons auto-sync to board-cron.json on first tick
- TOP_MARGIN 120px for canvas Y position
- pr-manager and daily-devlog crons now register automatically

## Test plan
- [ ] Set active layout in planner, close, verify office loads it
- [ ] Check /api/cron shows pr-manager and daily-devlog
- [ ] Verify canvas has proper top margin