### PR TITLE
fix(mc-trust): vault binary path regression

### DIFF
--- a/plugins/mc-trust/index.ts
+++ b/plugins/mc-trust/index.ts
@@ -27,7 +27,7 @@ function resolveConfig(api: OpenClawPluginApi): TrustConfig {
   return {
     agentId:      raw.agentId ?? "am",
     trustDir:     resolvePath(raw.trustDir ?? "~/.openclaw/trust"),
-    vaultBin:     resolvePath(raw.vaultBin ?? "~/.openclaw/miniclaw/SYSTEM/bin/miniclaw-vault"),
+    vaultBin:     resolvePath(raw.vaultBin ?? "~/.openclaw/miniclaw/SYSTEM/bin/mc-vault"),
     sessionTtlMs: raw.sessionTtlMs ?? 3_600_000, // 1 hour default
   };
 }


### PR DESCRIPTION
## Summary
- Default `vaultBin` path in mc-trust referenced `miniclaw-vault` (old name) instead of `mc-vault` (current name)
- This prevented `trust init` from working — ENOENT on the vault binary

## Test plan
- [ ] `openclaw mc-trust init` succeeds
- [ ] `openclaw mc-trust pubkey` prints the public key

Fixes #268