### PR TITLE
fix(pixel-office): rendering and collision bugs (#263)

### DIFF
--- a/plugins/mc-board/web/src/components/office-zone-editor.tsx
+++ b/plugins/mc-board/web/src/components/office-zone-editor.tsx
@@ -13,7 +13,7 @@ import {
 type ZoneType = "in-progress" | "backlog" | "in-review";
 type Facing = "up" | "down" | "left" | "right";
 type SpotAction = "sit" | "stand";
-type Mode = ZoneType | "erase" | "hand";
+type Mode = ZoneType | "spawn" | "erase" | "hand";
 
 interface Spot {
   col: number;
@@ -42,6 +42,7 @@ const MODE_LABELS: Record<Mode, string> = {
   "in-progress": "In Progress [P]",
   "backlog": "Backlog [B]",
   "in-review": "In Review [R]",
+  "spawn": "Spawn [S]",
   "erase": "Eraser [E]",
   "hand": "Pan [H]",
 };
@@ -57,6 +58,7 @@ export function OfficeZoneEditor({ onClose }: Props) {
   const [loaded, setLoaded] = useState(false);
   const [zones, setZones] = useState<Record<string, ZoneType>>({});
   const [spots, setSpots] = useState<Spot[]>([]);
+  const [spawnPoints, setSpawnPoints] = useState<Record<string, boolean>>({});
   const [mode, setMode] = useState<Mode>("in-progress");
   const [painting, setPainting] = useState(false);
   const [panning, setPanning] = useState(false);
@@ -73,6 +75,7 @@ export function OfficeZoneEditor({ onClose }: Props) {
         case "p": setMode("in-progress"); setLastPainted(null); break;
         case "b": setMode("backlog"); setLastPainted(null); break;
         case "r": setMode("in-review"); setLastPainted(null); break;
+        case "s": setMode("spawn"); setLastPainted(null); break;
         case "e": setMode("erase"); setLastPainted(null); break;
         case "h": setMode("hand"); setLastPainted(null); break;
         case "escape": setLastPainted(null); break;
@@ -91,6 +94,11 @@ export function OfficeZoneEditor({ onClose }: Props) {
           const data = await resp.json();
           if (data.zones) setZones(data.zones);
           if (data.spots) setSpots(data.spots);
+          if (data.spawnPoints) {
+            const sp: Record<string, boolean> = {};
+            for (const p of data.spawnPoints) sp[`${p.col},${p.row}`] = true;
+            setSpawnPoints(sp);
+          }
         }
       } catch {}
       let layout: OfficeLayout | null = null;
@@ -159,6 +167,20 @@ export function OfficeZoneEditor({ onClose }: Props) {
             ctx.fillRect(offsetX + c * sz, offsetY + r * sz, sz, sz);
           }
 
+          // Spawn point overlays (green)
+          for (const key of Object.keys(spawnPoints)) {
+            const [c, r] = key.split(",").map(Number);
+            ctx.fillStyle = "rgba(34, 197, 94, 0.5)";
+            ctx.fillRect(offsetX + c * sz, offsetY + r * sz, sz, sz);
+            // Small "S" label
+            ctx.fillStyle = "#fff";
+            const spFs = Math.max(8, Math.round(8 * zoom));
+            ctx.font = `bold ${spFs}px sans-serif`;
+            ctx.textAlign = "center";
+            ctx.textBaseline = "middle";
+            ctx.fillText("S", offsetX + c * sz + sz / 2, offsetY + r * sz + sz / 2);
+          }
+
           // Spots
           for (const spot of spots) {
             const x = offsetX + spot.col * sz;
@@ -213,7 +235,7 @@ export function OfficeZoneEditor({ onClose }: Props) {
     };
     rafId = requestAnimationFrame(frame);
     return () => cancelAnimationFrame(rafId);
-  }, [loaded, zones, spots, lastPainted]);
+  }, [loaded, zones, spots, spawnPoints, lastPainted]);
 
   // Convert mouse to tile — for painting: floor only. For facing: any non-void.
   const canvasToTile = useCallback((e: React.MouseEvent<HTMLCanvasElement>, allowWalls: boolean): { col: number; row: number } | null => {
@@ -275,6 +297,13 @@ export function OfficeZoneEditor({ onClose }: Props) {
       const key = `${tile.col},${tile.row}`;
       setZones((prev) => { const n = { ...prev }; delete n[key]; return n; });
       setSpots((prev) => prev.filter((s) => !(s.col === tile.col && s.row === tile.row)));
+      setSpawnPoints((prev) => { const n = { ...prev }; delete n[key]; return n; });
+      setLastPainted(null);
+      setDirty(true);
+      setPainting(true);
+    } else if (mode === "spawn") {
+      const key = `${tile.col},${tile.row}`;
+      setSpawnPoints((prev) => ({ ...prev, [key]: true }));
       setLastPainted(null);
       setDirty(true);
       setPainting(true);
@@ -298,8 +327,12 @@ export function OfficeZoneEditor({ onClose }: Props) {
     const tile = canvasToTile(e, false);
     if (!tile) return;
     if (mode === "erase") {
-      setZones((prev) => { const n = { ...prev }; delete n[`${tile.col},${tile.row}`]; return n; });
+      const key = `${tile.col},${tile.row}`;
+      setZones((prev) => { const n = { ...prev }; delete n[key]; return n; });
       setSpots((prev) => prev.filter((s) => !(s.col === tile.col && s.row === tile.row)));
+      setSpawnPoints((prev) => { const n = { ...prev }; delete n[key]; return n; });
+    } else if (mode === "spawn") {
+      setSpawnPoints((prev) => ({ ...prev, [`${tile.col},${tile.row}`]: true }));
     } else if (mode !== "hand") {
       setZones((prev) => ({ ...prev, [`${tile.col},${tile.row}`]: mode }));
     }
@@ -315,10 +348,15 @@ export function OfficeZoneEditor({ onClose }: Props) {
   async function handleSave() {
     setSaving(true);
     try {
+      // Convert spawnPoints record to array format for API
+      const spawnPointsArray = Object.keys(spawnPoints).map((key) => {
+        const [col, row] = key.split(",").map(Number);
+        return { col, row };
+      });
       await fetch("/api/office/zones", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ zones, spots }),
+        body: JSON.stringify({ zones, spots, spawnPoints: spawnPointsArray }),
       });
       setDirty(false);
     } finally {
@@ -360,6 +398,14 @@ export function OfficeZoneEditor({ onClose }: Props) {
             {MODE_LABELS[z]}
           </button>
         ))}
+        <button onClick={() => { setMode("spawn"); setLastPainted(null); }}
+          style={{
+            background: mode === "spawn" ? "rgba(34, 197, 94, 0.8)" : "#27272a",
+            border: mode === "spawn" ? "2px solid #fff" : "1px solid #3f3f46",
+            color: "#e4e4e7", borderRadius: 4, padding: "4px 10px", cursor: "pointer", fontSize: 12,
+          }}>
+          {MODE_LABELS["spawn"]}
+        </button>
         <div style={{ flex: 1 }} />
         <span style={{ color: "#52525b", fontSize: 11 }}>
           {mode === "hand" ? "✋ Pan" : mode === "erase" ? "🧹 Erase" : ""}
@@ -414,8 +460,12 @@ export function OfficeZoneEditor({ onClose }: Props) {
           </span>
         ))}
         <span>{spots.length} seats</span>
+        <span style={{ display: "flex", alignItems: "center", gap: 3 }}>
+          <span style={{ width: 8, height: 8, borderRadius: 2, background: "rgba(34, 197, 94, 0.8)" }} />
+          {Object.keys(spawnPoints).length} spawns
+        </span>
         <div style={{ flex: 1 }} />
-        <span>P B R: zones · E: erase · H: pan · Scroll: zoom</span>
+        <span>P B R: zones · S: spawn · E: erase · H: pan · Scroll: zoom</span>
       </div>
     </div>
   );

