### PR TITLE
fix: sync OAuth tokens from Claude Code Keychain to gateway

### DIFF
--- a/SYSTEM/bin/mc-oauth-sync
+++ b/SYSTEM/bin/mc-oauth-sync
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# mc-oauth-sync — copy Claude Code OAuth tokens from macOS Keychain to gateway auth-profiles.json
+#
+# Claude Code stores OAuth tokens in macOS Keychain ("Claude Code-credentials").
+# The gateway reads from auth-profiles.json which goes stale when tokens expire.
+# This script bridges the two so /login in Claude Code fixes the gateway too.
+#
+# Usage:
+#   mc-oauth-sync              Sync if current token is expired
+#   mc-oauth-sync --force      Always sync, even if token looks valid
+
+set -euo pipefail
+
+STATE_DIR="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
+AUTH_FILE="$STATE_DIR/agents/main/agent/auth-profiles.json"
+FORCE=false
+[[ "${1:-}" == "--force" ]] && FORCE=true
+
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "mc-oauth-sync: macOS only (Keychain)" >&2
+  exit 0
+fi
+
+# Read current token expiry
+if [[ -f "$AUTH_FILE" ]] && ! $FORCE; then
+  EXPIRES=$(python3 -c "
+import json, time
+try:
+    d = json.load(open('$AUTH_FILE'))
+    e = d.get('profiles', {}).get('claude-cli', {}).get('expires', 0)
+    print(e)
+except: print(0)
+" 2>/dev/null || echo 0)
+  NOW=$(python3 -c "import time; print(int(time.time() * 1000))" 2>/dev/null)
+  if [[ "$EXPIRES" -gt "$NOW" ]]; then
+    # Token still valid
+    exit 0
+  fi
+fi
+
+# Read fresh token from Keychain
+KEYCHAIN_JSON=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null || true)
+if [[ -z "$KEYCHAIN_JSON" ]]; then
+  echo "mc-oauth-sync: no Claude Code credentials in Keychain" >&2
+  exit 1
+fi
+
+# Extract and write to auth-profiles.json
+python3 - "$KEYCHAIN_JSON" "$AUTH_FILE" <<'PYEOF'
+import json, sys, os
+
+raw = sys.argv[1]
+auth_file = sys.argv[2]
+
+try:
+    creds = json.loads(raw)
+    oauth = creds.get("claudeAiOauth", {})
+    access = oauth.get("accessToken", "")
+    refresh = oauth.get("refreshToken", "")
+    expires = oauth.get("expiresAt", 0)
+
+    if not access:
+        print("mc-oauth-sync: no accessToken in Keychain credentials", file=sys.stderr)
+        sys.exit(1)
+
+    # Read existing auth-profiles or create new
+    if os.path.exists(auth_file):
+        auth = json.load(open(auth_file))
+    else:
+        os.makedirs(os.path.dirname(auth_file), exist_ok=True)
+        auth = {"version": 1, "profiles": {}, "usageStats": {}}
+
+    profile = auth.setdefault("profiles", {}).setdefault("claude-cli", {
+        "type": "oauth",
+        "provider": "anthropic",
+    })
+    profile["access"] = access
+    profile["refresh"] = refresh
+    profile["expires"] = expires
+
+    with open(auth_file, "w") as f:
+        json.dump(auth, f, indent=2)
+
+    import time
+    remaining = (expires - int(time.time() * 1000)) / 1000 / 60
+    print(f"mc-oauth-sync: token synced from Keychain (valid for {remaining:.0f} minutes)")
+
+except Exception as e:
+    print(f"mc-oauth-sync: failed — {e}", file=sys.stderr)
+    sys.exit(1)
+PYEOF

--- a/install.sh
+++ b/install.sh
@@ -1574,6 +1574,12 @@ fi
 GW_LABELS=("Configuring Telegram" "Connecting to gateway" "Hacking the matrix" "Coming online")
 step "Step 27: ${GW_LABELS[$((RANDOM % ${#GW_LABELS[@]}))]}"
 
+# Sync OAuth token from Claude Code Keychain before starting gateway
+if [[ -x "$SYSTEM_BIN/mc-oauth-sync" ]]; then
+  "$SYSTEM_BIN/mc-oauth-sync" 2>/dev/null && ok "OAuth token synced from Keychain" \
+    || info "OAuth sync skipped (no Keychain credentials yet)"
+fi
+
 # The gateway is the core process — it runs the telegram bot, cron workers,
 # and agent sessions.  `openclaw gateway install` creates a LaunchAgent plist
 # and loads it via launchctl.

--- a/plugins/mc-board/agent-runner/runner.mjs
+++ b/plugins/mc-board/agent-runner/runner.mjs
@@ -57,6 +57,12 @@ function getMaxConcurrentPerColumn() {
 // Full-agent columns run claude directly. Other columns delegate to openclaw triage CLI.
 const FULL_AGENT_COLUMNS = new Set(["backlog", "in-progress", "in-review"]);
 
+// Sync OAuth token from Claude Code Keychain on startup
+const oauthSyncBin = path.join(STATE_DIR, "miniclaw", "SYSTEM", "bin", "mc-oauth-sync");
+if (fs.existsSync(oauthSyncBin)) {
+  try { execFileSync(oauthSyncBin, [], { timeout: 10_000, stdio: "pipe" }); } catch {}
+}
+
 // ---- Logging ----
 
 const runnerLog = path.join(STATE_DIR, "logs", "agent-runner.log");


### PR DESCRIPTION
Closes #295. mc-oauth-sync bridges Claude Code Keychain → auth-profiles.json. Runs on install and agent-runner startup.