### PR TITLE
feat(mc-x): scaffold X/Twitter plugin

### DIFF
--- a/plugins/mc-x/cli/commands.ts
+++ b/plugins/mc-x/cli/commands.ts
@@ -1,0 +1,102 @@
+/**
+ * mc-x — CLI commands (commander integration)
+ *
+ * Registers the "mc-x" command group so the plugin can be used via:
+ *   mc mc-x <subcommand> [options]
+ */
+
+import type { Command } from "commander";
+import { getBearerToken, saveBearerToken } from "../src/vault.js";
+import { XClient } from "../src/client.js";
+
+export interface XCliContext {
+  program: Command;
+  vaultBin: string;
+  logger: { info: (m: string) => void; warn: (m: string) => void; error: (m: string) => void };
+}
+
+export function registerXCommands(ctx: XCliContext): void {
+  const { program, vaultBin, logger } = ctx;
+
+  const cmd = program
+    .command("mc-x")
+    .description("X/Twitter integration — post tweets, read timelines, reply");
+
+  // ── auth ──────────────────────────────────────────────────────────────
+  cmd
+    .command("auth")
+    .description("Store X/Twitter Bearer token in vault")
+    .requiredOption("--token <bearer>", "Bearer token from X developer portal")
+    .action((opts: { token: string }) => {
+      saveBearerToken(opts.token, vaultBin);
+      logger.info("Bearer token saved to vault.");
+    });
+
+  // ── post ──────────────────────────────────────────────────────────────
+  cmd
+    .command("post <text>")
+    .description("Post a new tweet")
+    .action(async (text: string) => {
+      const token = getBearerToken(vaultBin);
+      if (!token) {
+        logger.error("No bearer token found. Run: mc mc-x auth --token <bearer>");
+        return;
+      }
+      const client = new XClient(token);
+      try {
+        const result = await client.postTweet(text);
+        logger.info(`Tweet posted: id=${result.id} text="${result.text}"`);
+      } catch (err: unknown) {
+        logger.error(`Failed to post tweet: ${(err as Error).message}`);
+      }
+    });
+
+  // ── timeline ──────────────────────────────────────────────────────────
+  cmd
+    .command("timeline")
+    .description("Read recent tweets from a user timeline")
+    .option("--user-id <id>", "User ID to fetch timeline for")
+    .option("--count <n>", "Number of tweets to fetch", "10")
+    .action(async (opts: { userId?: string; count: string }) => {
+      const token = getBearerToken(vaultBin);
+      if (!token) {
+        logger.error("No bearer token found. Run: mc mc-x auth --token <bearer>");
+        return;
+      }
+      if (!opts.userId) {
+        logger.error("--user-id is required for timeline.");
+        return;
+      }
+      const client = new XClient(token);
+      try {
+        const result = await client.getTimeline(opts.userId, parseInt(opts.count, 10));
+        for (const tweet of result.tweets) {
+          logger.info(`[${tweet.id}] ${tweet.text}`);
+        }
+        if (result.tweets.length === 0) {
+          logger.info("No tweets found.");
+        }
+      } catch (err: unknown) {
+        logger.error(`Failed to fetch timeline: ${(err as Error).message}`);
+      }
+    });
+
+  // ── reply ─────────────────────────────────────────────────────────────
+  cmd
+    .command("reply <tweetId> <text>")
+    .description("Reply to a tweet")
+    .action(async (tweetId: string, text: string) => {
+      const token = getBearerToken(vaultBin);
+      if (!token) {
+        logger.error("No bearer token found. Run: mc mc-x auth --token <bearer>");
+        return;
+      }
+      const client = new XClient(token);
+      try {
+        const result = await client.replyToTweet(tweetId, text);
+        logger.info(`Reply posted: id=${result.id} text="${result.text}"`);
+      } catch (err: unknown) {
+        logger.error(`Failed to reply: ${(err as Error).message}`);
+      }
+    });
+}

