### PR TITLE
feat: add FUNDING.yml and Support section to README

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: augmentedmike
+custom: https://helloam.bot/#support

--- a/README.md
+++ b/README.md
@@ -222,6 +222,16 @@ mc-doctor         # Full diagnosis & auto-repair
 
 ---
 
+## Support
+
+**Free support:** [miniclaw.bot/#support](https://miniclaw.bot/#support) — community forums, knowledge base, and async help.
+
+**Paid consulting:** Setup assistance, custom plugin development, architecture reviews, and ongoing support via Amelia's sponsor program. [Learn more →](https://helloam.bot/#support)
+
+**Report a bug or suggest a feature:** Use the [GitHub Issues](https://github.com/augmentedmike/miniclaw-os/issues) or [GitHub Discussions](https://github.com/augmentedmike/miniclaw-os/discussions) — your agent can file these for you.
+
+---
+
 ## Contributing
 
 Your agent handles contributions autonomously via **[mc-contribute](./docs/mc-contribute.md)**. Tell it what you want — file a bug, request a feature, submit a fix — and it does the work.


### PR DESCRIPTION
## What

Adds GitHub sponsor configuration and a dedicated Support section to README.

## Why

Discussion #252 — the repo needs a support CTA. GitHub displays a Sponsor button when `.github/FUNDING.yml` exists. Users should know where to find free community help vs. paid consulting.

## Changes

- **.github/FUNDING.yml** — configures GitHub Sponsor button with links to:
  - `github` — direct GitHub sponsorship
  - `custom` — [helloam.bot/#support](https://helloam.bot/#support) for all support options
  
- **README.md** — new Support section (before Contributing) with:
  - Free support link (community forums + KB)
  - Paid consulting option (setup, custom plugins, architecture reviews)
  - Bug/feature request guidance (GitHub Issues/Discussions)

## Testing

- Sponsor button will appear on repo page (visible in GitHub's UI)
- Links are correct and accessible
- README renders without markdown errors