### PR TITLE
fix(cron): use dynamic WIP limits instead of hardcoded value

### DIFF
--- a/cron/prompts/board-worker-in-progress.md
+++ b/cron/prompts/board-worker-in-progress.md
@@ -1,12 +1,14 @@
 Board worker — IN-PROGRESS triage.
 
-MAX_CONCURRENT_COLUMN_TASKS=3. You may work on at most 3 cards, selecting the best candidate per project.
-
-1. Check active workers: openclaw mc-board active
-2. Get full column context (excludes on-hold): openclaw mc-board context --column in-progress --skip-hold
-3. Group by project. Per project pick 1 card — highest priority then oldest. Skip cards already active.
+1. Get configured WIP limit: openclaw mc-board wip-limit in-progress → call this MAX
+2. Count current in-progress cards: openclaw mc-board context --column in-progress
+   Count ALL cards returned → call this IN_PROGRESS_COUNT.
+   If IN_PROGRESS_COUNT ≥ MAX: Stop here. Silent exit. Do NOT send any Telegram message.
+3. Check active workers: openclaw mc-board active
+4. Get full column context (excludes on-hold): openclaw mc-board context --column in-progress --skip-hold
+5. Select up to [MAX - IN_PROGRESS_COUNT] cards to work: highest priority then oldest, across all projects. Skip cards already in the active list.
    If 0 cards available: Stop here. Silent exit. Do NOT send any Telegram message.
-4. For each selected card:
+6. For each selected card:
    a. Register pickup: openclaw mc-board pickup <id> --worker board-worker-in-progress
    b. Read full detail: openclaw mc-board show <id>
    c. Do one unit of work toward completing it — whatever the plan calls for next
@@ -14,4 +16,4 @@ MAX_CONCURRENT_COLUMN_TASKS=3. You may work on at most 3 cards, selecting the be
    e. Update notes with what was done: openclaw mc-board update <id> --notes "<what was done>"
    f. If all criteria checked: openclaw mc-board move <id> in-review
    g. Release: openclaw mc-board release <id> --worker board-worker-in-progress
-5. Done. Silent exit.
+7. Done. Silent exit.

--- a/cron/prompts/board-worker-in-review.md
+++ b/cron/prompts/board-worker-in-review.md
@@ -1,12 +1,14 @@
 Board worker — IN-REVIEW triage.
 
-MAX_CONCURRENT_COLUMN_TASKS=3. Select best candidate per project.
-
-1. Check active workers: openclaw mc-board active
-2. Get full column context (excludes on-hold): openclaw mc-board context --column in-review --skip-hold
-3. Group by project. Per project pick 1 card — highest priority then oldest. Skip cards already active.
+1. Get configured WIP limit: openclaw mc-board wip-limit in-review → call this MAX
+2. Count current in-review cards: openclaw mc-board context --column in-review
+   Count ALL cards returned → call this IN_REVIEW_COUNT.
+   If IN_REVIEW_COUNT ≥ MAX: Stop here. Silent exit. Do NOT send any Telegram message.
+3. Check active workers: openclaw mc-board active
+4. Get full column context (excludes on-hold): openclaw mc-board context --column in-review --skip-hold
+5. Select up to [MAX - IN_REVIEW_COUNT] cards to work: highest priority then oldest, across all projects. Skip cards already in the active list.
    If 0 cards available: Stop here. Silent exit. Do NOT send any Telegram message.
-4. For each selected card:
+6. For each selected card:
    a. Register pickup: openclaw mc-board pickup <id> --worker board-worker-in-review
    b. Read full detail: openclaw mc-board show <id>
    c. Audit: verify the work product exists and all criteria are genuinely met
@@ -32,4 +34,4 @@ MAX_CONCURRENT_COLUMN_TASKS=3. Select best candidate per project.
       - openclaw mc-board update <id> --notes "Review failed: <reason>"
       - Leave in in-review for another pass
    f. Release: openclaw mc-board release <id> --worker board-worker-in-review
-5. Done. Silent exit.
+7. Done. Silent exit.


### PR DESCRIPTION
## Summary
- Replace hardcoded `MAX_CONCURRENT_COLUMN_TASKS=3` in `board-worker-in-progress.md` and `board-worker-in-review.md` with dynamic `openclaw mc-board wip-limit` lookup
- Aligns in-progress and in-review workers with the backlog worker pattern already on main
- Recovered from closed PR #210

## Test plan
- [ ] Verify cron board workers respect configured WIP limits from `mc-board wip-limit`
- [ ] Confirm silent exit when at or over capacity