### PR TITLE
release: v0.1.8-prerelease version bump

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -1,11 +1,11 @@
 {
   "name": "miniclaw-os",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "openclaw": {
     "npm": "@miniclaw_official/openclaw",
     "npmVersion": "2026.3.12",
     "repo": "augmentedmike/openclaw",
-    "tag": "v0.1.7"
+    "tag": "v0.1.8"
   },
   "description": "AugmentedMike's AI operating system \u2014 plugins, tools, and infrastructure for OpenClaw",
   "dependencies": {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="#install"><img src="https://img.shields.io/badge/Install_in_60s-FF6D00?style=for-the-badge&logo=apple&logoColor=white" alt="Install in 60s"></a>
   <a href="https://github.com/augmentedmike/miniclaw-os/stargazers"><img src="https://img.shields.io/github/stars/augmentedmike/miniclaw-os?style=for-the-badge&color=yellow" alt="GitHub Stars"></a>
   <a href="https://github.com/augmentedmike/miniclaw-os/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge" alt="Apache 2.0 License"></a>
-  <a href="https://github.com/augmentedmike/miniclaw-os/releases"><img src="https://img.shields.io/badge/version-v0.1.7-blue?style=for-the-badge" alt="v0.1.7"></a>
+  <a href="https://github.com/augmentedmike/miniclaw-os/releases"><img src="https://img.shields.io/badge/version-v0.1.8-blue?style=for-the-badge" alt="v0.1.8"></a>
   <a href="https://github.com/augmentedmike/miniclaw-os/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/augmentedmike/miniclaw-os/test.yml?branch=stable&style=for-the-badge&label=tests" alt="Tests"></a>
 </p>
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,7 +7,7 @@ STATE_DIR="${HOME}/.openclaw"
 WEB_DIR="$STATE_DIR/web"
 APP_PORT=4220
 LOG_FILE="/tmp/miniclaw-bootstrap.log"
-ZIP_URL="https://github.com/augmentedmike/miniclaw-os/releases/download/v0.1.7/MiniClaw-Installer-v0.1.7.zip"
+ZIP_URL="https://github.com/augmentedmike/miniclaw-os/releases/download/v0.1.8/MiniClaw-Installer-v0.1.8.zip"
 
 # Detect if running from .app bundle vs curl|bash
 IS_APP=false


### PR DESCRIPTION
## Summary
- Bump version to 0.1.8 in MANIFEST.json, README.md, bootstrap.sh
- Prerelease candidate — do NOT move stable tag

## Test plan
- [ ] Fresh install from v0.1.8-prerelease zip
- [ ] All plugins load
- [ ] Session isolation verified