### PR TITLE
fix: skip password gate during initial setup

### DIFF
--- a/plugins/mc-board/web/src/app/api/setup/anthropic/route.ts
+++ b/plugins/mc-board/web/src/app/api/setup/anthropic/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server";
 import { execSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { consumeToken } from "@/lib/sensitive-auth";
+import { isSetupComplete } from "@/lib/setup-state";
 
 const CLAUDE_BIN = "/Users/michaeloneal/.local/bin/claude";
 const HOME = process.env.HOME || "";
@@ -68,7 +69,7 @@ export async function POST() {
 export async function PUT(req: Request) {
   const { token, sensitiveToken } = await req.json();
 
-  if (!consumeToken(sensitiveToken)) {
+  if (isSetupComplete() && !consumeToken(sensitiveToken)) {
     return NextResponse.json(
       { ok: false, error: "Password confirmation required" },
       { status: 403 },

--- a/plugins/mc-board/web/src/app/api/setup/email/route.ts
+++ b/plugins/mc-board/web/src/app/api/setup/email/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { checkImapAuth, checkSmtpAuth } from "@/lib/email-check";
-import { writeSetupState } from "@/lib/setup-state";
+import { writeSetupState, isSetupComplete } from "@/lib/setup-state";
 import { consumeToken } from "@/lib/sensitive-auth";
 
 function isGmail(email: string): boolean {
@@ -13,7 +13,7 @@ function isGmail(email: string): boolean {
 export async function POST(req: Request) {
   const { email, appPassword, smtpHost, smtpPort, sensitiveToken } = await req.json();
 
-  if (!consumeToken(sensitiveToken)) {
+  if (isSetupComplete() && !consumeToken(sensitiveToken)) {
     return NextResponse.json(
       { ok: false, error: "Password confirmation required" },
       { status: 403 },

--- a/plugins/mc-board/web/src/app/api/setup/gemini/route.ts
+++ b/plugins/mc-board/web/src/app/api/setup/gemini/route.ts
@@ -1,13 +1,13 @@
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
-import { writeSetupState } from "@/lib/setup-state";
+import { writeSetupState, isSetupComplete } from "@/lib/setup-state";
 import { consumeToken } from "@/lib/sensitive-auth";
 
 export async function POST(req: Request) {
   const { apiKey, sensitiveToken } = await req.json();
 
-  if (!consumeToken(sensitiveToken)) {
+  if (isSetupComplete() && !consumeToken(sensitiveToken)) {
     return NextResponse.json(
       { ok: false, error: "Password confirmation required" },
       { status: 403 },

--- a/plugins/mc-board/web/src/app/api/setup/github/route.ts
+++ b/plugins/mc-board/web/src/app/api/setup/github/route.ts
@@ -1,13 +1,13 @@
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
-import { writeSetupState } from "@/lib/setup-state";
+import { writeSetupState, isSetupComplete } from "@/lib/setup-state";
 import { consumeToken } from "@/lib/sensitive-auth";
 
 export async function POST(req: Request) {
   const { token, sensitiveToken } = (await req.json()) as { token: string; sensitiveToken?: string };
 
-  if (!consumeToken(sensitiveToken)) {
+  if (isSetupComplete() && !consumeToken(sensitiveToken)) {
     return NextResponse.json(
       { ok: false, error: "Password confirmation required" },
       { status: 403 },

--- a/plugins/mc-board/web/src/app/api/setup/telegram/route.ts
+++ b/plugins/mc-board/web/src/app/api/setup/telegram/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
-import { writeSetupState } from "@/lib/setup-state";
+import { writeSetupState, isSetupComplete } from "@/lib/setup-state";
 import { consumeToken } from "@/lib/sensitive-auth";
 
 export async function POST(req: Request) {
   const { botToken, chatId, botUsername, sensitiveToken } = await req.json();
 
-  if (!consumeToken(sensitiveToken)) {
+  if (isSetupComplete() && !consumeToken(sensitiveToken)) {
     return NextResponse.json(
       { ok: false, error: "Password confirmation required" },
       { status: 403 },


### PR DESCRIPTION
Setup routes block on sensitiveToken even during first-time setup. Skip when isSetupComplete() is false.