### PR TITLE
fix(mc-email): sanitize attachment filenames to prevent path traversal

### DIFF
--- a/plugins/mc-email/__tests__/path-traversal.test.ts
+++ b/plugins/mc-email/__tests__/path-traversal.test.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "vitest";
+import * as path from "node:path";
+
+/**
+ * Validates that path.basename strips directory traversal payloads,
+ * which is the sanitization used in cli/commands.ts for attachment filenames.
+ */
+
+// POSIX traversal payloads only — backslash paths are not traversal vectors
+// on Linux/macOS since backslash is a valid filename character, not a separator.
+const traversalPayloads = [
+  "../../etc/passwd",
+  "../../../etc/shadow",
+  "foo/../../bar/secret.txt",
+  "../.env",
+  "../../../../tmp/evil.sh",
+  "./../credentials.json",
+];
+
+test("path.basename strips all traversal prefixes", () => {
+  for (const payload of traversalPayloads) {
+    const sanitized = path.basename(payload);
+    expect(sanitized).not.toContain("..");
+    expect(sanitized).not.toContain("/");
+  }
+});
+
+test("path.basename preserves safe filenames", () => {
+  expect(path.basename("report.pdf")).toBe("report.pdf");
+  expect(path.basename("my-file_v2.tar.gz")).toBe("my-file_v2.tar.gz");
+  expect(path.basename("image.png")).toBe("image.png");
+});
+
+test("path.join with basename never escapes target directory", () => {
+  const targetDir = "/tmp/attachments";
+  for (const payload of traversalPayloads) {
+    const outPath = path.join(targetDir, path.basename(payload));
+    expect(outPath.startsWith(targetDir)).toBe(true);
+  }
+});
+
+test("known payloads resolve to expected basenames", () => {
+  expect(path.basename("../../etc/passwd")).toBe("passwd");
+  expect(path.basename("../../../etc/shadow")).toBe("shadow");
+  expect(path.basename("../.env")).toBe(".env");
+  expect(path.basename("foo/../../bar/secret.txt")).toBe("secret.txt");
+});

--- a/plugins/mc-email/cli/commands.ts
+++ b/plugins/mc-email/cli/commands.ts
@@ -101,7 +101,7 @@ export function registerEmailCommands(ctx: Ctx): void {
         }
         const att = msg.attachments[idx];
         const fs = await import("node:fs/promises");
-        const outPath = path.join(process.cwd(), att.filename);
+        const outPath = path.join(process.cwd(), path.basename(att.filename));
         if (att.content) {
           await fs.writeFile(outPath, att.content);
           console.log(`Extracted: ${outPath}`);
@@ -120,7 +120,7 @@ export function registerEmailCommands(ctx: Ctx): void {
           await fs.mkdir(opts.saveAttachments, { recursive: true });
           for (const att of msg.attachments) {
             if (att.content) {
-              const outPath = path.join(opts.saveAttachments, att.filename);
+              const outPath = path.join(opts.saveAttachments, path.basename(att.filename));
               await fs.writeFile(outPath, att.content);
               console.log(`Saved: ${outPath}`);
             }


### PR DESCRIPTION
## Summary

- Sanitize email attachment filenames with `path.basename()` before writing to disk, preventing directory traversal attacks (e.g. `../../etc/passwd`)
- Both save locations in `cli/commands.ts` are patched: single attachment extraction (`--attachment`) and bulk save (`--save-attachments`)
- Add `__tests__/path-traversal.test.ts` with POSIX traversal payload coverage

Recovered from #211 which was closed for a process violation (pushed to upstream instead of fork), not for code quality reasons. This PR contains only the path traversal fix — the mc-update and mc-vpn changes from #211 are already on main.

## Security checklist (per REVIEWING.md)

- [x] No new dependencies
- [x] No outbound network calls
- [x] No eval, Function constructor, or dynamic code execution
- [x] No filesystem writes outside expected paths (this fix *prevents* exactly that)
- [x] No secrets or credentials in diff

## Test plan

- [x] `bun test __tests__/path-traversal.test.ts` — 4 tests pass
- [ ] Manual: craft email with traversal filename, confirm it saves to CWD only

Fixes #211