### PR TITLE
fix(mc-email): improve HTML-to-text for HTML-only multipart emails

### DIFF
--- a/plugins/mc-email/src/client.test.ts
+++ b/plugins/mc-email/src/client.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { htmlToText } from "./client.js";
+
+describe("htmlToText", () => {
+  it("extracts readable text from HTML-only email body", () => {
+    const html =
+      "<html><body><h1>Welcome</h1><p>This is an <b>HTML-only</b> email.</p></body></html>";
+    const result = htmlToText(html);
+    expect(result).toBeTruthy();
+    expect(result).toContain("Welcome");
+    expect(result).toContain("HTML-only");
+    expect(result).not.toContain("<");
+    expect(result).not.toContain(">");
+  });
+
+  it("decodes HTML entities", () => {
+    const html = "<p>A &amp; B &lt; C &gt; D &quot;E&quot; F&#39;s &nbsp; end</p>";
+    const result = htmlToText(html);
+    expect(result).toContain("A & B");
+    expect(result).toContain("< C >");
+    expect(result).toContain('"E"');
+    expect(result).toContain("F's");
+  });
+
+  it("strips style blocks before tag removal", () => {
+    const html = [
+      "<html><head><style>body { color: red; font-family: Arial; }</style></head>",
+      "<body><p>Visible content only</p></body></html>",
+    ].join("");
+    const result = htmlToText(html);
+    expect(result).toContain("Visible content");
+    expect(result).not.toContain("color: red");
+    expect(result).not.toContain("font-family");
+  });
+
+  it("strips script blocks", () => {
+    const html =
+      '<body><script>alert("xss")</script><p>Safe text</p></body>';
+    const result = htmlToText(html);
+    expect(result).toContain("Safe text");
+    expect(result).not.toContain("alert");
+  });
+
+  it("handles complex multipart HTML with CSS and entities", () => {
+    const html = `
+      <html>
+      <head>
+        <style>
+          .header { background: #f0f0f0; padding: 20px; }
+          .content { font-size: 14px; }
+        </style>
+      </head>
+      <body>
+        <div class="header"><h1>Newsletter</h1></div>
+        <div class="content">
+          <p>Hello &amp; welcome to our Q1 update.</p>
+          <p>Revenue grew &gt; 20% &mdash; a great result.</p>
+          <p>&copy; 2026 Acme Corp&trade;</p>
+        </div>
+        <script>trackOpen();</script>
+      </body>
+      </html>
+    `;
+    const result = htmlToText(html);
+    expect(result).toContain("Newsletter");
+    expect(result).toContain("Hello & welcome");
+    expect(result).toContain("> 20%");
+    expect(result).toContain("—");
+    expect(result).toContain("© 2026 Acme Corp™");
+    expect(result).not.toContain("background");
+    expect(result).not.toContain("trackOpen");
+    expect(result).not.toContain("<");
+  });
+
+  it("decodes numeric character references", () => {
+    const html = "<p>&#65;&#66;&#67; and &#x41;&#x42;&#x43;</p>";
+    const result = htmlToText(html);
+    expect(result).toContain("ABC");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(htmlToText("")).toBe("");
+  });
+});

--- a/plugins/mc-email/src/client.ts
+++ b/plugins/mc-email/src/client.ts
@@ -5,6 +5,56 @@ import type { EmailConfig } from "./config.js";
 import { getAppPassword } from "./vault.js";
 import type { EmailAttachment, EmailMessage, SendEmailOptions } from "./types.js";
 
+const HTML_ENTITY_MAP: Record<string, string> = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#39;": "'",
+  "&apos;": "'",
+  "&nbsp;": " ",
+  "&ndash;": "–",
+  "&mdash;": "—",
+  "&hellip;": "…",
+  "&copy;": "©",
+  "&reg;": "®",
+  "&trade;": "™",
+};
+
+/**
+ * Convert HTML to readable plain text.
+ * 1. Strip <style> and <script> blocks (including contents)
+ * 2. Strip remaining HTML tags
+ * 3. Decode common HTML entities + numeric character references
+ * 4. Collapse whitespace
+ */
+export function htmlToText(html: string): string {
+  let text = html;
+  // Remove style blocks
+  text = text.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "");
+  // Remove script blocks
+  text = text.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "");
+  // Strip all HTML tags
+  text = text.replace(/<[^>]+>/g, " ");
+  // Decode named HTML entities
+  text = text.replace(/&[a-z#0-9]+;/gi, (entity) => {
+    const lower = entity.toLowerCase();
+    if (HTML_ENTITY_MAP[lower]) return HTML_ENTITY_MAP[lower];
+    // Numeric character references: &#123; or &#x1a;
+    const numMatch = lower.match(/^&#x?([0-9a-f]+);$/);
+    if (numMatch) {
+      const code = lower.startsWith("&#x")
+        ? parseInt(numMatch[1], 16)
+        : parseInt(numMatch[1], 10);
+      return String.fromCharCode(code);
+    }
+    return entity;
+  });
+  // Collapse whitespace
+  text = text.replace(/\s+/g, " ").trim();
+  return text;
+}
+
 function createImapClient(cfg: EmailConfig): ImapFlow {
   const password = getAppPassword(cfg.vaultBin);
   if (!password) {
@@ -94,8 +144,7 @@ export class GmailClient {
           const parsed = await simpleParser(msg.source);
           body = parsed.text ?? "";
           if (!body && parsed.html) {
-            // Strip HTML tags as fallback when no plain-text part exists
-            body = parsed.html.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+            body = htmlToText(parsed.html);
           }
           snippet = body.substring(0, 500);
 


### PR DESCRIPTION
## Summary
- Add `htmlToText()` helper that strips `<style>`/`<script>` blocks, removes HTML tags, decodes named & numeric HTML entities, and collapses whitespace
- Fix `getMessage()` to use `htmlToText()` instead of brittle `/<[^>]+>/g` regex that leaked CSS into output
- Add comprehensive unit tests for `htmlToText()` covering entity decoding, style/script stripping, and complex HTML emails

Fixes crd_bf8dc365 — HTML-only multipart emails now return readable plain text.

Supersedes #259 (closed due to merge conflicts).

## Test plan
- [x] `vitest run` passes all 23 tests (4 test files)
- [x] New `htmlToText` tests verify entity decoding, style stripping, script stripping
- [x] Existing snippet extraction tests still pass