### PR TITLE
fix: MANIFEST openclaw tag → v0.1.8-prerelease

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -3,9 +3,9 @@
   "version": "0.1.8",
   "openclaw": {
     "npm": "@miniclaw_official/openclaw",
-    "npmVersion": "2026.3.12",
+    "npmVersion": "2026.3.12-prerelease",
     "repo": "augmentedmike/openclaw",
-    "tag": "v0.1.8"
+    "tag": "v2026.3.12-prerelease"
   },
   "description": "AugmentedMike's AI operating system \u2014 plugins, tools, and infrastructure for OpenClaw",
   "dependencies": {


### PR DESCRIPTION
Points install to the v0.1.8-prerelease tag on augmentedmike/openclaw.