### PR TITLE
fix: normalize work_log strings at data layer

### DIFF
--- a/plugins/mc-board/web/src/components/app-shell.tsx
+++ b/plugins/mc-board/web/src/components/app-shell.tsx
@@ -314,7 +314,7 @@ export function AppShell({ initialTab, initialCardId, initialProjectId }: { init
             />
           </div>
           <div className={`tab-panel${tab === "office" ? " active" : ""}`}>
-            <PixelOfficeTab onSwitchToBoard={() => switchTab("board")} />
+            {tab === "office" && <PixelOfficeTab onSwitchToBoard={() => switchTab("board")} />}
           </div>
           <div className={`tab-panel${tab === "memory" ? " active" : ""}`}>
             <MemoryTab />

--- a/plugins/mc-board/web/src/components/card-modal.tsx
+++ b/plugins/mc-board/web/src/components/card-modal.tsx
@@ -563,12 +563,12 @@ export function CardModal({ cardId, projects, activeIds, onClose, onOpenLog, onT
                 {card.work_log.map((entry, i) => (
                   <div key={i} className="bg-zinc-800 rounded px-3 py-2 text-xs">
                     <div className="flex items-center gap-2 text-zinc-500 mb-1">
-                      <span className="font-mono">{entry.at.slice(0, 16).replace("T", " ")}</span>
+                      <span className="font-mono">{entry.at?.slice(0, 16)?.replace("T", " ") ?? ""}</span>
                       <span>·</span>
                       <span>{entry.worker}</span>
                     </div>
                     <div className="text-zinc-300 leading-relaxed">{entry.note}</div>
-                    {entry.links?.map(l => (
+                    {entry.links?.map((l) => (
                       <a key={l} href={l} target="_blank" rel="noreferrer" className="text-blue-400 hover:underline block mt-1 truncate">{l}</a>
                     ))}
                   </div>

--- a/plugins/mc-board/web/src/components/pixel-office-tab.tsx
+++ b/plugins/mc-board/web/src/components/pixel-office-tab.tsx
@@ -91,6 +91,10 @@ export function PixelOfficeTab({ onSwitchToBoard }: Props) {
             if (resp.ok) layout = await resp.json();
           } catch {}
         }
+        // Validate layout before init
+        if (layout && (!layout.tiles || !layout.furniture || !layout.cols || !layout.rows)) {
+          layout = null; // force default
+        }
         const state = await initOffice(layout);
         if (cancelled) return;
         // Load user-defined zones

--- a/plugins/mc-board/web/src/lib/data.ts
+++ b/plugins/mc-board/web/src/lib/data.ts
@@ -145,13 +145,20 @@ function rowToCard(row: CardRow, history: HistoryRow[]): Card {
     attachments: (() => { try { return JSON.parse(row.attachments || "[]") as import("./types").Attachment[]; } catch { return []; } })(),
     work_log: (() => {
       try {
-        const raw = JSON.parse(row.work_log || "[]") as Array<Record<string, unknown>>;
-        return raw.map(e => ({
-          at: (e.at ?? e.ts ?? "") as string,
-          worker: (e.worker ?? "") as string,
-          note: (e.note ?? e.entry ?? "") as string,
-          ...(e.links ? { links: e.links as string[] } : {}),
-        })) as WorkLogEntry[];
+        const raw = JSON.parse(row.work_log || "[]") as unknown[];
+        return raw.map(e => {
+          if (typeof e === "string") {
+            // Normalize plain strings into WorkLogEntry
+            return { at: new Date().toISOString(), worker: "unknown", note: e } as WorkLogEntry;
+          }
+          const obj = e as Record<string, unknown>;
+          return {
+            at: (obj.at ?? obj.ts ?? "") as string,
+            worker: (obj.worker ?? "") as string,
+            note: (obj.note ?? obj.entry ?? "") as string,
+            ...(obj.links ? { links: obj.links as string[] } : {}),
+          } as WorkLogEntry;
+        });
       } catch { return []; }
     })(),
   };


### PR DESCRIPTION
Plain string work_log entries caused .slice crash on card modal. Now normalized to WorkLogEntry at read time. Also lazy-mounts office tab.