--- a/plugins/mc-x/index.ts
+++ b/plugins/mc-x/index.ts
@@ -1,0 +1,27 @@
+import * as path from "node:path";
+import * as os from "node:os";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { getBearerToken } from "./src/vault.js";
+import { registerXCommands } from "./cli/commands.js";
+import { createXTools } from "./tools/definitions.js";
+
+const STATE_DIR = process.env.OPENCLAW_STATE_DIR ?? path.join(os.homedir(), ".openclaw");
+
+export default function register(api: OpenClawPluginApi): void {
+  const vaultBin = path.join(STATE_DIR, "miniclaw", "SYSTEM", "bin", "mc-vault");
+  const hasToken = !!getBearerToken(vaultBin);
+
+  if (hasToken) {
+    api.logger.info("mc-x loaded — bearer token found in vault");
+  } else {
+    api.logger.warn("mc-x: no bearer token in vault. Run: mc mc-x auth --token '<bearer>'");
+  }
+
+  api.registerCli((ctx) => {
+    registerXCommands({ program: ctx.program, vaultBin, logger: api.logger });
+  });
+
+  for (const tool of createXTools(api.logger)) {
+    api.registerTool(tool);
+  }
+}

--- a/plugins/mc-x/openclaw.plugin.json
+++ b/plugins/mc-x/openclaw.plugin.json
@@ -1,0 +1,10 @@
+{
+  "id": "mc-x",
+  "name": "Miniclaw X/Twitter",
+  "description": "X/Twitter API v2 client — post tweets, read timelines, reply to tweets.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": true,
+    "properties": {}
+  }
+}

