### PR TITLE
fix(mc-board): use wss:// for WebSocket on HTTPS pages

### DIFF
--- a/plugins/mc-board/web/src/components/chat-panel.tsx
+++ b/plugins/mc-board/web/src/components/chat-panel.tsx
@@ -51,7 +51,8 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
   // WebSocket connection
   useEffect(() => {
     const wsHost = window.location.hostname;
-    const ws = new WebSocket(`ws://${wsHost}:4221`);
+    const wsProto = window.location.protocol === "https:" ? "wss" : "ws";
+    const ws = new WebSocket(`${wsProto}://${wsHost}:4221`);
     wsRef.current = ws;
 
     ws.onopen = () => {

--- a/plugins/mc-board/web/src/lib/human-session-server.ts
+++ b/plugins/mc-board/web/src/lib/human-session-server.ts
@@ -329,7 +329,8 @@ function buildViewerHtml(reason: string, token: string): string {
 import RFB from 'https://cdn.jsdelivr.net/npm/@novnc/novnc@1.5.0/core/rfb.js';
 const status = document.getElementById('status');
 const overlay = document.getElementById('overlay');
-const wsUrl = 'ws://' + location.host + '${WS_PATH}';
+const wsProto = location.protocol === 'https:' ? 'wss' : 'ws';
+const wsUrl = wsProto + '://' + location.host + '${WS_PATH}';
 let rfb;
 try {
   rfb = new RFB(document.getElementById('screen'), wsUrl, { credentials: {} });


### PR DESCRIPTION
## Summary
- Detect page protocol and use `wss://` when served over HTTPS
- Fixes `chat-panel.tsx` (chat WebSocket) and `human-session-server.ts` (noVNC WebSocket)

## Problem
Browsers block mixed content when the board is served via HTTPS (e.g. Tailscale Serve) but WebSocket connections are hardcoded to `ws://`. Chat and VNC fail silently.

## Test plan
- [ ] Load board over HTTPS (Tailscale Serve) -- chat panel connects successfully
- [ ] Load board over HTTP (localhost) -- chat panel still works with ws://
- [ ] noVNC session connects over HTTPS without mixed content errors

Generated with [Claude Code](https://claude.com/claude-code)