### PR TITLE
feat(mc-research): competitive intelligence plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ MiniClaw OS isn't another wrapper around an LLM. It's the **operating system** f
 
 ## The Plugin Brain
 
-36 plugins. Each one is a cognitive region — modular, composable, replaceable.
+40 plugins + 4 standalone tools. Each one is a cognitive region — modular, composable, replaceable.
 
 ### Core Cognition
 
@@ -113,52 +113,56 @@ MiniClaw OS isn't another wrapper around an LLM. It's the **operating system** f
 |--------|-------------|
 | **[mc-board](./docs/mc-board.md)** | Kanban brain — autonomous task lifecycle, priority queue, WIP limits, pixel office |
 | **[mc-kb](./docs/mc-kb.md)** | Long-term memory — vector + keyword search, facts, lessons, postmortems |
-| **[mc-memory](./docs/mc-memory.md)** | Unified memory gateway — smart routing, recall, memo-to-KB promotion |
+| **[mc-memory](./plugins/mc-memory)** | Unified memory gateway — smart routing, recall, memo-to-KB promotion |
 | **[mc-reflection](./docs/mc-reflection.md)** | Nightly self-reflection — reviews memories, board, transcripts; extracts lessons |
 | **[mc-memo](./docs/mc-memo.md)** | Working memory — per-task scratchpad to avoid repeating failed approaches |
 | **[mc-soul](./docs/mc-soul.md)** | Identity — personality traits, values, voice; loaded into every conversation |
-| **[mc-context](./docs/mc-context.md)** | Context window — sliding window management, automatic pruning |
+| **[mc-context](./docs/mc-context.md)** | Context window — sliding window management, image pruning, QMD injection |
 | **[mc-queue](./docs/mc-queue.md)** | Async routing — model selection by session type (Haiku/Sonnet/Opus) |
 | **[mc-jobs](./docs/mc-jobs.md)** | Role templates — role-specific prompts, procedures, and review gates |
-| **[mc-guardian](./docs/mc-guardian.md)** | Crash guard — absorbs non-fatal exceptions to keep the gateway alive |
+| **[mc-guardian](./plugins/mc-guardian)** | Crash guard — absorbs non-fatal exceptions to keep the gateway alive |
 
 ### Communication & Social
 
 | Plugin | What it does |
 |--------|-------------|
-| **[mc-email](./docs/mc-email.md)** | Email — IMAP polling, auto-classification, signature generation, attachment download |
-| **[mc-rolodex](./docs/mc-rolodex.md)** | Contacts — fuzzy search, update, trust status tracking |
-| **[mc-trust](./docs/mc-trust.md)** | Agent identity — cryptographic verification and signed messages |
+| **[mc-email](./docs/mc-email.md)** | Email — IMAP/SMTP, read, send, reply, triage, attachment download |
+| **[mc-rolodex](./docs/mc-rolodex.md)** | Contacts — fuzzy search, trust status tracking, TUI browser |
+| **[mc-trust](./docs/mc-trust.md)** | Agent identity — Ed25519 keypairs, cryptographic verification, signed messages |
 | **[mc-human](./docs/mc-human.md)** | Human-in-the-loop — noVNC browser handoff for CAPTCHAs and login flows |
+| **[mc-web-chat](./plugins/mc-web-chat)** | Web chat — browser-based chat panel powered by Claude Code |
 | **[mc-reddit](./docs/mc-reddit.md)** | Reddit — posts, comments, voting, subreddit moderation |
-| **[mc-social](./docs/mc-social.md)** | GitHub social — track repos, find contribution opportunities, log engagement |
-| **[mc-fan](./docs/mc-fan.md)** | Fan engagement — follow and engage with people, agents, and projects the agent admires |
+| **[mc-x](./plugins/mc-x)** | X/Twitter — auth, post, timeline, reply |
+| **[mc-moltbook](./plugins/mc-moltbook)** | Moltbook — social network for AI agents (post, reply, vote, follow) |
+| **[mc-social](./plugins/mc-social)** | GitHub social — track repos, find contribution opportunities, log engagement |
+| **[mc-fan](./plugins/mc-fan)** | Fan engagement — follow and engage with people, agents, and projects the agent admires |
 
 ### Content & Publishing
 
 | Plugin | What it does |
 |--------|-------------|
-| **[mc-designer](./docs/mc-designer.md)** | Visual studio — Gemini-backed image generation, compositing, blend modes |
+| **[mc-designer](./docs/mc-designer.md)** | Visual studio — Gemini-backed image generation, layers, compositing, blend modes |
 | **[mc-blog](./docs/mc-blog.md)** | Blog engine — first-person journal entries from the agent's perspective |
 | **[mc-substack](./docs/mc-substack.md)** | Substack — draft, schedule, publish with bilingual support |
-| **[mc-devlog](./docs/mc-devlog.md)** | Daily devlog — aggregates git activity, credits contributors, cross-posts |
+| **[mc-devlog](./plugins/mc-devlog)** | Daily devlog — aggregates git activity, credits contributors, cross-posts |
 | **[mc-youtube](./docs/mc-youtube.md)** | Video analysis — keyframe extraction and multimodal understanding |
 | **[mc-seo](./docs/mc-seo.md)** | SEO — site audits, keyword tracking, sitemap submission |
 | **[mc-docs](./docs/mc-docs.md)** | Document authoring — versioning and linked document management |
-| **[mc-voice](./docs/mc-voice.md)** | Speech-to-text — local transcription via whisper.cpp |
+| **[mc-voice](./plugins/mc-voice)** | Speech-to-text — local transcription via whisper.cpp |
 
 ### Infrastructure & Operations
 
 | Plugin | What it does |
 |--------|-------------|
-| **[mc-github](./docs/mc-github.md)** | GitHub — issues, PRs, reviews, releases, Actions via gh CLI |
-| **[mc-vpn](./docs/mc-vpn.md)** | VPN — Mullvad connection management, country switching, auto-connect |
-| **[mc-tailscale](./docs/mc-tailscale.md)** | Tailscale — diagnostics, status, Serve/Funnel, custom domains |
+| **[mc-github](./plugins/mc-github)** | GitHub — issues, PRs, reviews, releases, Actions via gh CLI |
+| **[mc-vpn](./plugins/mc-vpn)** | VPN — Mullvad connection management, country switching, auto-connect |
+| **[mc-tailscale](./plugins/mc-tailscale)** | Tailscale — diagnostics, status, Serve/Funnel, custom domains |
 | **[mc-authenticator](./docs/mc-authenticator.md)** | 2FA — TOTP codes for autonomous login |
 | **[mc-backup](./docs/mc-backup.md)** | Backups — daily tgz snapshots with tiered retention |
-| **[mc-update](./docs/mc-update.md)** | Self-update — nightly version checks, smoke verification, rollback |
-| **[mc-calendar](./docs/mc-calendar.md)** | Apple Calendar — create, update, delete, search events via EventKit |
+| **[mc-update](./plugins/mc-update)** | Self-update — nightly version checks, smoke verification, rollback |
+| **[mc-calendar](./plugins/mc-calendar)** | Apple Calendar — create, update, delete, search events via EventKit |
 | **[mc-contribute](./docs/mc-contribute.md)** | Self-improvement — scaffold plugins, file bugs, submit PRs |
+| **[mc-oauth-guard](./plugins/mc-oauth-guard)** | OAuth guard — detects refresh failures, exponential backoff, auto-recovery |
 
 ### Commerce
 
@@ -167,6 +171,15 @@ MiniClaw OS isn't another wrapper around an LLM. It's the **operating system** f
 | **[mc-stripe](./docs/mc-stripe.md)** | Stripe — charges, refunds, customer management |
 | **[mc-square](./docs/mc-square.md)** | Square — payments, refunds, payment links |
 | **[mc-booking](./docs/mc-booking.md)** | Scheduling — bookable slots, payment integration |
+
+### Standalone Tools
+
+| Tool | What it does |
+|------|-------------|
+| **[mc-vault](./docs/mc-vault.md)** | Secure secrets — age-encrypted key-value store for API keys and credentials |
+| **mc-doctor** | Full diagnosis — automated health checks and auto-repair |
+| **mc-smoke** | Quick health check — fast pre-flight verification |
+| **mc-chrome** | Browser automation — Chrome control for web interactions |
 
 ---
 

