### PR TITLE
feat(mc-board): add wip-limit CLI command

### DIFF
--- a/plugins/mc-board/cli/commands.ts
+++ b/plugins/mc-board/cli/commands.ts
@@ -892,6 +892,25 @@ Useful for auditing which agent processed which ticket and when.
       }
     });
 
+  // ---- brain wip-limit ----
+  brain
+    .command("wip-limit <column>")
+    .description("Show the configured WIP limit for a column (reads from board-cron.json or default)")
+    .addHelpText("after", `
+Returns the max concurrent cards allowed in the given column.
+Reads from board-cron.json maxConcurrent field, falls back to default (3).
+
+  openclaw mc-board wip-limit in-progress
+  openclaw mc-board wip-limit in-review`)
+    .action((column: string) => {
+      if (!COLUMNS.includes(column as Column)) {
+        console.error(`Invalid column: ${column}. Valid: ${COLUMNS.join(", ")}`);
+        process.exit(1);
+      }
+      const limit = getWipLimit(column as Column, ctx.stateDir);
+      console.log(`${limit}`);
+    });
+
   // ---- brain check-dupes ----
   brain
     .command("check-dupes")


### PR DESCRIPTION
## Summary
- Adds `brain wip-limit <column>` CLI command
- Queries the configured WIP limit for any board column
- Reads from board-cron.json maxConcurrent field, falls back to default (3)

## Problem
No way to check WIP limits from CLI. Workers and scripts had to guess or hardcode limits, making debugging WIP-related issues difficult.

## Test plan
- [ ] Run `openclaw mc-board wip-limit in-progress` -- should print the configured limit
- [ ] Run `openclaw mc-board wip-limit in-review` -- should print the configured limit
- [ ] Run `openclaw mc-board wip-limit invalid` -- should error with valid column list

Generated with [Claude Code](https://claude.com/claude-code)