### PR TITLE
fix: version badge shows stable v0.1.7 + mc-rebuild-web script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="#install"><img src="https://img.shields.io/badge/Install_in_60s-FF6D00?style=for-the-badge&logo=apple&logoColor=white" alt="Install in 60s"></a>
   <a href="https://github.com/augmentedmike/miniclaw-os/stargazers"><img src="https://img.shields.io/github/stars/augmentedmike/miniclaw-os?style=for-the-badge&color=yellow" alt="GitHub Stars"></a>
   <a href="https://github.com/augmentedmike/miniclaw-os/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge" alt="Apache 2.0 License"></a>
-  <a href="https://github.com/augmentedmike/miniclaw-os/releases"><img src="https://img.shields.io/badge/version-v0.1.8-prerelease-blue?style=for-the-badge" alt="v0.1.8-prerelease"></a>
+  <a href="https://github.com/augmentedmike/miniclaw-os/releases"><img src="https://img.shields.io/badge/version-v0.1.7-blue?style=for-the-badge" alt="v0.1.7"></a>
   <a href="https://github.com/augmentedmike/miniclaw-os/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/augmentedmike/miniclaw-os/test.yml?branch=stable&style=for-the-badge&label=tests" alt="Tests"></a>
 </p>
 

--- a/SYSTEM/bin/mc-rebuild-web
+++ b/SYSTEM/bin/mc-rebuild-web
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# mc-rebuild-web — rebuild the board web app and restart the LaunchAgent
+set -euo pipefail
+
+WEB_SRC="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}/miniclaw/web"
+STANDALONE="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}/miniclaw/plugins/mc-board/web/.next/standalone"
+PLIST="$HOME/Library/LaunchAgents/com.miniclaw.board-web.plist"
+
+echo "  Syncing source from plugins..."
+rsync -a --exclude='node_modules' --exclude='.next' \
+  "${OPENCLAW_STATE_DIR:-$HOME/.openclaw}/miniclaw/plugins/mc-board/web/src/" "$WEB_SRC/src/"
+
+echo "  Installing deps..."
+cd "$WEB_SRC"
+npm install --silent 2>/dev/null || true
+npm install react react-dom --silent 2>/dev/null || true
+
+echo "  Building..."
+rm -rf .next
+node node_modules/next/dist/bin/next build 2>&1 | tail -3
+
+echo "  Deploying standalone..."
+cp -a .next/standalone/. "$STANDALONE/"
+mkdir -p "$STANDALONE/.next"
+cp -r .next/static "$STANDALONE/.next/static"
+cp -r public "$STANDALONE/public" 2>/dev/null || true
+
+echo "  Restarting..."
+lsof -ti :4220 2>/dev/null | xargs kill -9 2>/dev/null || true
+sleep 1
+launchctl unload "$PLIST" 2>/dev/null || true
+launchctl load "$PLIST" 2>/dev/null
+sleep 2
+
+if lsof -ti :4220 &>/dev/null; then
+  echo "  ✓ Board web running on :4220"
+else
+  echo "  ✗ Failed to start — check logs"
+  exit 1
+fi


### PR DESCRIPTION
Badge was broken due to hyphen in v0.1.8-prerelease. Set to stable v0.1.7. Added mc-rebuild-web for clean build+deploy cycle.