--- a/plugins/mc-research/cli/commands.ts
+++ b/plugins/mc-research/cli/commands.ts
@@ -1,0 +1,267 @@
+/**
+ * mc-research — CLI commands
+ *
+ *   mc mc-research query '<question>'          — deep research via Perplexity
+ *   mc mc-research search '<keyword>'          — web search
+ *   mc mc-research watch add <name> <domain>   — register a competitor
+ *   mc mc-research watch remove <domain>       — remove a competitor
+ *   mc mc-research watch list                  — list tracked competitors
+ *   mc mc-research snapshot <domain>           — scrape competitor pages
+ *   mc mc-research report '<query>'            — full competitive intelligence report
+ *   mc mc-research history                     — list past research
+ */
+
+import type { Command } from "commander";
+import type { ResearchConfig } from "../src/config.js";
+import { ResearchDb } from "../src/db.js";
+import { queryPerplexity } from "../src/perplexity.js";
+import { webSearch, type SearchKeys } from "../src/search.js";
+import { scrapePage, guessPageUrls, diffSnapshots } from "../src/scraper.js";
+import {
+  getPerplexityApiKey,
+  getSerpApiKey,
+  getGoogleSearchApiKey,
+  getGoogleSearchCx,
+  getBingApiKey,
+} from "../src/vault.js";
+import {
+  formatResearchReport,
+  formatSearchResults,
+  formatCompetitorList,
+  formatSnapshot,
+  formatHistory,
+} from "../src/reporter.js";
+import * as path from "node:path";
+
+type Logger = { info(m: string): void; warn(m: string): void; error(m: string): void };
+
+function getDb(cfg: ResearchConfig): ResearchDb {
+  return new ResearchDb(path.join(cfg.stateDir, "research.db"));
+}
+
+function getSearchKeys(): SearchKeys {
+  return {
+    serpApiKey: getSerpApiKey(),
+    googleApiKey: getGoogleSearchApiKey(),
+    googleCx: getGoogleSearchCx(),
+    bingApiKey: getBingApiKey(),
+  };
+}
+
+export function registerResearchCommands(
+  ctx: { program: Command; logger: Logger },
+  cfg: ResearchConfig,
+): void {
+  const cmd = ctx.program
+    .command("mc-research")
+    .description("Competitive intelligence and deep research");
+
+  // ── query ──────────────────────────────────────────────────────────
+  cmd
+    .command("query <question>")
+    .description("Deep research via Perplexity sonar API")
+    .option("-f, --focus <focus>", "Focus area: web, news, academic", "web")
+    .action(async (question: string, opts: { focus: string }) => {
+      const apiKey = getPerplexityApiKey();
+      if (!apiKey) {
+        console.error("ERROR: Perplexity API key not found. Set it with: openclaw mc-vault set research-perplexity-api-key <key>");
+        process.exitCode = 1;
+        return;
+      }
+
+      ctx.logger.info(`mc-research: query "${question}" (focus=${opts.focus})`);
+      try {
+        const result = await queryPerplexity(apiKey, question, opts.focus, cfg.perplexityModel);
+        const db = getDb(cfg);
+        const id = db.saveReport(question, opts.focus, "perplexity", result.answer, result.citations);
+        const report = db.getReportById(id)!;
+        db.close();
+        console.log(formatResearchReport(report));
+      } catch (e) {
+        console.error(`ERROR: ${(e as Error).message}`);
+        process.exitCode = 1;
+      }
+    });
+
+  // ── search ─────────────────────────────────────────────────────────
+  cmd
+    .command("search <query>")
+    .description("Web search via Google/SerpAPI/Bing")
+    .option("-n, --num <number>", "Number of results", "5")
+    .action(async (query: string, opts: { num: string }) => {
+      ctx.logger.info(`mc-research: search "${query}"`);
+      try {
+        const keys = getSearchKeys();
+        const result = await webSearch(query, keys, cfg.searchProvider, parseInt(opts.num, 10));
+        const db = getDb(cfg);
+        db.saveSearch(query, result.provider, result.results);
+        db.close();
+        console.log(formatSearchResults(result.results, query, result.provider));
+      } catch (e) {
+        console.error(`ERROR: ${(e as Error).message}`);
+        process.exitCode = 1;
+      }
+    });
+
+  // ── watch ──────────────────────────────────────────────────────────
+  const watchCmd = cmd.command("watch").description("Manage competitor tracking");
+
+  watchCmd
+    .command("add <name> <domain>")
+    .description("Register a competitor to track")
+    .option("--notes <notes>", "Notes about this competitor", "")
+    .action((name: string, domain: string, opts: { notes: string }) => {
+      ctx.logger.info(`mc-research: watch add ${name} (${domain})`);
+      const db = getDb(cfg);
+      db.addCompetitor(name, domain, opts.notes);
+      const competitors = db.getCompetitors();
+      db.close();
+      console.log(`Added competitor: ${name} (${domain})`);
+      console.log(formatCompetitorList(competitors));
+    });
+
+  watchCmd
+    .command("remove <domain>")
+    .description("Remove a tracked competitor")
+    .action((domain: string) => {
+      const db = getDb(cfg);
+      const removed = db.removeCompetitor(domain);
+      db.close();
+      console.log(removed ? `Removed: ${domain}` : `Not found: ${domain}`);
+    });
+
+  watchCmd
+    .command("list")
+    .description("List all tracked competitors")
+    .action(() => {
+      const db = getDb(cfg);
+      const competitors = db.getCompetitors();
+      db.close();
+      console.log(formatCompetitorList(competitors));
+    });
+
+  // ── snapshot ───────────────────────────────────────────────────────
+  cmd
+    .command("snapshot <domain>")
+    .description("Scrape competitor pages and detect changes")
+    .option("-p, --pages <pages>", "Comma-separated page types (default: all)")
+    .action(async (domain: string, opts: { pages?: string }) => {
+      const db = getDb(cfg);
+      const competitor = db.getCompetitorByDomain(domain);
+      if (!competitor) {
+        console.error(`ERROR: Competitor not found: ${domain}. Add it first with: mc mc-research watch add <name> ${domain}`);
+        db.close();
+        process.exitCode = 1;
+        return;
+      }
+
+      ctx.logger.info(`mc-research: snapshot ${domain}`);
+      const pageTypes = opts.pages ? opts.pages.split(",").map((s) => s.trim()) : undefined;
+      const urls = guessPageUrls(domain, cfg.maxSnapshotPages);
+      const filtered = pageTypes ? urls.filter((u) => pageTypes.includes(u.type)) : urls;
+
+      for (const page of filtered) {
+        try {
+          const data = await scrapePage(page.url);
+          const prevSnapshot = db.getLatestSnapshot(competitor.id, page.type);
+          const prevData = prevSnapshot ? (JSON.parse(prevSnapshot.data) as Record<string, unknown>) : null;
+          const diff = diffSnapshots(prevData as any, data);
+
+          db.saveSnapshot(
+            competitor.id,
+            page.type,
+            page.url,
+            data,
+            diff.hasChanges ? diff.details.join("\n") : "",
+          );
+
+          console.log(`✅ ${page.type} (${page.url}): ${diff.summary}`);
+          if (diff.hasChanges) {
+            diff.details.forEach((d) => console.log(`   - ${d}`));
+          }
+        } catch (e) {
+          console.log(`⚠️  ${page.type} (${page.url}): ${(e as Error).message}`);
+        }
+      }
+
+      db.close();
+    });
+
+  // ── report ─────────────────────────────────────────────────────────
+  cmd
+    .command("report <query>")
+    .description("Generate a full competitive intelligence report")
+    .option("-c, --competitor <domain>", "Include competitor snapshots")
+    .action(async (query: string, opts: { competitor?: string }) => {
+      ctx.logger.info(`mc-research: report "${query}"`);
+
+      const sections: string[] = [];
+      sections.push(`# Competitive Intelligence Report\n**Topic:** ${query}\n**Date:** ${new Date().toISOString().split("T")[0]}\n`);
+
+      // Deep research
+      const apiKey = getPerplexityApiKey();
+      if (apiKey) {
+        try {
+          const result = await queryPerplexity(apiKey, query, "web", cfg.perplexityModel);
+          const db = getDb(cfg);
+          db.saveReport(query, "web", "perplexity", result.answer, result.citations);
+          db.close();
+          sections.push(`## Deep Research\n\n${result.answer}\n`);
+          if (result.citations.length > 0) {
+            sections.push(`### Sources\n${result.citations.map((c, i) => `${i + 1}. ${c}`).join("\n")}\n`);
+          }
+        } catch (e) {
+          sections.push(`## Deep Research\n\n⚠️ ${(e as Error).message}\n`);
+        }
+      }
+
+      // Web search
+      try {
+        const keys = getSearchKeys();
+        const result = await webSearch(query, keys, cfg.searchProvider, 5);
+        const db = getDb(cfg);
+        db.saveSearch(query, result.provider, result.results);
+        db.close();
+        sections.push(formatSearchResults(result.results, query, result.provider));
+      } catch { /* no search providers */ }
+
+      // Competitor snapshots
+      if (opts.competitor) {
+        const db = getDb(cfg);
+        const comp = db.getCompetitorByDomain(opts.competitor);
+        if (comp) {
+          const snapshots = db.getSnapshots(comp.id);
+          if (snapshots.length > 0) {
+            sections.push(`## Competitor Snapshots: ${comp.name}\n`);
+            const seen = new Set<string>();
+            for (const snap of snapshots) {
+              if (!seen.has(snap.page_type)) {
+                seen.add(snap.page_type);
+                sections.push(formatSnapshot(snap, comp.name));
+              }
+            }
+          }
+        }
+        db.close();
+      }
+
+      const fullReport = sections.join("\n---\n\n");
+      const db = getDb(cfg);
+      db.saveReport(query, "report", "combined", fullReport, []);
+      db.close();
+
+      console.log(fullReport);
+    });
+
+  // ── history ────────────────────────────────────────────────────────
+  cmd
+    .command("history")
+    .description("List past research queries and reports")
+    .option("-n, --num <number>", "Number of recent items", "20")
+    .action((opts: { num: string }) => {
+      const db = getDb(cfg);
+      const reports = db.getReports(parseInt(opts.num, 10));
+      db.close();
+      console.log(formatHistory(reports));
+    });
+}

