### PR TITLE
fix: restore openclaw fork tag to v0.1.7 in MANIFEST

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -5,7 +5,7 @@
     "npm": "@miniclaw_official/openclaw",
     "npmVersion": "2026.3.12",
     "repo": "augmentedmike/openclaw",
-    "tag": "v0.1.8"
+    "tag": "v0.1.7"
   },
   "description": "AugmentedMike's AI operating system \u2014 plugins, tools, and infrastructure for OpenClaw",
   "dependencies": {


### PR DESCRIPTION
The openclaw fork hasn't changed — tag was accidentally bumped to v0.1.8 in the release commit. Restoring to v0.1.7.