### PR TITLE
fix(mc-rolodex): add appends instead of overwriting contacts.json

### DIFF
--- a/plugins/mc-rolodex/src/search/engine.ts
+++ b/plugins/mc-rolodex/src/search/engine.ts
@@ -20,7 +20,10 @@ export class SearchEngine implements ContactStore {
       if (fs.existsSync(this.storagePath)) {
         const data = fs.readFileSync(this.storagePath, 'utf8');
         const contacts: Contact[] = JSON.parse(data);
+        this.contacts.clear();
         contacts.forEach(c => this.contacts.set(c.id, c));
+      } else {
+        this.contacts.clear();
       }
     } catch (err) {
       console.error(`Failed to load contacts from ${this.storagePath}:`, err);


### PR DESCRIPTION
## Summary
- `loadContacts()` now calls `this.contacts.clear()` before repopulating from disk, so each `add`/`update`/`delete` operation works against the true on-disk state rather than a stale in-memory snapshot.
- This prevents separate CLI invocations (separate `SearchEngine` instances) from silently overwriting each other's changes to `contacts.json`.
- When `contacts.json` doesn't exist yet, the map is also cleared so a fresh add writes only the new contact.

## Test plan
- [x] All 35 existing tests pass, including the `concurrent-safe add` test that exercises two engine instances writing to the same file.

Closes #139