--- a/plugins/mc-board/web/src/components/pixel-office-tab.tsx
+++ b/plugins/mc-board/web/src/components/pixel-office-tab.tsx
@@ -23,11 +23,11 @@ const fetcher = (url: string) => fetch(url).then((r) => r.json());
 
 function cardsToAgents(cards: Card[], activeWorkers: Record<string, string>): ActiveAgent[] {
   return cards
-    .filter((c) => c.column !== "shipped")
+    .filter((c) => c.column !== "shipped" && activeWorkers[c.id] != null)
     .map((c) => ({
       cardId: c.id,
       title: c.title,
-      worker: activeWorkers[c.id] ?? c.id,
+      worker: activeWorkers[c.id],
       column: c.column,
       pickedUpAt: c.updated_at,
     }));

--- a/plugins/mc-board/web/src/lib/pixel-office/engine.ts
+++ b/plugins/mc-board/web/src/lib/pixel-office/engine.ts
@@ -30,7 +30,7 @@ const WALK_SPEED = 48; // px/sec
 const WALK_FRAME_DUR = 0.15;
 const TYPE_FRAME_DUR = 0.3;
 const WANDER_PAUSE_MIN = 3;
-const WANDER_PAUSE_MAX = 15;
+const WANDER_PAUSE_MAX = 6;
 const SEAT_REST_MIN = 30; // shorter than original for demo appeal
 const SEAT_REST_MAX = 60;
 const SITTING_OFFSET = 6;
@@ -390,6 +390,14 @@ function updateCharacter(
       }
 
       const next = ch.path[0];
+
+      // Defensive guard: abort walk if next tile is blocked (furniture placed after path was computed)
+      if (state.blocked.has(`${next.col},${next.row}`)) {
+        ch.path = [];
+        ch.state = CharacterState.IDLE;
+        ch.wanderTimer = rand(WANDER_PAUSE_MIN, WANDER_PAUSE_MAX);
+        break;
+      }
       const fromX = ch.tileCol * TILE_SIZE + TILE_SIZE / 2;
       const fromY = ch.tileRow * TILE_SIZE + TILE_SIZE / 2;
       const toX = next.col * TILE_SIZE + TILE_SIZE / 2;
@@ -1038,15 +1046,24 @@ export function syncAgents(
     const sprites = state.baseSprites[baseIdx];
 
     // Spawn priority: painted spawn zones > zone waypoints > all walkable
+    // Always filter out blocked tiles and seat positions to avoid spawning on furniture
+    const seatPositions = new Set(state.seats.map(s => `${s.col},${s.row}`));
+    const isSafeSpawn = (t: { col: number; row: number }) =>
+      !state.blocked.has(`${t.col},${t.row}`) && !seatPositions.has(`${t.col},${t.row}`);
+
     const zoneWps = state.zoneWaypoints[zone];
-    const spawnPool = state.spawnTiles.length > 0
+    const rawPool = state.spawnTiles.length > 0
       ? state.spawnTiles
       : zoneWps.length > 0
         ? zoneWps
         : state.walkable;
-    const fallback = state.walkable.length > 0
-      ? state.walkable[Math.floor(Math.random() * state.walkable.length)]
-      : { col: 5, row: 5 };
+    const spawnPool = rawPool.filter(isSafeSpawn);
+    const safeWalkable = state.walkable.filter(isSafeSpawn);
+    const fallback = safeWalkable.length > 0
+      ? safeWalkable[Math.floor(Math.random() * safeWalkable.length)]
+      : state.walkable.length > 0
+        ? state.walkable[Math.floor(Math.random() * state.walkable.length)]
+        : { col: 5, row: 5 };
     const spawn = spawnPool.length > 0
       ? spawnPool[Math.floor(Math.random() * spawnPool.length)]
       : fallback;
@@ -1073,6 +1090,8 @@ export function syncAgents(
         freeSeat.assigned = true;
         freeSeat.assignedTo = agent.worker;
         ch.seatId = freeSeat.uid;
+        // Immediately walk to seat on spawn instead of waiting 3-15s
+        ch.wanderTimer = 0;
       }
     }
 


### PR DESCRIPTION
## Summary
- Filter ghost characters: only render cards with active workers (no more phantom agents)
- Safe spawn placement: filter out blocked/seat tiles from spawn candidates with fallback chain
- Reduce WANDER_PAUSE_MAX from 15s to 6s for snappier character wandering
- Immediately walk to assigned seat on spawn (wanderTimer=0 instead of 3-15s delay)
- Add Spawn paint mode to zone editor with green overlay + API persistence
- Defensive pathfinding guard: abort walk if next tile becomes blocked mid-path

## Test plan
- [ ] Verify no ghost characters appear for unassigned cards
- [ ] Confirm characters spawn on walkable tiles, not on furniture/seats
- [ ] Check wander pause feels responsive (max 6s idle)
- [ ] New characters immediately path to their seat after spawning
- [ ] Zone editor: S key activates spawn mode, green tiles persist after save
- [ ] Characters stop walking when hitting newly-placed furniture

Fixes #263