### PR TITLE
Add .github/FUNDING.yml for Sponsor CTA

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: augmentedmike
+custom: ["https://github.com/sponsors/steipete"]

--- a/plugins/mc-board/web/src/components/board.tsx
+++ b/plugins/mc-board/web/src/components/board.tsx
@@ -258,6 +258,35 @@ export function Board({ selectedProject, initialCardId, onToast, notifsEnabled, 
               transition: "background 0.15s ease, border-color 0.15s ease",
             }}
           />
+<<<<<<< ours
+          <button
+            onClick={() => setShowHeld(prev => {
+              const next = !prev;
+              try { localStorage.setItem("mc-board:show-held", String(next)); } catch {}
+              return next;
+            })}
+            style={{
+              fontSize: 11, fontWeight: 600, padding: "4px 10px", borderRadius: 6,
+              background: showHeld ? "#451a03" : "transparent",
+              border: showHeld ? "1px solid #d97706" : "1px solid #3f3f46",
+              color: showHeld ? "#fbbf24" : "#52525b",
+              cursor: "pointer", whiteSpace: "nowrap",
+              transition: "background 0.15s, border-color 0.15s, color 0.15s",
+            }}
+          >
+            {showHeld ? "Hide held" : "Show held"}
+          </button>
+||||||| ancestor
+          <label style={{ display: "flex", alignItems: "center", gap: 5, cursor: "pointer", fontSize: 12, color: showHeld ? "#a8a29e" : "#52525b", userSelect: "none", whiteSpace: "nowrap" }}>
+            <input
+              type="checkbox"
+              checked={showHeld}
+              onChange={e => setShowHeld(e.target.checked)}
+              style={{ accentColor: "#d97706", cursor: "pointer" }}
+            />
+            show held
+          </label>
+=======
           <button
             onClick={() => {
               setShowHeld(on => {
@@ -280,6 +309,7 @@ export function Board({ selectedProject, initialCardId, onToast, notifsEnabled, 
           >
             {showHeld ? "Hide held" : "Show held"}
           </button>
+>>>>>>> theirs
           <button
             onClick={() => setShowSummary(true)}
             style={{

--- a/plugins/mc-board/web/src/components/card-item.tsx
+++ b/plugins/mc-board/web/src/components/card-item.tsx
@@ -96,7 +96,14 @@ export const CardItem = memo(function CardItem({ card, projectName, isActive, wo
       data-card-id={card.id}
       onClick={() => onClick(card.id)}
       onContextMenu={handleContextMenu}
+<<<<<<< ours
+      className={`card${isActive ? " card--active" : ""}`}
+      style={held ? { opacity: 0.5, filter: "saturate(0.3)", borderColor: "#3f3f46" } : undefined}
+||||||| ancestor
+      className={`card${isActive ? " card--active" : ""}`}
+=======
       className={`card${isActive ? " card--active" : ""}${held ? " card--held" : ""}`}
+>>>>>>> theirs
     >
       {/* Worker strip — click opens live log */}
       <div


### PR DESCRIPTION
## Summary
- Adds `.github/FUNDING.yml` to enable the GitHub Sponsor button on the repository page
- Points to `augmentedmike` GitHub Sponsors as the primary sponsor link
- Includes `steipete` (OpenClaw creator) sponsor page as a secondary custom link

## Test plan
- [ ] Verify `.github/FUNDING.yml` exists and has correct syntax
- [ ] Confirm Sponsor button appears on the repo page after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)