--- a/plugins/mc-research/index.ts
+++ b/plugins/mc-research/index.ts
@@ -1,0 +1,37 @@
+/**
+ * mc-research — OpenClaw plugin
+ *
+ * Competitive intelligence and deep research: Perplexity queries,
+ * web search, competitor tracking, change detection, and reports.
+ *
+ * Usage:
+ *   mc mc-research query 'How does Cursor compare to Windsurf?'
+ *   mc mc-research search 'AI code editor market share 2026'
+ *   mc mc-research watch add Cursor cursor.com
+ *   mc mc-research watch list
+ *   mc mc-research snapshot cursor.com
+ *   mc mc-research report 'AI code editor competitive landscape'
+ *   mc mc-research history
+ */
+
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+
+import { resolveConfig } from "./src/config.js";
+import { registerResearchCommands } from "./cli/commands.js";
+import { createResearchTools } from "./tools/definitions.js";
+
+export default function register(api: OpenClawPluginApi): void {
+  const cfg = resolveConfig((api.pluginConfig ?? {}) as Record<string, unknown>);
+
+  api.logger.info(
+    `mc-research loaded (model=${cfg.perplexityModel} provider=${cfg.searchProvider} stateDir=${cfg.stateDir})`
+  );
+
+  api.registerCli((ctx) => {
+    registerResearchCommands({ program: ctx.program, logger: api.logger }, cfg);
+  });
+
+  for (const tool of createResearchTools(cfg, api.logger)) {
+    api.registerTool(tool);
+  }
+}

--- a/plugins/mc-research/openclaw.plugin.json
+++ b/plugins/mc-research/openclaw.plugin.json
@@ -1,0 +1,16 @@
+{
+  "id": "mc-research",
+  "name": "Miniclaw Research",
+  "description": "Competitive intelligence and deep research — query Perplexity, search the web, track competitors, detect changes, generate reports.",
+  "version": "0.1.0",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "stateDir": { "type": "string", "description": "Directory for research.db (default: ~/.openclaw/USER/research)" },
+      "perplexityModel": { "type": "string", "description": "Perplexity model to use (default: sonar)" },
+      "searchProvider": { "type": "string", "description": "Preferred search provider: serp | google | bing (default: google)" },
+      "maxSnapshotPages": { "type": "number", "description": "Max pages to scrape per competitor snapshot (default: 5)" }
+    }
+  }
+}

--- a/plugins/mc-research/package-lock.json
+++ b/plugins/mc-research/package-lock.json
@@ -1,0 +1,800 @@
+{
+  "name": "mc-research",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mc-research",
+      "version": "0.1.0",
+      "dependencies": {
+        "better-sqlite3": "^11.9.0",
+        "cheerio": "^1.0.0"
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
+        "openclaw": "file:../../../openclaw"
+      }
+    },
+    "../../../openclaw": {
+      "dev": true
+    },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/openclaw": {
+      "resolved": "../../../openclaw",
+      "link": true
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/plugins/mc-research/package.json
+++ b/plugins/mc-research/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "mc-research",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "index.ts",
+  "description": "Competitive intelligence and deep research — Perplexity queries, web search, competitor tracking, change detection, reports",
+  "dependencies": {
+    "better-sqlite3": "^11.9.0",
+    "cheerio": "^1.0.0"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
+    "openclaw": "file:../../../openclaw"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/plugins/mc-research/smoke.test.ts
+++ b/plugins/mc-research/smoke.test.ts
@@ -1,0 +1,119 @@
+import { test, expect } from "vitest";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveConfig } from "./src/config.ts";
+import { ResearchDb } from "./src/db.ts";
+import { diffSnapshots } from "./src/scraper.ts";
+import { formatHistory, formatCompetitorList, formatSearchResults } from "./src/reporter.ts";
+import * as os from "node:os";
+import * as fs from "node:fs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+test("index.ts exists", () => {
+  expect(existsSync(__dirname + "/index.ts")).toBe(true);
+});
+
+test("resolveConfig returns defaults", () => {
+  const cfg = resolveConfig({});
+  expect(cfg).toBeDefined();
+  expect(cfg.perplexityModel).toBe("sonar");
+  expect(cfg.searchProvider).toBe("google");
+  expect(cfg.maxSnapshotPages).toBe(5);
+  expect(typeof cfg.stateDir).toBe("string");
+});
+
+test("resolveConfig accepts overrides", () => {
+  const cfg = resolveConfig({
+    perplexityModel: "sonar-pro",
+    searchProvider: "serp",
+    maxSnapshotPages: 3,
+  });
+  expect(cfg.perplexityModel).toBe("sonar-pro");
+  expect(cfg.searchProvider).toBe("serp");
+  expect(cfg.maxSnapshotPages).toBe(3);
+});
+
+test("ResearchDb creates tables and does CRUD", () => {
+  const tmpDir = fs.mkdtempSync(join(os.tmpdir(), "mc-research-test-"));
+  const dbPath = join(tmpDir, "test.db");
+  const db = new ResearchDb(dbPath);
+
+  // Reports
+  const reportId = db.saveReport("test query", "web", "perplexity", "test answer", ["https://example.com"]);
+  expect(reportId).toBeGreaterThan(0);
+  const reports = db.getReports();
+  expect(reports.length).toBe(1);
+  expect(reports[0].query).toBe("test query");
+
+  const found = db.searchReports("test");
+  expect(found.length).toBe(1);
+
+  // Competitors
+  const compId = db.addCompetitor("TestCo", "testco.com", "A test competitor");
+  expect(compId).toBeGreaterThan(0);
+  const competitors = db.getCompetitors();
+  expect(competitors.length).toBe(1);
+  expect(competitors[0].name).toBe("TestCo");
+
+  const comp = db.getCompetitorByDomain("testco.com");
+  expect(comp).toBeDefined();
+  expect(comp!.domain).toBe("testco.com");
+
+  // Snapshots
+  const snapId = db.saveSnapshot(comp!.id, "pricing", "https://testco.com/pricing", { title: "Pricing" }, "Initial snapshot");
+  expect(snapId).toBeGreaterThan(0);
+  const latest = db.getLatestSnapshot(comp!.id, "pricing");
+  expect(latest).toBeDefined();
+  expect(latest!.page_type).toBe("pricing");
+
+  // Web searches
+  const searchId = db.saveSearch("test search", "google", [{ title: "Result", url: "https://example.com", snippet: "..." }]);
+  expect(searchId).toBeGreaterThan(0);
+  const searches = db.getSearches();
+  expect(searches.length).toBe(1);
+
+  // Remove competitor
+  const removed = db.removeCompetitor("testco.com");
+  expect(removed).toBe(true);
+  expect(db.getCompetitors().length).toBe(0);
+
+  db.close();
+  fs.rmSync(tmpDir, { recursive: true });
+});
+
+test("diffSnapshots detects changes", () => {
+  const prev = { url: "https://test.com", title: "Old Title", headings: ["H1"], textContent: "hello world", links: ["https://a.com"], meta: {}, fetchedAt: 1000 };
+  const curr = { url: "https://test.com", title: "New Title", headings: ["H1", "H2"], textContent: "hello world updated", links: ["https://a.com", "https://b.com"], meta: {}, fetchedAt: 2000 };
+
+  const diff = diffSnapshots(prev, curr);
+  expect(diff.hasChanges).toBe(true);
+  expect(diff.details.length).toBeGreaterThan(0);
+  expect(diff.details.some((d) => d.includes("Title changed"))).toBe(true);
+});
+
+test("diffSnapshots handles initial snapshot", () => {
+  const curr = { url: "https://test.com", title: "Title", headings: [], textContent: "", links: [], meta: {}, fetchedAt: 1000 };
+  const diff = diffSnapshots(null, curr);
+  expect(diff.hasChanges).toBe(true);
+  expect(diff.summary).toBe("Initial snapshot captured");
+});
+
+test("formatHistory handles empty list", () => {
+  const result = formatHistory([]);
+  expect(result).toContain("No research history");
+});
+
+test("formatCompetitorList handles empty list", () => {
+  const result = formatCompetitorList([]);
+  expect(result).toContain("No competitors tracked");
+});
+
+test("formatSearchResults formats results", () => {
+  const results = [{ title: "Test", url: "https://test.com", snippet: "A test result" }];
+  const formatted = formatSearchResults(results, "test query", "google");
+  expect(formatted).toContain("test query");
+  expect(formatted).toContain("google");
+  expect(formatted).toContain("Test");
+});

--- a/plugins/mc-research/src/config.ts
+++ b/plugins/mc-research/src/config.ts
@@ -1,0 +1,20 @@
+import * as path from "node:path";
+import * as os from "node:os";
+
+export type ResearchConfig = {
+  stateDir: string;
+  perplexityModel: string;
+  searchProvider: "serp" | "google" | "bing";
+  maxSnapshotPages: number;
+};
+
+export function resolveConfig(raw: Record<string, unknown>): ResearchConfig {
+  const defaultStateDir = path.join(os.homedir(), ".openclaw", "USER", "research");
+
+  return {
+    stateDir: (raw["stateDir"] as string | undefined) ?? defaultStateDir,
+    perplexityModel: (raw["perplexityModel"] as string | undefined) ?? "sonar",
+    searchProvider: (raw["searchProvider"] as "serp" | "google" | "bing" | undefined) ?? "google",
+    maxSnapshotPages: (raw["maxSnapshotPages"] as number | undefined) ?? 5,
+  };
+}

