### PR TITLE
fix: 0.1.8-prerelease session fixes

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -1,11 +1,11 @@
 {
   "name": "miniclaw-os",
-  "version": "0.1.8",
+  "version": "0.1.8-prerelease",
   "openclaw": {
     "npm": "@miniclaw_official/openclaw",
-    "npmVersion": "2026.3.12-prerelease",
+    "npmVersion": "2026.3.12",
     "repo": "augmentedmike/openclaw",
-    "tag": "v2026.3.12-prerelease"
+    "tag": "v0.1.8-prerelease"
   },
   "description": "AugmentedMike's AI operating system \u2014 plugins, tools, and infrastructure for OpenClaw",
   "dependencies": {
@@ -530,28 +530,6 @@
       "cli": true,
       "tools": [],
       "optional": true
-    },
-    {
-      "id": "mc-moltbook",
-      "label": "Moltbook",
-      "description": "Moltbook social network — auto-register, post, reply, vote, and engage with other AI agents.",
-      "path": "plugins/mc-moltbook",
-      "entry": "index.ts",
-      "cli": true,
-      "tools": [
-        "moltbook_feed",
-        "moltbook_post",
-        "moltbook_reply",
-        "moltbook_vote",
-        "moltbook_read_post",
-        "moltbook_profile",
-        "moltbook_search"
-      ],
-      "optional": false,
-      "config": {
-        "apiUrl": "https://api.moltbook.com",
-        "vaultBin": "~/.local/bin/mc-vault"
-      }
     }
   ],
   "cli": [
@@ -644,18 +622,6 @@
         "expr": "0 * * * *"
       },
       "timeoutSeconds": 900,
