### PR TITLE
fix: isolate cron sessions from chat via separate agentId

### DIFF
--- a/cron/scripts/mc-cron-sync
+++ b/cron/scripts/mc-cron-sync
@@ -104,6 +104,7 @@ try {
 
     const job = {
       name: cron.name,
+      agentId: 'cron',
       schedule: cron.schedule,
       sessionTarget: cron.sessionTarget || 'isolated',
       payload: {
@@ -125,11 +126,22 @@ try {
     added++;
   }
 
-  if (!dryRun && added > 0) {
+  // Backfill agentId on existing cron jobs that are missing it.
+  // This ensures cron sessions use a separate session store from chat.
+  let backfilled = 0;
+  for (const job of jobs.jobs) {
+    if (!job.agentId && job.sessionTarget === 'isolated') {
+      job.agentId = 'cron';
+      backfilled++;
+      log(`BACKFILL agentId=cron: ${job.name}`);
+    }
+  }
+
+  if (!dryRun && (added > 0 || backfilled > 0)) {
     saveJSON(JOBS_PATH, jobs);
   }
 
-  log(`Done. Added: ${added}, Skipped: ${skipped}, Existing: ${existingNames.size}`);
+  log(`Done. Added: ${added}, Skipped: ${skipped}, Existing: ${existingNames.size}, Backfilled: ${backfilled}`);
 } catch (err) {
   console.error('mc-cron-sync error:', err.message);
   process.exit(1);

--- a/install.sh
+++ b/install.sh
@@ -1063,6 +1063,7 @@ for mc in manifest_crons:
 
     w = {
         "name": mc["name"],
+        "agentId": "cron",
         "schedule": mc["schedule"],
         "sessionTarget": mc.get("sessionTarget", "isolated"),
         "model": mc.get("model", "claude-haiku-4-5-20251001"),
@@ -1081,6 +1082,7 @@ if not workers:
     workers = [
         {
             "name": "board-worker-backlog",
+            "agentId": "cron",
             "schedule": {"kind": "cron", "expr": "*/5 * * * *"},
             "sessionTarget": "isolated",
             "model": "claude-haiku-4-5-20251001",
@@ -1094,6 +1096,7 @@ if not workers:
         },
         {
             "name": "board-worker-in-progress",
+            "agentId": "cron",
             "schedule": {"kind": "cron", "expr": "1-59/5 * * * *"},
             "sessionTarget": "isolated",
             "model": "claude-haiku-4-5-20251001",
@@ -1107,6 +1110,7 @@ if not workers:
         },
         {
             "name": "board-worker-in-review",
+            "agentId": "cron",
             "schedule": {"kind": "cron", "expr": "2-59/5 * * * *"},
             "sessionTarget": "isolated",
             "model": "claude-haiku-4-5-20251001",
@@ -1907,7 +1911,7 @@ except: existing_names = set()
 for job in store.get("jobs", []):
     if job["name"] in existing_names: continue
     expr = job.get("schedule", {}).get("expr", "*/5 * * * *")
-    args = ["openclaw", "cron", "add", "--name", job["name"], "--cron", expr, "--session", job.get("sessionTarget", "isolated")]
+    args = ["openclaw", "cron", "add", "--name", job["name"], "--cron", expr, "--session", job.get("sessionTarget", "isolated"), "--agent", job.get("agentId", "cron")]
     if job.get("payload", {}).get("messageFile"):
         prompt_path = os.path.join(state_dir, "cron", job["payload"]["messageFile"])
         if os.path.exists(prompt_path):


### PR DESCRIPTION
## Summary
- Cron jobs now run under `agentId: "cron"` instead of the default `main` agent
- OpenClaw routes sessions by agentId to separate directories (`~/.openclaw/agents/cron/sessions/` vs `~/.openclaw/agents/main/sessions/`)
- This completely isolates cron/board-worker session transcripts from the TG chat session store
- `mc-cron-sync` backfills `agentId=cron` on existing jobs missing it (upgrade path)
- All `install.sh` cron creation paths include `agentId: "cron"`

## Root cause
All sessions (chat + cron) shared a single `sessions.json` under `agents/main/`. 404 session entries (1 chat + 399 cron runs) in one store. Cron output leaked into chat context, burning 600K+ tokens/hour on pruning.

## How the fix works
OpenClaw's `CronJobSchema` already supports an optional `agentId` field. When set, sessions for that job use `~/.openclaw/agents/{agentId}/sessions/` — a completely separate store. No core changes needed.

Fixes #186

## Test plan
- [ ] Run `mc-cron-sync` — existing jobs get backfilled with `agentId=cron`
- [ ] Verify cron sessions write to `~/.openclaw/agents/cron/sessions/`
- [ ] Verify TG chat sessions stay in `~/.openclaw/agents/main/sessions/`
- [ ] Chat via TG for 30 min — no cron output in context
- [ ] `mc-context` token count stays stable during cron activity