### PR TITLE
fix(mc-board): guard pickup against worker-column mismatch

### DIFF
--- a/plugins/mc-board/cli/commands.ts
+++ b/plugins/mc-board/cli/commands.ts
@@ -806,6 +806,16 @@ Examples:
     .action((id: string, opts: { worker: string; column?: string }) => {
       try {
         const card = store.findById(id);
+        const workerColumnMap: Record<string, string> = {
+          "board-worker-backlog": "backlog",
+          "board-worker-in-progress": "in-progress",
+          "board-worker-in-review": "in-review",
+        };
+        const expectedColumn = workerColumnMap[opts.worker];
+        if (expectedColumn && card.column !== expectedColumn) {
+          console.error(`COLUMN MISMATCH: ${opts.worker} cannot pick up card ${id} — card is in "${card.column}", worker expects "${expectedColumn}".`);
+          process.exit(1);
+        }
         const entry = activeWork.pickup({
           cardId: card.id,
           projectId: card.project_id,


### PR DESCRIPTION
## Summary
- Adds a column mismatch guard to the `brain pickup` command
- Maps worker names (board-worker-backlog, board-worker-in-progress, board-worker-in-review) to their expected columns
- Rejects pickup with a clear error if a worker tries to grab a card from the wrong column

## Problem
Board workers could pick up cards from any column. A backlog worker could accidentally grab an in-review card, causing confusion and incorrect processing.

## Test plan
- [ ] Run `openclaw mc-board pickup <card-in-backlog> --worker board-worker-backlog` -- should succeed
- [ ] Run `openclaw mc-board pickup <card-in-review> --worker board-worker-backlog` -- should fail with COLUMN MISMATCH error
- [ ] Verify existing pickup behavior unchanged for correct worker/column combinations

Generated with [Claude Code](https://claude.com/claude-code)