### PR TITLE
fix(mc-board): enforce WIP limit in triage move-to-in-progress

### DIFF
--- a/plugins/mc-board/cli/commands.ts
+++ b/plugins/mc-board/cli/commands.ts
@@ -1116,6 +1116,13 @@ Rules:
                   if (!gate.ok) {
                     throw new Error(formatGateError("backlog", "in-progress", gate.failures));
                   }
+                  // WIP limit check — same enforcement as `brain move` CLI command
+                  const wipLimit = getWipLimit("in-progress", ctx.stateDir);
+                  const wipCount = store.countByColumn("in-progress");
+                  const wip = checkWipLimit(wipCount, wipLimit);
+                  if (!wip.ok) {
+                    throw new Error(`WIP LIMIT: "in-progress" already has ${wip.current}/${wip.max} cards. Card left in backlog.`);
+                  }
                   store.move(currentCard, "in-progress");
                   log(`[${ts()}] moved to in-progress\n`);
                 } catch (moveErr) {


### PR DESCRIPTION
## Summary
- Adds WIP limit check to the triage command's `move_to="in-progress"` path
- Matches the enforcement already present in the `brain move` CLI command
- Cards stay in backlog with a clear error when in-progress is at capacity

## Problem
The triage command checked gate conditions before moving a card to in-progress, but skipped the WIP limit check. This allowed agent triage loops to pile up cards beyond the configured max, defeating the purpose of WIP limits.

## Test plan
- [ ] Set WIP limit for in-progress to a low number
- [ ] Fill in-progress to capacity
- [ ] Run triage with a card that requests `move_to: "in-progress"` -- should fail with WIP LIMIT error
- [ ] Verify the card stays in backlog with the error noted

Generated with [Claude Code](https://claude.com/claude-code)