--- a/plugins/mc-x/package.json
+++ b/plugins/mc-x/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "mc-x",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "index.ts",
+  "description": "X/Twitter API v2 client — post tweets, read timelines, reply to tweets",
+  "dependencies": {},
+  "devDependencies": {
+    "openclaw": "file:../../../openclaw"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/plugins/mc-x/smoke.test.ts
+++ b/plugins/mc-x/smoke.test.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "vitest";
+import { existsSync } from "node:fs";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+test("index.ts exists", () => {
+  expect(existsSync(__dirname + "/index.ts")).toBe(true);
+});
+
+test("plugin has required structure", () => {
+  expect(existsSync(__dirname + "/openclaw.plugin.json")).toBe(true);
+  expect(existsSync(__dirname + "/package.json")).toBe(true);
+  expect(existsSync(__dirname + "/src/vault.ts")).toBe(true);
+  expect(existsSync(__dirname + "/src/client.ts")).toBe(true);
+  expect(existsSync(__dirname + "/cli/commands.ts")).toBe(true);
+  expect(existsSync(__dirname + "/tools/definitions.ts")).toBe(true);
+});
+
+test("openclaw.plugin.json has correct id", async () => {
+  const config = JSON.parse(
+    (await import("node:fs")).readFileSync(__dirname + "/openclaw.plugin.json", "utf8")
+  );
+  expect(config.id).toBe("mc-x");
+  expect(config.name).toContain("X");
+});
+
+test("package.json has openclaw extension entry", async () => {
+  const pkg = JSON.parse(
+    (await import("node:fs")).readFileSync(__dirname + "/package.json", "utf8")
+  );
+  expect(pkg.openclaw.extensions).toContain("./index.ts");
+  expect(pkg.type).toBe("module");
+});
+
+test("client exports XClient class", async () => {
+  const mod = await import("./src/client.js");
+  expect(mod.XClient).toBeDefined();
+  expect(typeof mod.XClient).toBe("function");
+});
+
+test("vault exports getBearerToken and saveBearerToken", async () => {
+  const mod = await import("./src/vault.js");
+  expect(typeof mod.getBearerToken).toBe("function");
+  expect(typeof mod.saveBearerToken).toBe("function");
+});
+
+test("tools definitions exports createXTools", async () => {
+  const mod = await import("./tools/definitions.js");
+  expect(typeof mod.createXTools).toBe("function");
+
+  const mockLogger = { info: () => {}, warn: () => {}, error: () => {} };
+  const tools = mod.createXTools(mockLogger);
+  expect(Array.isArray(tools)).toBe(true);
+  expect(tools.length).toBe(3);
+
+  const names = tools.map((t: { name: string }) => t.name);
+  expect(names).toContain("x_post");
+  expect(names).toContain("x_timeline");
+  expect(names).toContain("x_reply");
+});
+
+test("CLI commands exports registerXCommands", async () => {
+  const mod = await import("./cli/commands.js");
+  expect(typeof mod.registerXCommands).toBe("function");
+});

--- a/plugins/mc-x/src/client.ts
+++ b/plugins/mc-x/src/client.ts
@@ -1,0 +1,101 @@
+/**
+ * Lightweight X/Twitter API v2 client using native fetch with Bearer token auth.
+ */
+
+const API_BASE = "https://api.twitter.com/2";
+
+export interface Tweet {
+  id: string;
+  text: string;
+  author_id?: string;
+  created_at?: string;
+}
+
+export interface PostTweetResult {
+  id: string;
+  text: string;
+}
+
+export interface TimelineResult {
+  tweets: Tweet[];
+  meta?: Record<string, unknown>;
+}
+
+export class XClient {
+  private bearerToken: string;
+
+  constructor(bearerToken: string) {
+    this.bearerToken = bearerToken;
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.bearerToken}`,
+      "Content-Type": "application/json",
+    };
+  }
+
+  /**
+   * Post a new tweet.
+   */
+  async postTweet(text: string): Promise<PostTweetResult> {
+    const res = await fetch(`${API_BASE}/tweets`, {
+      method: "POST",
+      headers: this.headers(),
+      body: JSON.stringify({ text }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`X API error ${res.status}: ${body}`);
+    }
+
+    const json = (await res.json()) as { data: { id: string; text: string } };
+    return json.data;
+  }
+
+  /**
+   * Read recent tweets from the authenticated user's timeline.
+   * Uses the "reverse chronological" home timeline endpoint.
+   */
+  async getTimeline(userId: string, count = 10): Promise<TimelineResult> {
+    const url = new URL(`${API_BASE}/users/${userId}/tweets`);
+    url.searchParams.set("max_results", String(Math.min(Math.max(count, 5), 100)));
+    url.searchParams.set("tweet.fields", "created_at,author_id");
+
+    const res = await fetch(url.toString(), {
+      method: "GET",
+      headers: this.headers(),
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`X API error ${res.status}: ${body}`);
+    }
+
+    const json = (await res.json()) as { data?: Tweet[]; meta?: Record<string, unknown> };
+    return { tweets: json.data ?? [], meta: json.meta };
+  }
+
+  /**
+   * Reply to an existing tweet.
+   */
+  async replyToTweet(tweetId: string, text: string): Promise<PostTweetResult> {
+    const res = await fetch(`${API_BASE}/tweets`, {
+      method: "POST",
+      headers: this.headers(),
+      body: JSON.stringify({
+        text,
+        reply: { in_reply_to_tweet_id: tweetId },
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`X API error ${res.status}: ${body}`);
+    }
+
+    const json = (await res.json()) as { data: { id: string; text: string } };
+    return json.data;
+  }
+}

--- a/plugins/mc-x/src/vault.ts
+++ b/plugins/mc-x/src/vault.ts
@@ -1,0 +1,37 @@
+import { execSync } from "node:child_process";
+import * as path from "node:path";
+import * as os from "node:os";
+
+const STATE_DIR = process.env.OPENCLAW_STATE_DIR ?? path.join(os.homedir(), ".openclaw");
+const DEFAULT_VAULT_BIN = path.join(STATE_DIR, "miniclaw", "SYSTEM", "bin", "mc-vault");
+
+export function vaultGet(key: string, vaultBin = DEFAULT_VAULT_BIN): string | null {
+  try {
+    const out = execSync(`${vaultBin} get ${key}`, {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    if (out.includes(" = ")) {
+      return out.split(" = ").slice(1).join(" = ").trim() || null;
+    }
+    return out || null;
+  } catch {
+    return null;
+  }
+}
+
+export function vaultSet(key: string, value: string, vaultBin = DEFAULT_VAULT_BIN): void {
+  execSync(`${vaultBin} set ${key} -`, {
+    input: value,
+    encoding: "utf8",
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+}
+
+export function getBearerToken(vaultBin = DEFAULT_VAULT_BIN): string | null {
+  return vaultGet("social-x-bearer-token", vaultBin);
+}
+
+export function saveBearerToken(token: string, vaultBin = DEFAULT_VAULT_BIN): void {
+  vaultSet("social-x-bearer-token", token, vaultBin);
+}

--- a/plugins/mc-x/tools/definitions.ts
+++ b/plugins/mc-x/tools/definitions.ts
@@ -1,0 +1,108 @@
+import type { AnyAgentTool } from "openclaw/plugin-sdk";
+import * as path from "node:path";
+import * as os from "node:os";
+import { getBearerToken } from "../src/vault.js";
+import { XClient } from "../src/client.js";
+
+type Logger = { info(m: string): void; warn(m: string): void; error(m: string): void };
+
+const STATE_DIR = process.env.OPENCLAW_STATE_DIR ?? path.join(os.homedir(), ".openclaw");
+const VAULT_BIN = path.join(STATE_DIR, "miniclaw", "SYSTEM", "bin", "mc-vault");
+
+function ok(text: string) {
+  return { content: [{ type: "text" as const, text: text.trim() }], details: {} };
+}
+
+function getClient(): XClient {
+  const token = getBearerToken(VAULT_BIN);
+  if (!token) {
+    throw new Error("No X bearer token in vault. Run: mc mc-x auth --token <bearer>");
+  }
+  return new XClient(token);
+}
+
+export function createXTools(logger: Logger): AnyAgentTool[] {
+  return [
+    // ── Post a tweet ──────────────────────────────────────────────────────
+    {
+      name: "x_post",
+      label: "x_post",
+      description: "Post a new tweet on X/Twitter.",
+      parameters: {
+        type: "object",
+        required: ["text"],
+        properties: {
+          text: { type: "string", description: "The tweet text (max 280 characters)" },
+        },
+      },
+      async execute(_id: string, params: unknown) {
+        const p = params as { text: string };
+        try {
+          const client = getClient();
+          const result = await client.postTweet(p.text);
+          logger.info(`x_post: tweet ${result.id} posted`);
+          return ok(`Tweet posted successfully.\nID: ${result.id}\nText: ${result.text}`);
+        } catch (err: unknown) {
+          return ok(`Error posting tweet: ${(err as Error).message}`);
+        }
+      },
+    },
+
+    // ── Read timeline ─────────────────────────────────────────────────────
+    {
+      name: "x_timeline",
+      label: "x_timeline",
+      description: "Read recent tweets from a user's X/Twitter timeline.",
+      parameters: {
+        type: "object",
+        required: ["user_id"],
+        properties: {
+          user_id: { type: "string", description: "X/Twitter user ID" },
+          count: { type: "number", description: "Number of tweets to fetch (5-100, default 10)" },
+        },
+      },
+      async execute(_id: string, params: unknown) {
+        const p = params as { user_id: string; count?: number };
+        try {
+          const client = getClient();
+          const result = await client.getTimeline(p.user_id, p.count ?? 10);
+          if (result.tweets.length === 0) {
+            return ok("No tweets found.");
+          }
+          const lines = result.tweets.map(
+            (t) => `[${t.id}] (${t.created_at ?? "unknown"}) ${t.text}`
+          );
+          return ok(lines.join("\n"));
+        } catch (err: unknown) {
+          return ok(`Error reading timeline: ${(err as Error).message}`);
+        }
+      },
+    },
+
+    // ── Reply to a tweet ──────────────────────────────────────────────────
+    {
+      name: "x_reply",
+      label: "x_reply",
+      description: "Reply to a tweet on X/Twitter.",
+      parameters: {
+        type: "object",
+        required: ["tweet_id", "text"],
+        properties: {
+          tweet_id: { type: "string", description: "ID of the tweet to reply to" },
+          text: { type: "string", description: "Reply text (max 280 characters)" },
+        },
+      },
+      async execute(_id: string, params: unknown) {
+        const p = params as { tweet_id: string; text: string };
+        try {
+          const client = getClient();
+          const result = await client.replyToTweet(p.tweet_id, p.text);
+          logger.info(`x_reply: reply ${result.id} posted`);
+          return ok(`Reply posted successfully.\nID: ${result.id}\nText: ${result.text}`);
+        } catch (err: unknown) {
+          return ok(`Error replying to tweet: ${(err as Error).message}`);
+        }
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Adds `mc-x` plugin: X/Twitter API v2 integration with Bearer token auth via mc-vault
- CLI commands: `mc-x auth`, `mc-x post`, `mc-x timeline`, `mc-x reply`
- Agent tools: `x_post`, `x_timeline`, `x_reply`
- Smoke tests: 8/8 passing (structure, exports, tool definitions)

Closes discussion #21.

## Test plan
- [x] `vitest run` — 8/8 smoke tests pass
- [ ] Manual: `mc mc-x auth --token <bearer>` stores token in vault
- [ ] Manual: `mc mc-x post "test"` posts a tweet via X API v2

🤖 Generated with [Claude Code](https://claude.com/claude-code)