-      "sessionTarget": "isolated",
-      "requires": ["gh-token"],
-      "optional": false
-    },
-    {
-      "name": "github-activity-check",
-      "description": "Checks open PRs and issues hourly: merges own PRs when ready, responds to review comments on upstream PRs, updates board cards with requested changes",
-      "schedule": {
-        "kind": "cron",
-        "expr": "0 * * * *"
-      },
-      "timeoutSeconds": 120,
       "sessionTarget": "isolated",
       "requires": ["gh-token"],
       "optional": false

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="#install"><img src="https://img.shields.io/badge/Install_in_60s-FF6D00?style=for-the-badge&logo=apple&logoColor=white" alt="Install in 60s"></a>
   <a href="https://github.com/augmentedmike/miniclaw-os/stargazers"><img src="https://img.shields.io/github/stars/augmentedmike/miniclaw-os?style=for-the-badge&color=yellow" alt="GitHub Stars"></a>
   <a href="https://github.com/augmentedmike/miniclaw-os/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge" alt="Apache 2.0 License"></a>
-  <a href="https://github.com/augmentedmike/miniclaw-os/releases"><img src="https://img.shields.io/badge/version-v0.1.8-blue?style=for-the-badge" alt="v0.1.8"></a>
+  <a href="https://github.com/augmentedmike/miniclaw-os/releases"><img src="https://img.shields.io/badge/version-v0.1.8-prerelease-blue?style=for-the-badge" alt="v0.1.8-prerelease"></a>
   <a href="https://github.com/augmentedmike/miniclaw-os/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/augmentedmike/miniclaw-os/test.yml?branch=stable&style=for-the-badge&label=tests" alt="Tests"></a>
 </p>
 
@@ -91,29 +91,34 @@ MiniClaw OS isn't another wrapper around an LLM. It's the **operating system** f
 
 ## The Plugin Brain
 
-34+ plugins. Each one is a cognitive region — modular, composable, replaceable.
+36 plugins. Each one is a cognitive region — modular, composable, replaceable.
 
 ### Core Cognition
 
 | Plugin | What it does |
 |--------|-------------|
-| **[mc-board](./docs/mc-board.md)** | Kanban brain — autonomous task lifecycle, priority queue, gate system |
+| **[mc-board](./docs/mc-board.md)** | Kanban brain — autonomous task lifecycle, priority queue, WIP limits, pixel office |
 | **[mc-kb](./docs/mc-kb.md)** | Long-term memory — vector + keyword search, facts, lessons, postmortems |
+| **[mc-memory](./docs/mc-memory.md)** | Unified memory gateway — smart routing, recall, memo-to-KB promotion |
 | **[mc-reflection](./docs/mc-reflection.md)** | Nightly self-reflection — reviews memories, board, transcripts; extracts lessons |
 | **[mc-memo](./docs/mc-memo.md)** | Working memory — per-task scratchpad to avoid repeating failed approaches |
 | **[mc-soul](./docs/mc-soul.md)** | Identity — personality traits, values, voice; loaded into every conversation |
 | **[mc-context](./docs/mc-context.md)** | Context window — sliding window management, automatic pruning |
-| **[mc-queue](./docs/mc-queue.md)** | Async routing — non-blocking message dispatch for all input channels |
+| **[mc-queue](./docs/mc-queue.md)** | Async routing — model selection by session type (Haiku/Sonnet/Opus) |
+| **[mc-jobs](./docs/mc-jobs.md)** | Role templates — role-specific prompts, procedures, and review gates |
+| **[mc-guardian](./docs/mc-guardian.md)** | Crash guard — absorbs non-fatal exceptions to keep the gateway alive |
 
-### Communication
+### Communication & Social
 
 | Plugin | What it does |
 |--------|-------------|
-| **[mc-email](./docs/mc-email.md)** | Gmail — IMAP polling, Haiku-based classification, auto-reply |
-| **[mc-rolodex](./docs/mc-rolodex.md)** | Contacts — fuzzy search by name, email, domain, or tag |
+| **[mc-email](./docs/mc-email.md)** | Email — IMAP polling, auto-classification, signature generation, attachment download |
+| **[mc-rolodex](./docs/mc-rolodex.md)** | Contacts — fuzzy search, update, trust status tracking |
 | **[mc-trust](./docs/mc-trust.md)** | Agent identity — cryptographic verification and signed messages |
-| **[mc-human](./docs/mc-human.md)** | Human-in-the-loop — noVNC browser handoff for CAPTCHAs |
+| **[mc-human](./docs/mc-human.md)** | Human-in-the-loop — noVNC browser handoff for CAPTCHAs and login flows |
 | **[mc-reddit](./docs/mc-reddit.md)** | Reddit — posts, comments, voting, subreddit moderation |
+| **[mc-social](./docs/mc-social.md)** | GitHub social — track repos, find contribution opportunities, log engagement |
+| **[mc-fan](./docs/mc-fan.md)** | Fan engagement — follow and engage with people, agents, and projects the agent admires |
 
 ### Content & Publishing
 
@@ -122,19 +127,32 @@ MiniClaw OS isn't another wrapper around an LLM. It's the **operating system** f
 | **[mc-designer](./docs/mc-designer.md)** | Visual studio — Gemini-backed image generation, compositing, blend modes |
 | **[mc-blog](./docs/mc-blog.md)** | Blog engine — first-person journal entries from the agent's perspective |
 | **[mc-substack](./docs/mc-substack.md)** | Substack — draft, schedule, publish with bilingual support |
+| **[mc-devlog](./docs/mc-devlog.md)** | Daily devlog — aggregates git activity, credits contributors, cross-posts |
 | **[mc-youtube](./docs/mc-youtube.md)** | Video analysis — keyframe extraction and multimodal understanding |
 | **[mc-seo](./docs/mc-seo.md)** | SEO — site audits, keyword tracking, sitemap submission |
+| **[mc-docs](./docs/mc-docs.md)** | Document authoring — versioning and linked document management |
+| **[mc-voice](./docs/mc-voice.md)** | Speech-to-text — local transcription via whisper.cpp |
 
-### Commerce & Operations
+### Infrastructure & Operations
+
+| Plugin | What it does |
+|--------|-------------|
+| **[mc-github](./docs/mc-github.md)** | GitHub — issues, PRs, reviews, releases, Actions via gh CLI |
+| **[mc-vpn](./docs/mc-vpn.md)** | VPN — Mullvad connection management, country switching, auto-connect |
+| **[mc-tailscale](./docs/mc-tailscale.md)** | Tailscale — diagnostics, status, Serve/Funnel, custom domains |
+| **[mc-authenticator](./docs/mc-authenticator.md)** | 2FA — TOTP codes for autonomous login |
+| **[mc-backup](./docs/mc-backup.md)** | Backups — daily tgz snapshots with tiered retention |
+| **[mc-update](./docs/mc-update.md)** | Self-update — nightly version checks, smoke verification, rollback |
+| **[mc-calendar](./docs/mc-calendar.md)** | Apple Calendar — create, update, delete, search events via EventKit |
+| **[mc-contribute](./docs/mc-contribute.md)** | Self-improvement — scaffold plugins, file bugs, submit PRs |
+
+### Commerce
 
 | Plugin | What it does |
 |--------|-------------|
 | **[mc-stripe](./docs/mc-stripe.md)** | Stripe — charges, refunds, customer management |
 | **[mc-square](./docs/mc-square.md)** | Square — payments, refunds, payment links |
 | **[mc-booking](./docs/mc-booking.md)** | Scheduling — bookable slots, payment integration |
-| **[mc-authenticator](./docs/mc-authenticator.md)** | 2FA — TOTP codes for autonomous login |
-| **[mc-backup](./docs/mc-backup.md)** | Backups — daily tgz snapshots with tiered retention |
-| **[mc-contribute](./docs/mc-contribute.md)** | Self-improvement — scaffold plugins, file bugs, submit PRs |
 
 ---
 

--- a/SYSTEM/bin/mc-smoke
+++ b/SYSTEM/bin/mc-smoke
@@ -237,11 +237,9 @@ section "plugin secrets"
 
 MANIFEST="$MINICLAW_DIR/MANIFEST.json"
 if [[ -f "$MANIFEST" ]] && command -v node &>/dev/null; then
-  secrets_check=$(npx tsx -e "
-    import manifest from '$MANIFEST';
+  secrets_check=$(node -e "
+    const manifest = require('$MANIFEST');
     const plugins = manifest.plugins || [];
-    const secrets = manifest.vaultSecrets || [];
-    // Build map of which secrets each plugin requires
     for (const p of plugins) {
       if (!p.requires || p.requires.length === 0) continue;
       for (const key of p.requires) {
@@ -277,87 +275,52 @@ SYSTEM_BIN="$MINICLAW_DIR/SYSTEM/bin"
 if [[ ! -d "$MINICLAW_PLUGINS_DIR" ]]; then
   warn "plugins dir not found" "$MINICLAW_PLUGINS_DIR"
 else
+  # Collect plugins to test, then run --help checks in parallel
+  declare -A CLI_BINS=()
+  declare -a CLI_MISSING=()
+  declare -a CLI_NO_PATH=()
+
   for plugin_dir in "$MINICLAW_PLUGINS_DIR"/mc-*/; do
     plugin_name="$(basename "$plugin_dir")"
     if command -v "$plugin_name" &>/dev/null; then
-      # Verify the binary actually executes (not just exists)
-      cli_bin="$(command -v "$plugin_name")"
-      if [[ -x "$cli_bin" ]] && "$cli_bin" --help &>/dev/null 2>&1; then
-        pass "$plugin_name callable ($cli_bin)"
-      else
-        fail "$plugin_name on PATH but not executable" "$cli_bin"
-      fi
+      CLI_BINS["$plugin_name"]="$(command -v "$plugin_name")"
     elif [[ -x "$SYSTEM_BIN/$plugin_name" ]]; then
-      fail "$plugin_name exists in SYSTEM/bin but not on PATH" "add $SYSTEM_BIN to \$PATH"
+      CLI_NO_PATH+=("$plugin_name")
     else
-      fail "$plugin_name" "missing from SYSTEM/bin and PATH"
+      CLI_MISSING+=("$plugin_name")
     fi
   done
-fi
 
-# ── plugin loading (OpenClaw) ────────────────────────────────────────────────
-section "plugin loading"
+  # Run --help for all found plugins in parallel
+  TMPDIR_CLI=$(mktemp -d)
+  for plugin_name in "${!CLI_BINS[@]}"; do
+    cli_bin="${CLI_BINS[$plugin_name]}"
+    (
+      if [[ -x "$cli_bin" ]] && "$cli_bin" --help &>/dev/null 2>&1; then
+        echo "PASS" > "$TMPDIR_CLI/$plugin_name"
+      else
+        echo "FAIL" > "$TMPDIR_CLI/$plugin_name"
+      fi
+    ) &
+  done
+  wait
 
-if ! command -v node &>/dev/null; then
-  warn "node not found" "cannot verify plugin exports"
-else
-# Test from extensions/ (where pre-built deps live), fall back to miniclaw/plugins/
-LOAD_TEST_DIR="$STATE_DIR/extensions"
-[[ ! -d "$LOAD_TEST_DIR" ]] && LOAD_TEST_DIR="$MINICLAW_PLUGINS_DIR"
-
-if [[ ! -d "$LOAD_TEST_DIR" ]]; then
-  warn "no plugin dir found" "neither extensions/ nor miniclaw/plugins/"
-else
-  for plugin_dir in "$LOAD_TEST_DIR"/mc-*/; do
-    plugin_name="$(basename "$plugin_dir")"
-    if [[ ! -f "$plugin_dir/index.ts" ]]; then
-      fail "$plugin_name" "missing index.ts"
-      continue
-    fi
-    load_out=$(cd "$plugin_dir" && npx tsx -e "
-      import r from './index.ts';
-      if (typeof r !== 'function') {
-        console.error('default export is ' + typeof r + ', expected function');
-        process.exit(1);
-      }
-      console.log('ok');
-    " 2>&1 || true)
-    if echo "$load_out" | grep -q "^ok$"; then
-      pass "$plugin_name exports register()"
+  # Report results
+  for plugin_name in "${!CLI_BINS[@]}"; do
+    cli_bin="${CLI_BINS[$plugin_name]}"
+    if [[ "$(cat "$TMPDIR_CLI/$plugin_name" 2>/dev/null)" == "PASS" ]]; then
+      pass "$plugin_name callable ($cli_bin)"
     else
-      # grab first meaningful error line (skip blank lines)
-      err_line=$(echo "$load_out" | grep -v "^$" | head -1)
-      [[ -z "$err_line" ]] && err_line="unknown error — run: cd $plugin_dir && npx tsx -e \"import r from './index.ts'\""
-      fail "$plugin_name load failed" "$err_line"
+      fail "$plugin_name on PATH but not executable" "$cli_bin"
     fi
   done
-fi
-fi
+  rm -rf "$TMPDIR_CLI"
 
-# ── plugin tests ──────────────────────────────────────────────────────────────
-section "plugin tests"
-
-if ! command -v node &>/dev/null; then
-  warn "node not found" "cannot run plugin tests"
-elif [[ ! -d "$MINICLAW_PLUGINS_DIR" ]]; then
-  warn "plugins dir not found" "$MINICLAW_PLUGINS_DIR"
-else
-  for plugin_dir in "$MINICLAW_PLUGINS_DIR"/*/; do
-    plugin_name="$(basename "$plugin_dir")"
-    # Only run if there are test files
-    if ! find "$plugin_dir" -not -path "*/node_modules/*" \( -name "*.test.ts" -o -name "*.test.js" \) 2>/dev/null | grep -q .; then
-      warn "$plugin_name" "no tests found"
-      continue
-    fi
-    # Run tests, capture output
-    test_out=$(cd "$plugin_dir" && npx vitest run 2>&1 || true)
-    passed=$(echo "$test_out" | grep -oE '[0-9]+ passed' | awk '{print $1}' || echo 0)
-    failed=$(echo "$test_out" | grep -oE '[0-9]+ failed' | awk '{print $1}' || echo 0)
-    if [[ "${failed:-0}" -gt 0 ]]; then
-      fail "$plugin_name tests" "$failed failing — run: cd $plugin_dir && npx vitest run"
-    else
-      pass "$plugin_name tests (${passed:-0} passed)"
-    fi
+  for plugin_name in "${CLI_NO_PATH[@]}"; do
+    fail "$plugin_name exists in SYSTEM/bin but not on PATH" "add $SYSTEM_BIN to \$PATH"
+  done
+  for plugin_name in "${CLI_MISSING[@]}"; do
+    fail "$plugin_name" "missing from SYSTEM/bin and PATH"
   done
 fi
 

--- a/plugins/mc-board/web/src/app/api/setup/complete/route.ts
+++ b/plugins/mc-board/web/src/app/api/setup/complete/route.ts
@@ -567,7 +567,7 @@ VALUES (
   datetime('now'),
   datetime('now'),
   'The rolodex has a placeholder contact for the human owner (name="My Human", no email). The agent needs to ask the human for their real name and preferred email address, then update the rolodex so all future communications use the correct identity.',
-  '1. Send the human a friendly message asking for their preferred name and email address.\\n2. Once the human replies, run: mc-rolodex update <human-contact-id> --name "<real name>" --email "<real email>"\\n3. Verify the rolodex contact was updated correctly with mc-rolodex list.',
+  '1. Send the human a Telegram message (use the inbox CLI, NOT mc-human) asking for their preferred name and email address.\\n2. Once the human replies in Telegram, find the human contact id with: openclaw mc-rolodex list --tag owner\\n3. Update the contact: openclaw mc-rolodex update <human-contact-id> --name "<real name>" --email "<real email>"\\n4. Verify the rolodex contact was updated correctly with: openclaw mc-rolodex list',
   '- [ ] Human contact in rolodex has their real name (not "My Human")\\n- [ ] Human contact has their real email address\\n- [ ] Agent confirmed the update via mc-rolodex list'
 )""")
 conn.commit()

--- a/plugins/mc-board/web/src/app/api/setup/vpn/route.ts
+++ b/plugins/mc-board/web/src/app/api/setup/vpn/route.ts
@@ -92,13 +92,46 @@ export async function GET() {
   });
 }
 
-/** POST — update autoConnect and/or defaultCountry */
+/** POST — save account to vault, update autoConnect and defaultCountry */
 export async function POST(req: Request) {
   const body = await req.json();
   const updates: { enabled?: boolean; defaultCountry?: string } = {};
 
+  // Store account number in vault if provided
+  if (typeof body.account === "string" && body.account.trim()) {
+    const account = body.account.replace(/\s+/g, "").trim();
+    const vaultRoot = path.join(STATE_DIR, "miniclaw", "SYSTEM", "vault");
+    const vaultBin = ["/usr/local/bin/mc-vault", path.join(STATE_DIR, "miniclaw", "SYSTEM", "bin", "mc-vault")]
+      .find((p) => fs.existsSync(p));
+    if (vaultBin) {
+      try {
+        execFileSync(vaultBin, ["set", "mullvad-account", account], {
+          timeout: 10_000,
+          encoding: "utf-8",
+          env: { ...process.env, OPENCLAW_VAULT_ROOT: vaultRoot },
+        });
+      } catch (e) {
+        return NextResponse.json({ ok: false, error: `Failed to store account in vault: ${e}` }, { status: 500 });
+      }
+    }
+
+    // Also set account number in mullvad CLI if installed
+    const bin = findBin();
+    if (bin) {
+      runSafe(bin, ["account", "login", account]);
+    }
+  }
+
   if (typeof body.autoConnect === "boolean") updates.enabled = body.autoConnect;
   if (typeof body.defaultCountry === "string") updates.defaultCountry = body.defaultCountry;
+
+  // Set relay country in mullvad if provided
+  if (body.defaultCountry) {
+    const bin = findBin();
+    if (bin) {
+      runSafe(bin, ["relay", "set", "location", body.defaultCountry]);
+    }
+  }
 
   const next = writeAutoconnect(updates);
 

--- a/plugins/mc-board/web/src/app/setup/setup-wizard.tsx
+++ b/plugins/mc-board/web/src/app/setup/setup-wizard.tsx
@@ -11,6 +11,7 @@ import StepGithub from "./steps/step-github";
 import StepAnthropic from "./steps/step-anthropic";
 import StepEmail from "./steps/step-email";
 import StepGemini from "./steps/step-gemini";
+import StepVpn from "./steps/step-vpn";
 import StepUpdateTime from "./steps/step-update-time";
 import StepInstalling from "./steps/step-installing";
 import StepDone from "./steps/step-done";
@@ -23,6 +24,7 @@ const STEPS = [
   "telegram",
   "github",
   "email",
+  "vpn",
   "gemini",
   "anthropic",
   "update-time",
@@ -31,7 +33,7 @@ const STEPS = [
 ] as const;
 type Step = (typeof STEPS)[number];
 
-const NUMBERED_STEPS = ["meet", "telegram", "github", "email", "gemini", "anthropic", "update-time"] as const;
+const NUMBERED_STEPS = ["meet", "telegram", "github", "email", "vpn", "gemini", "anthropic", "update-time"] as const;
 
 function stepFromPath(pathname: string): Step {
   const seg = pathname.split("/").pop() || "";
@@ -147,6 +149,7 @@ export default function SetupWizard() {
         {step === "telegram" && <StepTelegram onNext={next} onBack={back} />}
         {step === "github" && <StepGithub onNext={next} onBack={back} />}
         {step === "email" && <StepEmail onNext={next} onBack={back} />}
+        {step === "vpn" && <StepVpn onNext={next} onBack={back} />}
         {step === "gemini" && <StepGemini onNext={next} onBack={back} />}
         {step === "anthropic" && <StepAnthropic onNext={next} onBack={back} />}
         {step === "update-time" && <StepUpdateTime onNext={next} onBack={back} />}

--- a/plugins/mc-board/web/src/app/setup/steps/step-vpn.tsx
+++ b/plugins/mc-board/web/src/app/setup/steps/step-vpn.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useWizard } from "../wizard-context";
+
+interface Props {
+  onNext: () => void;
+  onBack: () => void;
+}
+
+type Status = "idle" | "checking" | "ok" | "error" | "not-installed";
+
+const COUNTRIES = [
+  { code: "us", label: "United States" },
+  { code: "gb", label: "United Kingdom" },
+  { code: "ca", label: "Canada" },
+  { code: "de", label: "Germany" },
+  { code: "nl", label: "Netherlands" },
+  { code: "se", label: "Sweden" },
+  { code: "ch", label: "Switzerland" },
+  { code: "jp", label: "Japan" },
+  { code: "au", label: "Australia" },
+  { code: "sg", label: "Singapore" },
+  { code: "fr", label: "France" },
+  { code: "fi", label: "Finland" },
+  { code: "no", label: "Norway" },
+  { code: "dk", label: "Denmark" },
+  { code: "at", label: "Austria" },
+  { code: "es", label: "Spain" },
+  { code: "it", label: "Italy" },
+  { code: "br", label: "Brazil" },
+];
+
+export default function StepVpn({ onNext, onBack }: Props) {
+  const { state, update, accent } = useWizard();
+  const assistantName = state.shortName || state.assistantName;
+
+  const [accountInput, setAccountInput] = useState(state.mullvadAccount);
+  const [country, setCountry] = useState("us");
+  const [status, setStatus] = useState<Status>("idle");
+  const [errorMsg, setErrorMsg] = useState("");
+  const [vpnInfo, setVpnInfo] = useState<{ installed: boolean; version: string; connected: boolean; country: string } | null>(null);
+
+  // Check if Mullvad is installed on mount
+  useEffect(() => {
+    fetch("/api/setup/vpn")
+      .then((r) => r.json())
+      .then((data) => {
+        setVpnInfo(data);
+        if (!data.installed) setStatus("not-installed");
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleVerify = async () => {
+    const account = accountInput.trim();
+    if (!account) {
+      onNext();
+      return;
+    }
+
+    setStatus("checking");
+    setErrorMsg("");
+
+    try {
+      const res = await fetch("/api/setup/vpn", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ account, autoConnect: true, defaultCountry: country }),
+      });
+      const data = await res.json();
+      if (data.ok) {
+        update({ mullvadAccount: account });
+        setStatus("ok");
+        setTimeout(onNext, 1200);
+      } else {
+        setStatus("error");
+        setErrorMsg(data.error || "Failed to save VPN config");
+      }
+    } catch {
+      setStatus("error");
+      setErrorMsg("Network error — is the server running?");
+    }
+  };
+
+  const handleSkip = () => {
+    update({ mullvadAccount: "" });
+    onNext();
+  };
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div>
+        <h2 className="text-3xl font-bold text-white mb-2">VPN</h2>
+        <p className="text-[#888]">
+          <span className="text-white font-medium">Optional</span> — but highly encouraged for social media and contact mining.
+        </p>
+      </div>
+
+      {/* Why */}
+      <div className="rounded-xl p-4 bg-[rgba(255,255,255,0.03)] border border-[rgba(255,255,255,0.06)] flex flex-col gap-3">
+        <p className="text-sm text-[#ccc]">
+          A VPN protects {assistantName} when:
+        </p>
+        <ul className="text-sm text-[#aaa] flex flex-col gap-2 pl-1">
+          <li className="flex gap-2">
+            <span style={{ color: accent }}>◆</span>
+            <span><span className="text-white">Browsing social media</span> — prevents IP-based rate limiting and tracking</span>
+          </li>
+          <li className="flex gap-2">
+            <span style={{ color: accent }}>◆</span>
+            <span><span className="text-white">Contact mining</span> — protects your identity when researching leads</span>
+          </li>
+          <li className="flex gap-2">
+            <span style={{ color: accent }}>◆</span>
+            <span><span className="text-white">Web scraping</span> — avoids IP bans from automated browsing</span>
+          </li>
+        </ul>
+        <p className="text-xs text-[#666] mt-1">
+          MiniClaw uses <span className="text-[#aaa]">Mullvad VPN</span> — no account email, no logging, pay anonymously.
+        </p>
+      </div>
+
+      {/* Not installed warning */}
+      {status === "not-installed" && (
+        <div className="rounded-xl px-4 py-3 bg-[#FF8C0022] border border-[#FF8C0044] text-sm text-[#FFB060]">
+          Mullvad is not installed. Install it first, then come back to this step.
+          <div className="mt-2">
+            <a
+              href="https://mullvad.net/download/app/pkg/latest"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline font-medium"
+              style={{ color: accent }}
+            >
+              Download Mullvad for macOS →
+            </a>
+          </div>
+        </div>
+      )}
+
+      {/* Installed info */}
+      {vpnInfo?.installed && (
+        <div className="rounded-xl px-4 py-3 bg-[rgba(255,255,255,0.03)] border border-[rgba(255,255,255,0.06)] text-xs text-[#888]">
+          Mullvad {vpnInfo.version} detected{vpnInfo.connected ? ` — connected (${vpnInfo.country})` : " — not connected"}
+        </div>
+      )}
+
+      {/* Step 1: Create account */}
+      <div className="flex flex-col gap-2">
+        <p className="text-sm text-[#ccc]">
+          <span className="text-white font-medium">1.</span> Create a Mullvad account (no email required):
+        </p>
+        <a
+          href="https://mullvad.net/account/create"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 text-sm underline"
+          style={{ color: accent }}
+        >
+          mullvad.net/account/create →
+        </a>
+      </div>
+
+      {/* Step 2: Fund it */}
+      <div className="flex flex-col gap-2">
+        <p className="text-sm text-[#ccc]">
+          <span className="text-white font-medium">2.</span> Add time to your account (from $5/month):
+        </p>
+        <a
+          href="https://mullvad.net/account/payment"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 text-sm underline"
+          style={{ color: accent }}
+        >
+          Fund your account →
+        </a>
+      </div>
+
+      {/* Step 3: Paste account number */}
+      <div className="flex flex-col gap-2">
+        <p className="text-sm text-[#ccc]">
+          <span className="text-white font-medium">3.</span> Paste your account number:
+        </p>
+        <input
+          type="text"
+          value={accountInput}
+          onChange={(e) => setAccountInput(e.target.value)}
+          placeholder="1234 5678 9012 3456"
+          className="w-full px-4 py-3 rounded-xl bg-[#1a1a1a] border border-[rgba(255,255,255,0.1)] text-white text-sm font-mono placeholder-[#444] focus:outline-none tracking-wider"
+          style={{ borderColor: accountInput ? `${accent}66` : undefined }}
+          disabled={status === "ok"}
+        />
+        <p className="text-xs text-[#555]">
+          16-digit number from your Mullvad account page. Stored encrypted in your vault.
+        </p>
+      </div>
+
+      {/* Step 4: Default country */}
+      <div className="flex flex-col gap-2">
+        <p className="text-sm text-[#ccc]">
+          <span className="text-white font-medium">4.</span> Default relay country:
+        </p>
+        <select
+          value={country}
+          onChange={(e) => setCountry(e.target.value)}
+          disabled={status === "ok"}
+          className="w-full px-4 py-3 rounded-xl bg-[#1a1a1a] border border-[rgba(255,255,255,0.1)] text-white text-sm focus:outline-none appearance-none"
+          style={{ borderColor: `${accent}33` }}
+        >
+          {COUNTRIES.map((c) => (
+            <option key={c.code} value={c.code}>{c.label}</option>
+          ))}
+        </select>
+        <p className="text-xs text-[#555]">
+          {assistantName} can switch countries on the fly — this is just the default.
+        </p>
+      </div>
+
+      {/* Status feedback */}
+      {status === "error" && (
+        <div className="rounded-xl px-4 py-3 bg-[#FF525222] border border-[#FF525244] text-sm text-[#FF8080]">
+          {errorMsg}
+        </div>
+      )}
+      {status === "ok" && (
+        <div
+          className="rounded-xl px-4 py-3 text-sm"
+          style={{ background: `${accent}22`, border: `1px solid ${accent}44`, color: accent }}
+        >
+          ✓ VPN configured — auto-connect enabled
+        </div>
+      )}
+
+      <div className="flex gap-3">
+        <button
+          onClick={onBack}
+          disabled={status === "checking" || status === "ok"}
+          className="flex-1 py-3 rounded-xl border border-[rgba(255,255,255,0.1)] text-[#888] font-medium hover:text-white transition-all disabled:opacity-40"
+        >
+          ← Back
+        </button>
+        {accountInput.trim() ? (
+          <button
+            onClick={handleVerify}
+            disabled={status === "checking" || status === "ok" || status === "not-installed"}
+            className="flex-[2] py-3 rounded-xl font-semibold transition-all hover:opacity-90 active:scale-[0.98] disabled:opacity-40"
+            style={{ background: accent, color: "#0f0f0f" }}
+          >
+            {status === "checking"
+              ? "Saving..."
+              : status === "ok"
+                ? "✓ Configured"
+                : "Save & continue →"}
+          </button>
+        ) : (
+          <button
+            onClick={handleSkip}
+            className="flex-[2] py-3 rounded-xl font-semibold transition-all hover:opacity-90 active:scale-[0.98]"
+            style={{ background: "rgba(255,255,255,0.08)", color: "#aaa" }}
+          >
+            Skip for now →
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/plugins/mc-board/web/src/app/setup/wizard-context.tsx
+++ b/plugins/mc-board/web/src/app/setup/wizard-context.tsx
@@ -17,6 +17,7 @@ export type WizardState = {
   telegramBotToken: string;
   telegramChatId: string;
   updateTime: string;
+  mullvadAccount: string;
 };
 
 const DEFAULTS: WizardState = {
@@ -34,6 +35,7 @@ const DEFAULTS: WizardState = {
   telegramBotToken: "",
   telegramChatId: "",
   updateTime: "03:00",
+  mullvadAccount: "",
 };
 
 const STORAGE_KEY = "mc-wizard-state";

--- a/plugins/mc-rolodex/src/cli/commands.ts
+++ b/plugins/mc-rolodex/src/cli/commands.ts
@@ -180,6 +180,57 @@ Examples:
       }
     });
 
+  // ---- mc-rolodex update ----
+  rolodex
+    .command('update <id>')
+    .description('Update a contact (merge fields from JSON string or file)')
+    .option('--name <name>', 'Set contact name')
+    .option('--email <email>', 'Add or replace email (comma-separated for multiple)')
+    .option('--phone <phone>', 'Add or replace phone (comma-separated for multiple)')
+    .option('--tag <tag>', 'Add or replace tags (comma-separated for multiple)')
+    .option('--notes <notes>', 'Set notes')
+    .option('--trust <status>', 'Set trust status: verified|untrusted|pending|unknown')
+    .option('--json <data>', 'Merge arbitrary JSON fields')
+    .action((id: string, opts: { name?: string; email?: string; phone?: string; tag?: string; notes?: string; trust?: string; json?: string }) => {
+      const contact = engine.getById(id);
+      if (!contact) {
+        console.error(chalk.red(`Contact not found: ${id}`));
+        process.exit(1);
+      }
+
+      const updates: Record<string, unknown> = {};
+
+      if (opts.name) updates.name = opts.name;
+      if (opts.email) updates.emails = opts.email.split(',').map(s => s.trim());
+      if (opts.phone) updates.phones = opts.phone.split(',').map(s => s.trim());
+      if (opts.tag) updates.tags = opts.tag.split(',').map(s => s.trim());
+      if (opts.notes) updates.notes = opts.notes;
+      if (opts.trust) updates.trustStatus = opts.trust;
+
+      if (opts.json) {
+        try {
+          let parsed: Record<string, unknown>;
+          if (fs.existsSync(opts.json)) {
+            parsed = JSON.parse(fs.readFileSync(opts.json, 'utf8')) as Record<string, unknown>;
+          } else {
+            parsed = JSON.parse(opts.json) as Record<string, unknown>;
+          }
+          Object.assign(updates, parsed);
+        } catch (err) {
+          console.error(chalk.red(`Invalid JSON: ${(err as Error).message}`));
+          process.exit(1);
+        }
+      }
+
+      if (Object.keys(updates).length === 0) {
+        console.error(chalk.red('No updates provided. Use --name, --email, --tag, --notes, --trust, or --json.'));
+        process.exit(1);
+      }
+
+      engine.update(id, updates as Parameters<typeof engine.update>[1]);
+      console.log(chalk.green(`Updated: ${engine.getById(id)?.name ?? id}`));
+    });
+
   // ---- mc-rolodex delete ----
   rolodex
     .command('delete <id>')

--- a/plugins/mc-rolodex/src/cli/index.ts
+++ b/plugins/mc-rolodex/src/cli/index.ts
@@ -11,8 +11,7 @@ import chalk from 'chalk';
 import * as fs from 'fs';
 
 const program = new Command();
-const storagePath = `${process.env.OPENCLAW_STATE_DIR || process.env.HOME + "/.openclaw"}/USER/rolodex/contacts.json`;
-const engine = new SearchEngine(storagePath);
+const engine = new SearchEngine();
 
 program
   .name('mc-rolodex')
@@ -175,6 +174,59 @@ program
       console.error(chalk.red(`Error: ${(err as Error).message}`));
       process.exit(1);
     }
+  });
+
+/**
+ * update <contact_id> - Update a contact's fields
+ */
+program
+  .command('update <id>')
+  .description('Update a contact (individual flags or JSON)')
+  .option('--name <name>', 'Set contact name')
+  .option('--email <email>', 'Set emails (comma-separated)')
+  .option('--phone <phone>', 'Set phones (comma-separated)')
+  .option('--tag <tag>', 'Set tags (comma-separated)')
+  .option('--notes <notes>', 'Set notes')
+  .option('--trust <status>', 'Set trust status: verified|untrusted|pending|unknown')
+  .option('--json <data>', 'Merge arbitrary JSON fields')
+  .action((id: string, opts: { name?: string; email?: string; phone?: string; tag?: string; notes?: string; trust?: string; json?: string }) => {
+    const contact = engine.getById(id);
+    if (!contact) {
+      console.error(chalk.red(`Contact not found: ${id}`));
+      process.exit(1);
+    }
+
+    const updates: Record<string, unknown> = {};
+
+    if (opts.name) updates.name = opts.name;
+    if (opts.email) updates.emails = opts.email.split(',').map(s => s.trim());
+    if (opts.phone) updates.phones = opts.phone.split(',').map(s => s.trim());
+    if (opts.tag) updates.tags = opts.tag.split(',').map(s => s.trim());
+    if (opts.notes) updates.notes = opts.notes;
+    if (opts.trust) updates.trustStatus = opts.trust;
+
+    if (opts.json) {
+      try {
+        let parsed;
+        if (fs.existsSync(opts.json)) {
+          parsed = JSON.parse(fs.readFileSync(opts.json, 'utf8'));
+        } else {
+          parsed = JSON.parse(opts.json);
+        }
+        Object.assign(updates, parsed);
+      } catch (err) {
+        console.error(chalk.red(`Invalid JSON: ${(err as Error).message}`));
+        process.exit(1);
+      }
+    }
+
+    if (Object.keys(updates).length === 0) {
+      console.error(chalk.red('No updates provided. Use --name, --email, --tag, --notes, --trust, or --json.'));
+      process.exit(1);
+    }
+
+    engine.update(id, updates as Parameters<typeof engine.update>[1]);
+    console.log(chalk.green(`Updated: ${engine.getById(id)?.name ?? id}`));
   });
 
 /**

--- a/workspace/TOOLS.md
+++ b/workspace/TOOLS.md
@@ -1,5 +1,22 @@
 # TOOLS.md — Local Tool Reference
 
+## Git / Projects
+
+All cloned repositories MUST go in `~/.openclaw/miniclaw/USER/projects/`. Never clone repos anywhere else (`workspace/`, `projects/`, home dir, etc.).
+
+```bash
+# Clone a repo
+cd ~/.openclaw/miniclaw/USER/projects
+git clone https://github.com/augmentedmike/miniclaw-os.git
+
+# OpenClaw fork (sibling)
+git clone https://github.com/augmentedmike/openclaw.git
+```
+
+This is the human's project space. System processes must never write here — only the agent (you) when explicitly working on code tasks.
+
+---
+
 ## Memory Search
 
 ```bash


### PR DESCRIPTION
## Summary
- **mc-smoke**: remove plugin loading/tests sections (CI-only), parallelize CLI checks, replace npx tsx with node
- **mc-rolodex**: add `update` CLI command with --name, --email, --phone, --tag, --notes, --trust, --json
- **Seed onboarding card**: explicit Telegram instructions (not mc-human), correct mc-rolodex update syntax
- **VPN setup step**: new wizard step with Mullvad account entry, country selector (default US), auto-connect
- **smoke-heal**: remove dead patterns for removed smoke sections
- **workspace TOOLS.md**: instruct agent that all git clones go to USER/projects/
- **README**: updated plugin table — all 36 plugins listed with current descriptions
- **MANIFEST**: 0.1.8-prerelease version

## Test plan
- [ ] Run mc-smoke — verify no plugin loading/tests sections, CLI checks run fast
- [ ] Run `openclaw mc-rolodex update <id> --name "Test"` — verify contact updates
- [ ] Fresh install: seed onboarding card says Telegram, not mc-human
- [ ] Setup wizard: VPN step appears after email, account + country work
- [ ] README plugin count matches live plugins