--- a/plugins/mc-research/src/db.ts
+++ b/plugins/mc-research/src/db.ts
@@ -1,0 +1,195 @@
+/**
+ * db.ts — SQLite state for mc-research
+ *
+ * Tables:
+ *   research_reports      — deep research query results
+ *   competitors           — tracked competitors
+ *   competitor_snapshots  — periodic competitor page snapshots
+ *   web_searches          — cached web search results
+ */
+
+import Database from "better-sqlite3";
+import * as path from "node:path";
+import * as fs from "node:fs";
+
+export type ReportRow = {
+  id: number;
+  query: string;
+  focus: string;
+  source: string;
+  result: string;
+  citations: string; // JSON array
+  created_at: number;
+};
+
+export type CompetitorRow = {
+  id: number;
+  name: string;
+  domain: string;
+  notes: string;
+  created_at: number;
+};
+
+export type SnapshotRow = {
+  id: number;
+  competitor_id: number;
+  page_type: string;
+  url: string;
+  data: string; // JSON
+  diff_summary: string;
+  fetched_at: number;
+};
+
+export type SearchRow = {
+  id: number;
+  query: string;
+  provider: string;
+  results: string; // JSON
+  created_at: number;
+};
+
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS research_reports (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  query       TEXT NOT NULL,
+  focus       TEXT NOT NULL DEFAULT 'web',
+  source      TEXT NOT NULL DEFAULT 'perplexity',
+  result      TEXT NOT NULL,
+  citations   TEXT NOT NULL DEFAULT '[]',
+  created_at  INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS reports_query ON research_reports(query);
+CREATE INDEX IF NOT EXISTS reports_created ON research_reports(created_at);
+
+CREATE TABLE IF NOT EXISTS competitors (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  name        TEXT NOT NULL,
+  domain      TEXT NOT NULL UNIQUE,
+  notes       TEXT NOT NULL DEFAULT '',
+  created_at  INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS competitors_domain ON competitors(domain);
+
+CREATE TABLE IF NOT EXISTS competitor_snapshots (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  competitor_id INTEGER NOT NULL REFERENCES competitors(id),
+  page_type     TEXT NOT NULL,
+  url           TEXT NOT NULL,
+  data          TEXT NOT NULL DEFAULT '{}',
+  diff_summary  TEXT NOT NULL DEFAULT '',
+  fetched_at    INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS snapshots_competitor ON competitor_snapshots(competitor_id, page_type);
+
+CREATE TABLE IF NOT EXISTS web_searches (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  query       TEXT NOT NULL,
+  provider    TEXT NOT NULL,
+  results     TEXT NOT NULL DEFAULT '[]',
+  created_at  INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS searches_query ON web_searches(query);
+`;
+
+export class ResearchDb {
+  private db: Database.Database;
+
+  constructor(dbPath: string) {
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+    this.db = new Database(dbPath);
+    this.db.exec(SCHEMA);
+  }
+
+  // ── Reports ──────────────────────────────────────────────────────
+
+  saveReport(query: string, focus: string, source: string, result: string, citations: string[]): number {
+    const info = this.db.prepare(`
+      INSERT INTO research_reports (query, focus, source, result, citations, created_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(query, focus, source, result, JSON.stringify(citations), Date.now());
+    return Number(info.lastInsertRowid);
+  }
+
+  getReports(limit = 20): ReportRow[] {
+    return this.db.prepare(`SELECT * FROM research_reports ORDER BY created_at DESC LIMIT ?`).all(limit) as ReportRow[];
+  }
+
+  getReportById(id: number): ReportRow | undefined {
+    return this.db.prepare(`SELECT * FROM research_reports WHERE id = ?`).get(id) as ReportRow | undefined;
+  }
+
+  searchReports(query: string): ReportRow[] {
+    return this.db.prepare(`SELECT * FROM research_reports WHERE query LIKE ? ORDER BY created_at DESC LIMIT 20`)
+      .all(`%${query}%`) as ReportRow[];
+  }
+
+  // ── Competitors ──────────────────────────────────────────────────
+
+  addCompetitor(name: string, domain: string, notes: string): number {
+    const info = this.db.prepare(`
+      INSERT INTO competitors (name, domain, notes, created_at)
+      VALUES (?, ?, ?, ?)
+      ON CONFLICT(domain) DO UPDATE SET name = excluded.name, notes = excluded.notes
+    `).run(name, domain, notes, Date.now());
+    return Number(info.lastInsertRowid);
+  }
+
+  getCompetitors(): CompetitorRow[] {
+    return this.db.prepare(`SELECT * FROM competitors ORDER BY name`).all() as CompetitorRow[];
+  }
+
+  getCompetitorByDomain(domain: string): CompetitorRow | undefined {
+    return this.db.prepare(`SELECT * FROM competitors WHERE domain = ?`).get(domain) as CompetitorRow | undefined;
+  }
+
+  removeCompetitor(domain: string): boolean {
+    const competitor = this.getCompetitorByDomain(domain);
+    if (competitor) {
+      this.db.prepare(`DELETE FROM competitor_snapshots WHERE competitor_id = ?`).run(competitor.id);
+    }
+    const info = this.db.prepare(`DELETE FROM competitors WHERE domain = ?`).run(domain);
+    return info.changes > 0;
+  }
+
+  // ── Snapshots ────────────────────────────────────────────────────
+
+  saveSnapshot(competitorId: number, pageType: string, url: string, data: object, diffSummary: string): number {
+    const info = this.db.prepare(`
+      INSERT INTO competitor_snapshots (competitor_id, page_type, url, data, diff_summary, fetched_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(competitorId, pageType, url, JSON.stringify(data), diffSummary, Date.now());
+    return Number(info.lastInsertRowid);
+  }
+
+  getLatestSnapshot(competitorId: number, pageType: string): SnapshotRow | undefined {
+    return this.db.prepare(`
+      SELECT * FROM competitor_snapshots
+      WHERE competitor_id = ? AND page_type = ?
+      ORDER BY fetched_at DESC LIMIT 1
+    `).get(competitorId, pageType) as SnapshotRow | undefined;
+  }
+
+  getSnapshots(competitorId: number): SnapshotRow[] {
+    return this.db.prepare(`
+      SELECT * FROM competitor_snapshots WHERE competitor_id = ? ORDER BY fetched_at DESC
+    `).all(competitorId) as SnapshotRow[];
+  }
+
+  // ── Web searches ─────────────────────────────────────────────────
+
+  saveSearch(query: string, provider: string, results: object[]): number {
+    const info = this.db.prepare(`
+      INSERT INTO web_searches (query, provider, results, created_at)
+      VALUES (?, ?, ?, ?)
+    `).run(query, provider, JSON.stringify(results), Date.now());
+    return Number(info.lastInsertRowid);
+  }
+
+  getSearches(limit = 20): SearchRow[] {
+    return this.db.prepare(`SELECT * FROM web_searches ORDER BY created_at DESC LIMIT ?`).all(limit) as SearchRow[];
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}

--- a/plugins/mc-research/src/perplexity.ts
+++ b/plugins/mc-research/src/perplexity.ts
@@ -1,0 +1,56 @@
+/**
+ * perplexity.ts — Deep research via Perplexity sonar API
+ */
+
+export type PerplexityResult = {
+  answer: string;
+  citations: string[];
+  model: string;
+};
+
+export async function queryPerplexity(
+  apiKey: string,
+  query: string,
+  focus: string = "web",
+  model: string = "sonar",
+): Promise<PerplexityResult> {
+  const systemPrompt =
+    focus === "academic"
+      ? "You are a thorough academic researcher. Provide detailed, well-cited analysis."
+      : focus === "news"
+        ? "You are a news analyst. Focus on recent events, announcements, and developments."
+        : "You are a competitive intelligence analyst. Provide detailed, actionable research with specific data points, comparisons, and strategic insights.";
+
+  const response = await fetch("https://api.perplexity.ai/chat/completions", {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: query },
+      ],
+      max_tokens: 4096,
+    }),
+  });
+
+  if (!response.ok) {
+    const errBody = await response.text();
+    throw new Error(`Perplexity API error ${response.status}: ${errBody}`);
+  }
+
+  const data = (await response.json()) as {
+    choices: Array<{ message: { content: string } }>;
+    citations?: string[];
+    model: string;
+  };
+
+  return {
+    answer: data.choices?.[0]?.message?.content ?? "(no answer)",
+    citations: data.citations ?? [],
+    model: data.model ?? model,
+  };
+}

--- a/plugins/mc-research/src/reporter.ts
+++ b/plugins/mc-research/src/reporter.ts
@@ -1,0 +1,84 @@
+/**
+ * reporter.ts — Format competitive intelligence reports
+ */
+
+import type { ReportRow, CompetitorRow, SnapshotRow } from "./db.js";
+
+export function formatResearchReport(report: ReportRow): string {
+  const citations = JSON.parse(report.citations) as string[];
+  const date = new Date(report.created_at).toISOString().split("T")[0];
+
+  let out = `## Research Report #${report.id}\n`;
+  out += `**Query:** ${report.query}\n`;
+  out += `**Focus:** ${report.focus} | **Source:** ${report.source} | **Date:** ${date}\n\n`;
+  out += report.result + "\n";
+
+  if (citations.length > 0) {
+    out += "\n### Sources\n";
+    citations.forEach((c, i) => {
+      out += `${i + 1}. ${c}\n`;
+    });
+  }
+
+  return out;
+}
+
+export function formatCompetitorList(competitors: CompetitorRow[]): string {
+  if (competitors.length === 0) return "No competitors tracked yet. Use `research_competitor_watch` to add one.";
+
+  let out = "## Tracked Competitors\n\n";
+  out += "| # | Name | Domain | Notes | Added |\n";
+  out += "|---|------|--------|-------|-------|\n";
+  competitors.forEach((c, i) => {
+    const date = new Date(c.created_at).toISOString().split("T")[0];
+    out += `| ${i + 1} | ${c.name} | ${c.domain} | ${c.notes || "—"} | ${date} |\n`;
+  });
+  return out;
+}
+
+export function formatSnapshot(snapshot: SnapshotRow, competitorName: string): string {
+  const data = JSON.parse(snapshot.data) as Record<string, unknown>;
+  const date = new Date(snapshot.fetched_at).toISOString().split("T")[0];
+
+  let out = `## Snapshot: ${competitorName} — ${snapshot.page_type}\n`;
+  out += `**URL:** ${snapshot.url} | **Date:** ${date}\n\n`;
+
+  if (snapshot.diff_summary) {
+    out += `### Changes\n${snapshot.diff_summary}\n\n`;
+  }
+
+  if (data["title"]) out += `**Title:** ${data["title"]}\n`;
+  if (Array.isArray(data["headings"]) && (data["headings"] as string[]).length > 0) {
+    out += `**Headings:** ${(data["headings"] as string[]).join(" | ")}\n`;
+  }
+
+  return out;
+}
+
+export function formatSearchResults(results: Array<{ title: string; url: string; snippet: string }>, query: string, provider: string): string {
+  if (results.length === 0) return `No results found for "${query}" via ${provider}.`;
+
+  let out = `## Web Search: "${query}"\n`;
+  out += `**Provider:** ${provider} | **Results:** ${results.length}\n\n`;
+
+  results.forEach((r, i) => {
+    out += `${i + 1}. **${r.title}**\n`;
+    out += `   ${r.url}\n`;
+    out += `   ${r.snippet}\n\n`;
+  });
+
+  return out;
+}
+
+export function formatHistory(reports: ReportRow[]): string {
+  if (reports.length === 0) return "No research history yet.";
+
+  let out = "## Research History\n\n";
+  out += "| # | Date | Type | Query |\n";
+  out += "|---|------|------|-------|\n";
+  reports.forEach((r) => {
+    const date = new Date(r.created_at).toISOString().split("T")[0];
+    out += `| ${r.id} | ${date} | ${r.source}/${r.focus} | ${r.query.slice(0, 60)}${r.query.length > 60 ? "…" : ""} |\n`;
+  });
+  return out;
+}

--- a/plugins/mc-research/src/scraper.ts
+++ b/plugins/mc-research/src/scraper.ts
@@ -1,0 +1,138 @@
+/**
+ * scraper.ts — Competitor page scraper with change detection
+ */
+
+import * as cheerio from "cheerio";
+
+export type PageData = {
+  url: string;
+  title: string;
+  headings: string[];
+  textContent: string;
+  links: string[];
+  meta: Record<string, string>;
+  fetchedAt: number;
+};
+
+export type SnapshotDiff = {
+  hasChanges: boolean;
+  summary: string;
+  details: string[];
+};
+
+const USER_AGENT = "Mozilla/5.0 (compatible; mc-research/0.1; +https://miniclaw.bot)";
+
+/**
+ * Fetch and parse a page into structured data
+ */
+export async function scrapePage(url: string): Promise<PageData> {
+  const resp = await fetch(url, {
+    headers: { "User-Agent": USER_AGENT },
+    redirect: "follow",
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (!resp.ok) {
+    throw new Error(`Failed to fetch ${url}: ${resp.status} ${resp.statusText}`);
+  }
+
+  const html = await resp.text();
+  const $ = cheerio.load(html);
+
+  // Remove scripts and styles
+  $("script, style, noscript").remove();
+
+  const title = $("title").text().trim();
+  const headings: string[] = [];
+  $("h1, h2, h3").each((_, el) => {
+    const text = $(el).text().trim();
+    if (text) headings.push(text);
+  });
+
+  const textContent = $("body").text().replace(/\s+/g, " ").trim().slice(0, 10_000);
+
+  const links: string[] = [];
+  $("a[href]").each((_, el) => {
+    const href = $(el).attr("href");
+    if (href && href.startsWith("http")) links.push(href);
+  });
+
+  const meta: Record<string, string> = {};
+  $("meta[name], meta[property]").each((_, el) => {
+    const name = $(el).attr("name") ?? $(el).attr("property") ?? "";
+    const content = $(el).attr("content") ?? "";
+    if (name && content) meta[name] = content;
+  });
+
+  return {
+    url,
+    title,
+    headings,
+    textContent,
+    links: [...new Set(links)].slice(0, 50),
+    meta,
+    fetchedAt: Date.now(),
+  };
+}
+
+/**
+ * Guess common page URLs for a competitor domain
+ */
+export function guessPageUrls(domain: string, maxPages: number = 5): Array<{ url: string; type: string }> {
+  const base = domain.startsWith("http") ? domain : `https://${domain}`;
+  const candidates = [
+    { url: base, type: "homepage" },
+    { url: `${base}/pricing`, type: "pricing" },
+    { url: `${base}/features`, type: "features" },
+    { url: `${base}/about`, type: "about" },
+    { url: `${base}/changelog`, type: "changelog" },
+    { url: `${base}/blog`, type: "blog" },
+    { url: `${base}/docs`, type: "docs" },
+    { url: `${base}/product`, type: "product" },
+  ];
+  return candidates.slice(0, maxPages);
+}
+
+/**
+ * Compare two snapshots and produce a diff summary
+ */
+export function diffSnapshots(prev: PageData | null, curr: PageData): SnapshotDiff {
+  if (!prev) {
+    return {
+      hasChanges: true,
+      summary: "Initial snapshot captured",
+      details: [`Title: ${curr.title}`, `Headings: ${curr.headings.length}`, `Links: ${curr.links.length}`],
+    };
+  }
+
+  const details: string[] = [];
+
+  if (prev.title !== curr.title) {
+    details.push(`Title changed: "${prev.title}" → "${curr.title}"`);
+  }
+
+  const newHeadings = curr.headings.filter((h) => !prev.headings.includes(h));
+  const removedHeadings = prev.headings.filter((h) => !curr.headings.includes(h));
+  if (newHeadings.length > 0) details.push(`New headings: ${newHeadings.join(", ")}`);
+  if (removedHeadings.length > 0) details.push(`Removed headings: ${removedHeadings.join(", ")}`);
+
+  const newLinks = curr.links.filter((l) => !prev.links.includes(l));
+  const removedLinks = prev.links.filter((l) => !curr.links.includes(l));
+  if (newLinks.length > 0) details.push(`New links: +${newLinks.length}`);
+  if (removedLinks.length > 0) details.push(`Removed links: -${removedLinks.length}`);
+
+  // Simple text similarity check
+  const prevWords = new Set(prev.textContent.split(/\s+/).slice(0, 500));
+  const currWords = new Set(curr.textContent.split(/\s+/).slice(0, 500));
+  const overlap = [...prevWords].filter((w) => currWords.has(w)).length;
+  const similarity = prevWords.size > 0 ? overlap / prevWords.size : 1;
+  if (similarity < 0.8) {
+    details.push(`Significant content change detected (${Math.round(similarity * 100)}% overlap)`);
+  }
+
+  return {
+    hasChanges: details.length > 0,
+    summary: details.length > 0 ? `${details.length} change(s) detected` : "No changes detected",
+    details,
+  };
+}

--- a/plugins/mc-research/src/search.ts
+++ b/plugins/mc-research/src/search.ts
@@ -1,0 +1,162 @@
+/**
+ * search.ts — Web search via multiple providers (Google Custom Search, SerpAPI, Bing)
+ */
+
+export type SearchResult = {
+  title: string;
+  url: string;
+  snippet: string;
+};
+
+export type SearchResponse = {
+  provider: string;
+  results: SearchResult[];
+};
+
+// ── Google Custom Search ────────────────────────────────────────────
+
+async function searchGoogle(
+  query: string,
+  apiKey: string,
+  cx: string,
+  numResults: number,
+): Promise<SearchResponse> {
+  const url = new URL("https://www.googleapis.com/customsearch/v1");
+  url.searchParams.set("q", query);
+  url.searchParams.set("key", apiKey);
+  url.searchParams.set("cx", cx);
+  url.searchParams.set("num", String(Math.min(numResults, 10)));
+
+  const resp = await fetch(url.toString());
+  if (!resp.ok) {
+    throw new Error(`Google CSE error ${resp.status}: ${await resp.text()}`);
+  }
+
+  const data = (await resp.json()) as {
+    items?: Array<{ title: string; link: string; snippet: string }>;
+  };
+
+  return {
+    provider: "google",
+    results: (data.items ?? []).map((item) => ({
+      title: item.title,
+      url: item.link,
+      snippet: item.snippet ?? "",
+    })),
+  };
+}
+
+// ── SerpAPI ─────────────────────────────────────────────────────────
+
+async function searchSerp(
+  query: string,
+  apiKey: string,
+  numResults: number,
+): Promise<SearchResponse> {
+  const url = new URL("https://serpapi.com/search");
+  url.searchParams.set("q", query);
+  url.searchParams.set("api_key", apiKey);
+  url.searchParams.set("engine", "google");
+  url.searchParams.set("num", String(Math.min(numResults, 10)));
+
+  const resp = await fetch(url.toString());
+  if (!resp.ok) {
+    throw new Error(`SerpAPI error ${resp.status}: ${await resp.text()}`);
+  }
+
+  const data = (await resp.json()) as {
+    organic_results?: Array<{ title: string; link: string; snippet: string }>;
+  };
+
+  return {
+    provider: "serp",
+    results: (data.organic_results ?? []).map((r) => ({
+      title: r.title,
+      url: r.link,
+      snippet: r.snippet ?? "",
+    })),
+  };
+}
+
+// ── Bing Web Search ─────────────────────────────────────────────────
+
+async function searchBing(
+  query: string,
+  apiKey: string,
+  numResults: number,
+): Promise<SearchResponse> {
+  const url = new URL("https://api.bing.microsoft.com/v7.0/search");
+  url.searchParams.set("q", query);
+  url.searchParams.set("count", String(Math.min(numResults, 10)));
+
+  const resp = await fetch(url.toString(), {
+    headers: { "Ocp-Apim-Subscription-Key": apiKey },
+  });
+  if (!resp.ok) {
+    throw new Error(`Bing API error ${resp.status}: ${await resp.text()}`);
+  }
+
+  const data = (await resp.json()) as {
+    webPages?: { value: Array<{ name: string; url: string; snippet: string }> };
+  };
+
+  return {
+    provider: "bing",
+    results: (data.webPages?.value ?? []).map((r) => ({
+      title: r.name,
+      url: r.url,
+      snippet: r.snippet ?? "",
+    })),
+  };
+}
+
+// ── Unified search with fallback chain ──────────────────────────────
+
+export type SearchKeys = {
+  serpApiKey?: string | null;
+  googleApiKey?: string | null;
+  googleCx?: string | null;
+  bingApiKey?: string | null;
+};
+
+export async function webSearch(
+  query: string,
+  keys: SearchKeys,
+  preferred: "serp" | "google" | "bing" = "google",
+  numResults: number = 5,
+): Promise<SearchResponse> {
+  const providers: Array<() => Promise<SearchResponse>> = [];
+
+  const addGoogle = () => {
+    if (keys.googleApiKey && keys.googleCx) {
+      providers.push(() => searchGoogle(query, keys.googleApiKey!, keys.googleCx!, numResults));
+    }
+  };
+  const addSerp = () => {
+    if (keys.serpApiKey) {
+      providers.push(() => searchSerp(query, keys.serpApiKey!, numResults));
+    }
+  };
+  const addBing = () => {
+    if (keys.bingApiKey) {
+      providers.push(() => searchBing(query, keys.bingApiKey!, numResults));
+    }
+  };
+
+  // Order by preference
+  if (preferred === "serp") { addSerp(); addGoogle(); addBing(); }
+  else if (preferred === "bing") { addBing(); addGoogle(); addSerp(); }
+  else { addGoogle(); addSerp(); addBing(); }
+
+  for (const search of providers) {
+    try {
+      return await search();
+    } catch {
+      // Try next provider
+    }
+  }
+
+  throw new Error(
+    "No search providers available. Set API keys in vault: research-google-api-key + research-google-cx, research-serp-api-key, or research-bing-api-key",
+  );
+}

--- a/plugins/mc-research/src/vault.ts
+++ b/plugins/mc-research/src/vault.ts
@@ -1,0 +1,41 @@
+import { execSync } from "node:child_process";
+import * as path from "node:path";
+import * as os from "node:os";
+
+const STATE_DIR = process.env.OPENCLAW_STATE_DIR ?? path.join(os.homedir(), ".openclaw");
+const DEFAULT_VAULT_BIN = path.join(STATE_DIR, "miniclaw", "SYSTEM", "bin", "mc-vault");
+
+export function vaultGet(key: string, vaultBin = DEFAULT_VAULT_BIN): string | null {
+  try {
+    const out = execSync(`${vaultBin} get ${key}`, {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    if (out.includes(" = ")) {
+      return out.split(" = ").slice(1).join(" = ").trim() || null;
+    }
+    return out || null;
+  } catch {
+    return null;
+  }
+}
+
+export function getPerplexityApiKey(): string | null {
+  return vaultGet("research-perplexity-api-key");
+}
+
+export function getSerpApiKey(): string | null {
+  return vaultGet("research-serp-api-key");
+}
+
+export function getGoogleSearchApiKey(): string | null {
+  return vaultGet("research-google-api-key");
+}
+
+export function getGoogleSearchCx(): string | null {
+  return vaultGet("research-google-cx");
+}
+
+export function getBingApiKey(): string | null {
+  return vaultGet("research-bing-api-key");
+}

--- a/plugins/mc-research/tools/definitions.ts
+++ b/plugins/mc-research/tools/definitions.ts
@@ -1,0 +1,348 @@
+/**
+ * mc-research — agent tool definitions
+ */
+
+import type { AnyAgentTool } from "openclaw/plugin-sdk";
+import type { ResearchConfig } from "../src/config.js";
+import { ResearchDb } from "../src/db.js";
+import { queryPerplexity } from "../src/perplexity.js";
+import { webSearch, type SearchKeys } from "../src/search.js";
+import { scrapePage, guessPageUrls, diffSnapshots } from "../src/scraper.js";
+import {
+  getPerplexityApiKey,
+  getSerpApiKey,
+  getGoogleSearchApiKey,
+  getGoogleSearchCx,
+  getBingApiKey,
+} from "../src/vault.js";
+import {
+  formatResearchReport,
+  formatSearchResults,
+  formatCompetitorList,
+  formatSnapshot,
+  formatHistory,
+} from "../src/reporter.js";
+import * as path from "node:path";
+
+type Logger = { info(m: string): void; warn(m: string): void; error(m: string): void };
+
+function ok(text: string) {
+  return { content: [{ type: "text" as const, text: text.trim() }], details: {} };
+}
+
+function err(text: string) {
+  return { content: [{ type: "text" as const, text: `ERROR: ${text}` }], details: {} };
+}
+
+function getDb(cfg: ResearchConfig): ResearchDb {
+  return new ResearchDb(path.join(cfg.stateDir, "research.db"));
+}
+
+function getSearchKeys(): SearchKeys {
+  return {
+    serpApiKey: getSerpApiKey(),
+    googleApiKey: getGoogleSearchApiKey(),
+    googleCx: getGoogleSearchCx(),
+    bingApiKey: getBingApiKey(),
+  };
+}
+
+export function createResearchTools(cfg: ResearchConfig, logger: Logger): AnyAgentTool[] {
+  return [
+
+    // ── research_query ──────────────────────────────────────────────
+    {
+      name: "research_query",
+      label: "research_query",
+      description:
+        "Deep research via Perplexity sonar API. Returns a synthesized answer with citations " +
+        "for any research question, competitive analysis, or market intelligence query.",
+      parameters: {
+        type: "object",
+        required: ["query"],
+        properties: {
+          query: { type: "string", description: "Research question or topic" },
+          focus: {
+            type: "string",
+            description: "Focus area: web (default), news, or academic",
+            enum: ["web", "news", "academic"],
+          },
+        },
+      },
+      async execute(_id: string, params: unknown) {
+        const p = params as Record<string, string>;
+        const query = p["query"] ?? "";
+        const focus = p["focus"] ?? "web";
+
+        const apiKey = getPerplexityApiKey();
+        if (!apiKey) {
+          return err(
+            "Perplexity API key not found. Set it with: openclaw mc-vault set research-perplexity-api-key <key>",
+          );
+        }
+
+        logger.info(`mc-research: research_query "${query}" (focus=${focus})`);
+
+        try {
+          const result = await queryPerplexity(apiKey, query, focus, cfg.perplexityModel);
+          const db = getDb(cfg);
+          const id = db.saveReport(query, focus, "perplexity", result.answer, result.citations);
+          const report = db.getReportById(id)!;
+          db.close();
+          return ok(formatResearchReport(report));
+        } catch (e) {
+          return err(`Perplexity query failed: ${(e as Error).message}`);
+        }
+      },
+    } as AnyAgentTool,
+
+    // ── research_web_search ─────────────────────────────────────────
+    {
+      name: "research_web_search",
+      label: "research_web_search",
+      description:
+        "Search the web via Google Custom Search, SerpAPI, or Bing. Returns ranked results " +
+        "with titles, URLs, and snippets. Falls back through available providers.",
+      parameters: {
+        type: "object",
+        required: ["query"],
+        properties: {
+          query: { type: "string", description: "Search query" },
+          num_results: { type: "number", description: "Number of results (default: 5, max: 10)" },
+        },
+      },
+      async execute(_id: string, params: unknown) {
+        const p = params as Record<string, unknown>;
+        const query = String(p["query"] ?? "");
+        const numResults = Math.min(Number(p["num_results"] ?? 5), 10);
+
+        logger.info(`mc-research: research_web_search "${query}" (n=${numResults})`);
+
+        try {
+          const keys = getSearchKeys();
+          const result = await webSearch(query, keys, cfg.searchProvider, numResults);
+          const db = getDb(cfg);
+          db.saveSearch(query, result.provider, result.results);
+          db.close();
+          return ok(formatSearchResults(result.results, query, result.provider));
+        } catch (e) {
+          return err(`Web search failed: ${(e as Error).message}`);
+        }
+      },
+    } as AnyAgentTool,
+
+    // ── research_competitor_watch ────────────────────────────────────
+    {
+      name: "research_competitor_watch",
+      label: "research_competitor_watch",
+      description:
+        "Register a competitor to track. Stores their name, domain, and notes. " +
+        "Use research_competitor_snapshot to scrape their pages and detect changes over time.",
+      parameters: {
+        type: "object",
+        required: ["name", "domain"],
+        properties: {
+          name: { type: "string", description: "Competitor name (e.g. 'Cursor')" },
+          domain: { type: "string", description: "Competitor domain (e.g. 'cursor.com')" },
+          notes: { type: "string", description: "Optional notes about this competitor" },
+          action: {
+            type: "string",
+            description: "Action: add (default), remove, list",
+            enum: ["add", "remove", "list"],
+          },
+        },
+      },
+      async execute(_id: string, params: unknown) {
+        const p = params as Record<string, string>;
+        const action = p["action"] ?? "add";
+        const db = getDb(cfg);
+
+        try {
+          if (action === "list") {
+            const competitors = db.getCompetitors();
+            db.close();
+            return ok(formatCompetitorList(competitors));
+          }
+
+          if (action === "remove") {
+            const domain = p["domain"] ?? "";
+            const removed = db.removeCompetitor(domain);
+            db.close();
+            return ok(removed ? `Removed competitor: ${domain}` : `No competitor found for domain: ${domain}`);
+          }
+
+          // add
+          const name = p["name"] ?? "";
+          const domain = p["domain"] ?? "";
+          const notes = p["notes"] ?? "";
+
+          logger.info(`mc-research: research_competitor_watch add ${name} (${domain})`);
+          db.addCompetitor(name, domain, notes);
+          const competitors = db.getCompetitors();
+          db.close();
+          return ok(`Added competitor: ${name} (${domain})\n\n${formatCompetitorList(competitors)}`);
+        } catch (e) {
+          db.close();
+          return err(`Competitor watch failed: ${(e as Error).message}`);
+        }
+      },
+    } as AnyAgentTool,
+
+    // ── research_competitor_snapshot ─────────────────────────────────
+    {
+      name: "research_competitor_snapshot",
+      label: "research_competitor_snapshot",
+      description:
+        "Scrape a competitor's key pages (homepage, pricing, features, changelog, about) and " +
+        "store a structured snapshot. Compares against the previous snapshot to detect changes.",
+      parameters: {
+        type: "object",
+        required: ["domain"],
+        properties: {
+          domain: { type: "string", description: "Competitor domain (must be registered via research_competitor_watch)" },
+          pages: {
+            type: "string",
+            description: "Comma-separated page types to scrape (default: all). Options: homepage, pricing, features, about, changelog, blog, docs",
+          },
+        },
+      },
+      async execute(_id: string, params: unknown) {
+        const p = params as Record<string, string>;
+        const domain = p["domain"] ?? "";
+
+        const db = getDb(cfg);
+        const competitor = db.getCompetitorByDomain(domain);
+        if (!competitor) {
+          db.close();
+          return err(`Competitor not found: ${domain}. Add it first with research_competitor_watch.`);
+        }
+
+        logger.info(`mc-research: research_competitor_snapshot ${domain}`);
+
+        const pageTypes = p["pages"] ? p["pages"].split(",").map((s) => s.trim()) : undefined;
+        const urls = guessPageUrls(domain, cfg.maxSnapshotPages);
+        const filtered = pageTypes ? urls.filter((u) => pageTypes.includes(u.type)) : urls;
+
+        const results: string[] = [];
+
+        for (const page of filtered) {
+          try {
+            const data = await scrapePage(page.url);
+            const prevSnapshot = db.getLatestSnapshot(competitor.id, page.type);
+            const prevData = prevSnapshot ? (JSON.parse(prevSnapshot.data) as Record<string, unknown>) : null;
+
+            const diff = diffSnapshots(prevData as any, data);
+            const snapshotId = db.saveSnapshot(
+              competitor.id,
+              page.type,
+              page.url,
+              data,
+              diff.hasChanges ? diff.details.join("\n") : "",
+            );
+
+            const snap = { id: snapshotId, competitor_id: competitor.id, page_type: page.type, url: page.url, data: JSON.stringify(data), diff_summary: diff.hasChanges ? diff.details.join("\n") : "", fetched_at: Date.now() };
+            results.push(formatSnapshot(snap, competitor.name));
+
+            if (diff.hasChanges) {
+              results.push(`⚡ Changes detected:\n${diff.details.map((d) => `  - ${d}`).join("\n")}\n`);
+            }
+          } catch (e) {
+            results.push(`⚠️ Failed to scrape ${page.url} (${page.type}): ${(e as Error).message}\n`);
+          }
+        }
+
+        db.close();
+        return ok(results.join("\n---\n\n"));
+      },
+    } as AnyAgentTool,
+
+    // ── research_report ─────────────────────────────────────────────
+    {
+      name: "research_report",
+      label: "research_report",
+      description:
+        "Generate a comprehensive competitive intelligence report. Combines Perplexity deep research " +
+        "with competitor snapshots and web search results into a formatted markdown report.",
+      parameters: {
+        type: "object",
+        required: ["query"],
+        properties: {
+          query: { type: "string", description: "Research topic or competitor name to report on" },
+          competitor_domain: { type: "string", description: "Optional: include latest snapshots for this competitor" },
+        },
+      },
+      async execute(_id: string, params: unknown) {
+        const p = params as Record<string, string>;
+        const query = p["query"] ?? "";
+        const competitorDomain = p["competitor_domain"];
+
+        logger.info(`mc-research: research_report "${query}"`);
+
+        const sections: string[] = [];
+        sections.push(`# Competitive Intelligence Report\n**Topic:** ${query}\n**Date:** ${new Date().toISOString().split("T")[0]}\n`);
+
+        // 1. Deep research via Perplexity
+        const apiKey = getPerplexityApiKey();
+        if (apiKey) {
+          try {
+            const result = await queryPerplexity(apiKey, query, "web", cfg.perplexityModel);
+            const db = getDb(cfg);
+            db.saveReport(query, "web", "perplexity", result.answer, result.citations);
+            db.close();
+
+            sections.push(`## Deep Research\n\n${result.answer}\n`);
+            if (result.citations.length > 0) {
+              sections.push(`### Sources\n${result.citations.map((c, i) => `${i + 1}. ${c}`).join("\n")}\n`);
+            }
+          } catch (e) {
+            sections.push(`## Deep Research\n\n⚠️ Perplexity query failed: ${(e as Error).message}\n`);
+          }
+        } else {
+          sections.push(`## Deep Research\n\n⚠️ Perplexity API key not configured. Set via: openclaw mc-vault set research-perplexity-api-key <key>\n`);
+        }
+
+        // 2. Web search for recent info
+        try {
+          const keys = getSearchKeys();
+          const searchResult = await webSearch(query, keys, cfg.searchProvider, 5);
+          const db = getDb(cfg);
+          db.saveSearch(query, searchResult.provider, searchResult.results);
+          db.close();
+          sections.push(formatSearchResults(searchResult.results, query, searchResult.provider));
+        } catch {
+          sections.push(`## Web Search\n\n⚠️ No search providers configured.\n`);
+        }
+
+        // 3. Competitor snapshots if specified
+        if (competitorDomain) {
+          const db = getDb(cfg);
+          const competitor = db.getCompetitorByDomain(competitorDomain);
+          if (competitor) {
+            const snapshots = db.getSnapshots(competitor.id);
+            if (snapshots.length > 0) {
+              sections.push(`## Latest Snapshots: ${competitor.name}\n`);
+              // Get latest snapshot per page type
+              const seen = new Set<string>();
+              for (const snap of snapshots) {
+                if (!seen.has(snap.page_type)) {
+                  seen.add(snap.page_type);
+                  sections.push(formatSnapshot(snap, competitor.name));
+                }
+              }
+            }
+          }
+          db.close();
+        }
+
+        const fullReport = sections.join("\n---\n\n");
+
+        // Save the full report
+        const db = getDb(cfg);
+        db.saveReport(query, "report", "combined", fullReport, []);
+        db.close();
+
+        return ok(fullReport);
+      },
+    } as AnyAgentTool,
+  ];
+}

--- a/workspace/TOOLS.md
+++ b/workspace/TOOLS.md
@@ -24,7 +24,7 @@ openclaw mc-board context --column backlog
 
 ## Memory (mc-memory)
 
-Short-term goes into markdown files. Long-term goes into KB vectors.
+Unified gateway — routes to mc-memo (short-term) and mc-kb (long-term). Handles promotion between them.
 
 ```bash
 openclaw mc-memory write "learned something"   # short-term (markdown)
@@ -59,18 +59,24 @@ openclaw mc-memo clear <key>
 ## Email (mc-email)
 
 ```bash
-openclaw mc-email list --unread --limit 20
-openclaw mc-email read <id>
+openclaw mc-email check [--limit 20]                          # list unread inbox
+openclaw mc-email read <id>                                    # read a message by UID
 openclaw mc-email send --to "addr" --subject "..." --body "..."
 openclaw mc-email reply <id> --body "..."
+openclaw mc-email archive <id>                                 # move to All Mail
+openclaw mc-email triage [--dry-run] [--limit 20]             # autonomous triage
+openclaw mc-email auth                                         # store app password
 ```
 
 ---
 
 ## Vault (mc-vault)
 
+Standalone tool — not an openclaw plugin. Call directly.
+
 ```bash
 mc-vault get <key>
+mc-vault export <key>        # raw value (for piping)
 mc-vault set <key> <value>
 mc-vault list
 mc-vault rm <key>
@@ -81,15 +87,18 @@ mc-vault rm <key>
 ## Contacts (mc-rolodex)
 
 ```bash
-openclaw mc-rolodex list
-openclaw mc-rolodex search "name or email"
+openclaw mc-rolodex list [--tag <tag>]
+openclaw mc-rolodex search "name or email" [--type email|phone|domain]
 openclaw mc-rolodex show <contact_id>
-openclaw mc-rolodex update <id> --name "..." --email "..."
+openclaw mc-rolodex add '{"name":"...","emails":["..."]}'
+openclaw mc-rolodex delete <contact_id>
 ```
 
 ---
 
 ## Soul (mc-soul)
+
+Identity — personality traits, values, voice. Loaded into every conversation.
 
 ```bash
 openclaw mc-soul backup <name>
@@ -141,7 +150,266 @@ openclaw mc-backup list
 ## Reflection (mc-reflection)
 
 ```bash
-openclaw mc-reflection run
-openclaw mc-reflection list
-openclaw mc-reflection show <date>
+openclaw mc-reflection gather [--date YYYY-MM-DD]   # collect day's context
+openclaw mc-reflection list [--limit N]              # list past reflections
+openclaw mc-reflection show <id_or_date>             # show by ID or date
+```
+
+---
+
+## Trust (mc-trust)
+
+Agent identity — Ed25519 keypairs, cryptographic verification, mutual handshake.
+
+```bash
+openclaw mc-trust init                        # generate identity keypair
+openclaw mc-trust pubkey                      # print public key (safe to share)
+openclaw mc-trust add-peer <id> <pubkey>      # register a peer's public key
+openclaw mc-trust list-peers                  # list known peers
+openclaw mc-trust challenge <peer_id>         # initiate handshake
+openclaw mc-trust respond <json>              # respond to handshake
+openclaw mc-trust complete <json>             # verify response, establish session
+openclaw mc-trust finish <json>               # complete mutual auth (responder side)
+openclaw mc-trust sessions                    # list active trust sessions
+openclaw mc-trust sign <message>              # sign a message
+openclaw mc-trust verify <message>            # verify a signed message
+```
+
+---
+
+## Designer (mc-designer)
+
+Gemini-powered image generation with layers and compositing.
+
+```bash
+openclaw mc-designer gen <prompt>                          # generate image
+openclaw mc-designer edit <canvas> <layer> <instructions>  # edit a layer
+openclaw mc-designer canvas new|list|show|rm               # canvas management
+openclaw mc-designer layer add|rm|mv|opacity|toggle|rename|blend
+openclaw mc-designer composite <canvas>                    # flatten → PNG
+openclaw mc-designer alpha strip <file>                    # remove background
+openclaw mc-designer stats [--full]                        # usage + cost
+```
+
+---
+
+## Blog (mc-blog)
+
+```bash
+openclaw mc-blog list                    # list posts
+openclaw mc-blog show <id>               # show post
+openclaw mc-blog create-seed             # create post metadata
+openclaw mc-blog write-body <id>         # write post content
+openclaw mc-blog generate-addendum <id>  # self-analysis
+openclaw mc-blog writing-brief           # get voice rules + context
+```
+
+---
+
+## Booking (mc-booking)
+
+```bash
+openclaw mc-booking setup                # guided Turso DB setup
+openclaw mc-booking slots                # list available slots
+openclaw mc-booking list [-n <limit>]    # list upcoming appointments
+openclaw mc-booking show <token>         # appointment details
+openclaw mc-booking cancel <token>       # cancel + refund
+openclaw mc-booking config [key] [value] # view/set config
+openclaw mc-booking serve                # start HTTP server (port 4221)
+```
+
+---
+
+## Stripe (mc-stripe)
+
+```bash
+openclaw mc-stripe setup                                     # vault keys, verify
+openclaw mc-stripe charge <amount> <currency> <description>  # create payment
+openclaw mc-stripe refund <payment-intent-id> [--amount N]   # full or partial refund
+openclaw mc-stripe status <payment-intent-id>                # payment details
+openclaw mc-stripe customers list|create                     # customer management
+openclaw mc-stripe balance                                   # available + pending
+```
+
+---
+
+## Square (mc-square)
+
+```bash
+openclaw mc-square setup                                     # vault token, verify
+openclaw mc-square charge <amount> <currency> <description>  # create payment
+openclaw mc-square refund <payment-id> [--amount N]          # refund
+openclaw mc-square status <payment-id>                       # payment details
+openclaw mc-square link <amount> <title>                     # hosted checkout URL
+openclaw mc-square locations                                 # list Square locations
+```
+
+---
+
+## Calendar (mc-calendar)
+
+```bash
+openclaw mc-calendar list [--days N]     # upcoming events
+openclaw mc-calendar create --title "..." --start "..." --end "..."
+openclaw mc-calendar update <id> ...
+openclaw mc-calendar delete <id>
+openclaw mc-calendar search "query"
+```
+
+---
+
+## Tailscale (mc-tailscale)
+
+```bash
+openclaw mc-tailscale status             # node status and IPs
+openclaw mc-tailscale serve <port>       # expose local port via Tailscale
+openclaw mc-tailscale funnel <port>      # expose publicly via Funnel
+```
+
+---
+
+## Authenticator (mc-authenticator)
+
+TOTP 2FA — Google Authenticator compatible.
+
+```bash
+openclaw mc-auth add <name> <secret> [--issuer X --account Y]
+openclaw mc-auth add-uri <name> "otpauth://..."
+openclaw mc-auth code <name>             # current 6-digit code + TTL
+openclaw mc-auth verify <name> <code>    # verify a code
+openclaw mc-auth list                    # list services
+openclaw mc-auth remove <name>
+```
+
+---
+
+## Contribute (mc-contribute)
+
+```bash
+openclaw mc-contribute scaffold <name>           # scaffold new plugin
+openclaw mc-contribute branch <topic>            # create contrib/ branch
+openclaw mc-contribute security [--all]          # run security scanner
+openclaw mc-contribute pr -t "..." -s "..."      # push + create PR
+openclaw mc-contribute status                    # branch, changes, open PRs
+openclaw mc-contribute guidelines                # print contribution rules
+```
+
+---
+
+## Context (mc-context)
+
+Automatic — runs on every prompt build. Manual status commands:
+
+```bash
+/context-status     # window stats: messages kept, images pruned, dropped by age
+/context-window     # which messages are in the current window
+/context-reset      # force a fresh window
+```
+
+---
+
+## Docs (mc-docs)
+
+```bash
+openclaw mc-docs create "Title" --author "..." [--tags "a,b" --card-id crd_X]
+openclaw mc-docs edit <doc_id> "content" --author "..." --message "..."
+openclaw mc-docs list [--tag X | --card-id X]
+openclaw mc-docs show <doc_id> [--raw]
+openclaw mc-docs versions <doc_id>
+```
+
+---
+
+## Substack (mc-substack)
+
+```bash
+openclaw mc-substack auth                # store auth cookie
+openclaw mc-substack draft --title "..." --body "..."
+openclaw mc-substack publish <draft_id>
+openclaw mc-substack list
+```
+
+---
+
+## Reddit (mc-reddit)
+
+```bash
+openclaw mc-reddit auth --cookies '<cookie_string>'
+openclaw mc-reddit post -s <subreddit> -t "Title" -c "Content"
+openclaw mc-reddit comment -p <post_id> -c "Comment"
+openclaw mc-reddit feed [--subreddit X]
+```
+
+---
+
+## X / Twitter (mc-x)
+
+```bash
+openclaw mc-x auth --token '<bearer>'
+openclaw mc-x post "tweet content"
+openclaw mc-x timeline [--limit N]
+openclaw mc-x reply <tweet_id> "reply content"
+```
+
+---
+
+## Moltbook (mc-moltbook)
+
+Social network for AI agents.
+
+```bash
+openclaw mc-moltbook status              # profile and connection
+openclaw mc-moltbook register            # register on Moltbook
+openclaw mc-moltbook feed [--sort hot|new|top|rising]
+openclaw mc-moltbook post -s <community> -t "Title" -c "Content"
+openclaw mc-moltbook reply -p <post_id> -c "Reply"
+openclaw mc-moltbook communities         # list communities
+```
+
+---
+
+## SEO (mc-seo)
+
+```bash
+openclaw mc-seo audit <domain>
+openclaw mc-seo keywords <domain>
+openclaw mc-seo sitemap submit <url>
+```
+
+---
+
+## YouTube (mc-youtube)
+
+```bash
+openclaw mc-youtube analyze <url>        # keyframe extraction + analysis
+```
+
+---
+
+## Devlog (mc-devlog)
+
+```bash
+openclaw mc-devlog generate [--date YYYY-MM-DD]   # generate daily devlog from git
+```
+
+---
+
+## Update (mc-update)
+
+```bash
+openclaw mc-update check                 # check for new version
+openclaw mc-update apply                 # apply update with smoke test
+```
+
+---
+
+## Standalone Tools
+
+These are NOT openclaw plugins — call directly:
+
+```bash
+mc-vault get|set|list|rm|export          # age-encrypted secrets
+mc-doctor                                 # full diagnosis + auto-repair
+mc-smoke                                  # quick health check
+mc-chrome                                 # browser automation
 ```


### PR DESCRIPTION
## Summary
- New mc-research plugin with 5 agent tools: research_query (Perplexity), research_web_search (Google/Serp/Bing fallback), research_competitor_watch, research_competitor_snapshot (with change detection), research_report
- 7 CLI commands for all tools + history
- SQLite persistence (research.db), API keys via mc-vault, 9 smoke tests passing
- Updates README plugin table and TOOLS.md docs

## Test plan
- [x] 9 smoke tests passing (config, DB CRUD, diff detection, formatters)
- [x] Standard plugin structure verified (index.ts, openclaw.plugin.json, package.json, src/, tools/, cli/)
- [x] Fast-forward merge onto main confirmed clean