### PR TITLE
fix: seed onboarding card angle brackets stripped as HTML

### DIFF
--- a/plugins/mc-board/web/src/app/api/setup/complete/route.ts
+++ b/plugins/mc-board/web/src/app/api/setup/complete/route.ts
@@ -566,7 +566,7 @@ VALUES (
   datetime('now'),
   datetime('now'),
   'The rolodex has a placeholder contact for the human owner (name="My Human", no email). The agent needs to ask the human for their real name and preferred email address, then update the rolodex so all future communications use the correct identity.',
-  '1. Send the human a Telegram message (use the inbox CLI, NOT mc-human) asking for their preferred name and email address.\\n2. Once the human replies in Telegram, find the human contact id with: openclaw mc-rolodex list --tag owner\\n3. Update the contact: openclaw mc-rolodex update <human-contact-id> --name "<real name>" --email "<real email>"\\n4. Verify the rolodex contact was updated correctly with: openclaw mc-rolodex list',
+  '1. Send the human a Telegram message (use the inbox CLI, NOT mc-human) asking for their preferred name and email address.\\n2. Once the human replies in Telegram, find the human contact id with: openclaw mc-rolodex list --tag owner\\n3. Update the contact: openclaw mc-rolodex update CONTACT_ID --name \"their name\" --email \"their email\"\\n4. Verify the rolodex contact was updated correctly with: openclaw mc-rolodex list',
   '- [ ] Human contact in rolodex has their real name (not "My Human")\\n- [ ] Human contact has their real email address\\n- [ ] Agent confirmed the update via mc-rolodex list'
 )""")
 conn.commit()


### PR DESCRIPTION
Replaced <human-contact-id>, <real name>, <real email> with plain text. Angle brackets get parsed as HTML tags and silently stripped.