### PR TITLE
fix: rebuild-prerelease cleans dirty state before pulling

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -85,7 +85,7 @@ BUNDLED_WEB="$EXTRACT_TMP/miniclaw-installer.app/Contents/Resources/miniclaw-web
 BUNDLED_PLUGINS="$EXTRACT_TMP/miniclaw-installer.app/Contents/Resources/plugins-prebuilt"
 if [[ -d "$BUNDLED_WEB" && -f "$BUNDLED_WEB/server.js" ]]; then
   rm -rf "$WEB_DIR"
-  mkdir -p "$STATE_DIR"
+  mkdir -p "$(dirname "$WEB_DIR")"
   mv "$BUNDLED_WEB" "$WEB_DIR"
 else
   echo "  ERROR: Pre-built app not in zip. Try again or use the .app installer."

--- a/scripts/rebuild-prerelease.sh
+++ b/scripts/rebuild-prerelease.sh
@@ -45,6 +45,8 @@ echo "  ✓ Clean"
 
 # 2. Pull
 echo "[2/8] Pulling latest main..."
+git -C "$REPO_DIR" clean -fd
+git -C "$REPO_DIR" checkout -- .
 git -C "$REPO_DIR" checkout main
 git -C "$REPO_DIR" pull --rebase origin main
 echo "  ✓ Up to date"


### PR DESCRIPTION
Adds git clean -fd and git checkout -- . before pull to handle stale .plugins-prebuilt artifacts.