### PR TITLE
feat(mc-kb): embedding model daemon — load once, serve via LaunchAgent

### DIFF
--- a/plugins/mc-email/cli/commands.ts
+++ b/plugins/mc-email/cli/commands.ts
@@ -8,6 +8,13 @@ import type { Logger } from "openclaw/plugin-sdk";
 import type { EmailConfig } from "../src/config.js";
 import { GmailClient } from "../src/client.js";
 import { getAppPassword, saveAppPassword } from "../src/vault.js";
+import {
+  loadTriageState,
+  saveTriageState,
+  filterNewUids,
+  markAllProcessed,
+  pruneState,
+} from "../src/triage-state.js";
 
 interface Ctx {
   program: Command;

--- a/plugins/mc-kb/cli/commands.ts
+++ b/plugins/mc-kb/cli/commands.ts
@@ -6,10 +6,17 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import * as os from "node:os";
+import * as net from "node:net";
+import { execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import type { Command } from "commander";
 import type { KBStore } from "../src/store.js";
 import type { Embedder } from "../src/embedder.js";
 import { hybridSearch } from "../src/search.js";
+
+const __filename_cli = fileURLToPath(import.meta.url);
+const __dirname_cli = path.dirname(__filename_cli);
 import { validateType, VALID_TYPES, type KBEntryCreate, entryToMarkdown } from "../src/entry.js";
 
 export interface CliContext {
@@ -295,6 +302,130 @@ Examples:
         }
       }
       console.log(`  Vector search: ${store.isVecLoaded() ? "enabled" : "disabled (FTS5-only)"}`);
+    });
+
+  // ---- mc-kb embedder ----
+  const embedderCmd = kb
+    .command("embedder")
+    .description("Manage the embedding daemon (LaunchAgent)");
+
+  const STATE_DIR = process.env.OPENCLAW_STATE_DIR ?? path.join(os.homedir(), ".openclaw");
+  const SOCK_PATH = path.join(STATE_DIR, "run", "embedder.sock");
+  const PID_PATH = path.join(STATE_DIR, "run", "embedder.pid");
+  const PLIST_NAME = "com.miniclaw.embedder";
+  const PLIST_SRC = path.join(__dirname_cli, "..", "com.miniclaw.embedder.plist");
+  const PLIST_DEST = path.join(os.homedir(), "Library", "LaunchAgents", `${PLIST_NAME}.plist`);
+  const GUI_DOMAIN = `gui/${process.getuid?.() ?? 501}`;
+
+  embedderCmd
+    .command("start")
+    .description("Install and start the embedding daemon via LaunchAgent")
+    .action(() => {
+      try {
+        // Copy plist to LaunchAgents
+        if (!fs.existsSync(PLIST_SRC)) {
+          console.error(`Plist not found: ${PLIST_SRC}`);
+          process.exit(1);
+        }
+        fs.mkdirSync(path.dirname(PLIST_DEST), { recursive: true });
+        fs.copyFileSync(PLIST_SRC, PLIST_DEST);
+        console.log(`Installed ${PLIST_DEST}`);
+
+        // Load the LaunchAgent
+        try {
+          execSync(`launchctl bootout ${GUI_DOMAIN} ${PLIST_DEST} 2>/dev/null`, { stdio: "ignore" });
+        } catch {}
+        execSync(`launchctl bootstrap ${GUI_DOMAIN} ${PLIST_DEST}`, { stdio: "inherit" });
+        console.log("Embedding daemon started.");
+      } catch (err) {
+        console.error(`Failed to start daemon: ${(err as Error).message}`);
+        process.exit(1);
+      }
+    });
+
+  embedderCmd
+    .command("stop")
+    .description("Stop and unload the embedding daemon")
+    .action(() => {
+      try {
+        execSync(`launchctl bootout gui/$(id -u) ${PLIST_DEST}`, { stdio: "inherit" });
+        console.log("Embedding daemon stopped.");
+      } catch (err) {
+        console.error(`Failed to stop daemon: ${(err as Error).message}`);
+      }
+      // Clean up socket and pid
+      try { fs.unlinkSync(SOCK_PATH); } catch {}
+      try { fs.unlinkSync(PID_PATH); } catch {}
+    });
+
+  embedderCmd
+    .command("status")
+    .description("Check embedding daemon status")
+    .action(async () => {
+      // Check PID file
+      let pid: string | null = null;
+      try {
+        pid = fs.readFileSync(PID_PATH, "utf-8").trim();
+      } catch {}
+
+      // Check if process is alive
+      let processAlive = false;
+      if (pid) {
+        try {
+          process.kill(Number(pid), 0);
+          processAlive = true;
+        } catch {}
+      }
+
+      // Check socket
+      const socketExists = fs.existsSync(SOCK_PATH);
+
+      // Ping daemon
+      let pingOk = false;
+      if (socketExists) {
+        try {
+          pingOk = await new Promise<boolean>((resolve) => {
+            const conn = net.createConnection(SOCK_PATH);
+            const timer = setTimeout(() => { conn.destroy(); resolve(false); }, 2000);
+            conn.on("connect", () => {
+              conn.write(JSON.stringify({ id: "status-check", ping: true }) + "\n");
+            });
+            conn.on("data", (chunk) => {
+              clearTimeout(timer);
+              conn.destroy();
+              try {
+                const resp = JSON.parse(chunk.toString().trim());
+                resolve(resp.pong === true);
+              } catch {
+                resolve(false);
+              }
+            });
+            conn.on("error", () => { clearTimeout(timer); resolve(false); });
+          });
+        } catch {}
+      }
+
+      // Check LaunchAgent
+      let launchAgentLoaded = false;
+      try {
+        const out = execSync(`launchctl print ${GUI_DOMAIN}/${PLIST_NAME} 2>&1`, { encoding: "utf-8" });
+        launchAgentLoaded = out.includes("state =");
+      } catch {}
+
+      console.log("\nEmbedding Daemon Status:");
+      console.log(`  PID:          ${pid ?? "none"} ${processAlive ? "(alive)" : pid ? "(dead)" : ""}`);
+      console.log(`  Socket:       ${socketExists ? SOCK_PATH : "not found"}`);
+      console.log(`  Ping:         ${pingOk ? "OK ✓" : "no response ✗"}`);
+      console.log(`  LaunchAgent:  ${launchAgentLoaded ? "loaded ✓" : "not loaded ✗"}`);
+      console.log();
+
+      if (pingOk) {
+        console.log("  Daemon is running and healthy.");
+      } else if (processAlive) {
+        console.log("  Daemon process exists but not responding — may still be loading model.");
+      } else {
+        console.log("  Daemon is not running. Start with: openclaw mc-kb embedder start");
+      }
     });
 }
 

--- a/plugins/mc-kb/com.miniclaw.embedder.plist
+++ b/plugins/mc-kb/com.miniclaw.embedder.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.miniclaw.embedder</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/michaeloneal/.nvm/versions/node/v24.9.0/bin/node</string>
+    <string>--import</string>
+    <string>tsx</string>
+    <string>/Users/michaeloneal/.openclaw/miniclaw/plugins/mc-kb/src/embed-daemon.ts</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>/Users/michaeloneal/.openclaw/miniclaw/plugins/mc-kb</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>/Users/michaeloneal</string>
+    <key>PATH</key>
+    <string>/Users/michaeloneal/.local/bin:/Users/michaeloneal/.nvm/versions/node/v24.9.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>NODE_PATH</key>
+    <string>/Users/michaeloneal/.openclaw/miniclaw/plugins/mc-kb/node_modules:/Users/michaeloneal/.nvm/versions/node/v24.9.0/lib/node_modules/@miniclaw_official/openclaw/node_modules:/Users/michaeloneal/.openclaw/extensions/node_modules</string>
+    <key>OPENCLAW_STATE_DIR</key>
+    <string>/Users/michaeloneal/.openclaw</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/Users/michaeloneal/.openclaw/logs/embedder.stdout.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/michaeloneal/.openclaw/logs/embedder.stderr.log</string>
+</dict>
+</plist>

--- a/plugins/mc-kb/src/embed-client.ts
+++ b/plugins/mc-kb/src/embed-client.ts
@@ -1,0 +1,148 @@
+/**
+ * mc-kb — Embedding Daemon Client
+ *
+ * Connects to the embedding daemon over Unix domain socket.
+ * Implements IEmbedder interface for transparent use by mc-kb and mc-memory.
+ */
+
+import * as net from "node:net";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import * as crypto from "node:crypto";
+import type { IEmbedder } from "./types.js";
+
+const STATE_DIR = process.env.OPENCLAW_STATE_DIR ?? path.join(os.homedir(), ".openclaw");
+const SOCK_PATH = path.join(STATE_DIR, "run", "embedder.sock");
+
+const DEFAULT_TIMEOUT_MS = 5000;
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (reason: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+export class EmbedClient implements IEmbedder {
+  private readonly sockPath: string;
+  private readonly timeoutMs: number;
+  private readonly dims: number = 768;
+
+  constructor(sockPath?: string, timeoutMs?: number) {
+    this.sockPath = sockPath ?? SOCK_PATH;
+    this.timeoutMs = timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  isReady(): boolean {
+    return fs.existsSync(this.sockPath);
+  }
+
+  getDims(): number {
+    return this.dims;
+  }
+
+  async load(): Promise<void> {
+    // No-op for client — daemon manages model loading
+  }
+
+  async dispose(): Promise<void> {
+    // No-op for client
+  }
+
+  /**
+   * Check if the daemon is available and responding.
+   */
+  async isAvailable(): Promise<boolean> {
+    if (!fs.existsSync(this.sockPath)) return false;
+    try {
+      const id = crypto.randomUUID();
+      const resp = await this._request({ id, ping: true });
+      return (resp as { pong?: boolean }).pong === true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Get embedding vector for text via daemon.
+   */
+  async embed(text: string): Promise<Float32Array | null> {
+    const id = crypto.randomUUID();
+    try {
+      const resp = await this._request({ id, text }) as {
+        id: string;
+        vector?: number[];
+        error?: string;
+      };
+
+      if (resp.error) {
+        console.warn(`[embed-client] Daemon error: ${resp.error}`);
+        return null;
+      }
+
+      if (!resp.vector) return null;
+
+      return new Float32Array(resp.vector);
+    } catch (err) {
+      console.warn(`[embed-client] Request failed: ${(err as Error).message}`);
+      return null;
+    }
+  }
+
+  /**
+   * Send a request to the daemon and wait for the matching response.
+   */
+  private _request(payload: Record<string, unknown>): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const conn = net.createConnection(this.sockPath);
+      let buffer = "";
+      let settled = false;
+
+      const timer = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          conn.destroy();
+          reject(new Error("Daemon request timed out"));
+        }
+      }, this.timeoutMs);
+
+      conn.on("connect", () => {
+        conn.write(JSON.stringify(payload) + "\n");
+      });
+
+      conn.on("data", (chunk) => {
+        buffer += chunk.toString();
+        const newlineIdx = buffer.indexOf("\n");
+        if (newlineIdx !== -1) {
+          const line = buffer.slice(0, newlineIdx).trim();
+          if (!settled) {
+            settled = true;
+            clearTimeout(timer);
+            conn.destroy();
+            try {
+              resolve(JSON.parse(line));
+            } catch (err) {
+              reject(new Error(`Invalid JSON from daemon: ${line}`));
+            }
+          }
+        }
+      });
+
+      conn.on("error", (err) => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
+          reject(err);
+        }
+      });
+
+      conn.on("close", () => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
+          reject(new Error("Connection closed before response"));
+        }
+      });
+    });
+  }
+}

--- a/plugins/mc-kb/src/embed-daemon.ts
+++ b/plugins/mc-kb/src/embed-daemon.ts
@@ -1,0 +1,201 @@
+/**
+ * mc-kb — Embedding Daemon Server
+ *
+ * Loads EmbeddingGemma-300M once and serves embedding vectors over a Unix domain socket.
+ * Protocol: newline-delimited JSON (NDJSON) over Unix socket.
+ *
+ * Request:  {"id":"<uuid>","text":"..."}\n
+ * Response: {"id":"<uuid>","vector":[...]}\n
+ *
+ * Health:   {"id":"<uuid>","ping":true}\n
+ * Response: {"id":"<uuid>","pong":true}\n
+ *
+ * Socket: ~/.openclaw/run/embedder.sock
+ * PID:    ~/.openclaw/run/embedder.pid
+ */
+
+import * as net from "node:net";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { Embedder } from "./embedder.js";
+
+const STATE_DIR = process.env.OPENCLAW_STATE_DIR ?? path.join(os.homedir(), ".openclaw");
+const RUN_DIR = path.join(STATE_DIR, "run");
+const SOCK_PATH = path.join(RUN_DIR, "embedder.sock");
+const PID_PATH = path.join(RUN_DIR, "embedder.pid");
+
+const MODEL_PATH = process.env.EMBEDDER_MODEL_PATH ?? path.join(
+  os.homedir(),
+  ".cache/qmd/models/hf_ggml-org_embeddinggemma-300M-Q8_0.gguf",
+);
+
+interface EmbedRequest {
+  id: string;
+  text?: string;
+  ping?: boolean;
+}
+
+interface EmbedResponse {
+  id: string;
+  vector?: number[];
+  pong?: boolean;
+  error?: string;
+}
+
+function log(msg: string): void {
+  const ts = new Date().toISOString();
+  console.log(`[${ts}] [embed-daemon] ${msg}`);
+}
+
+function cleanup(): void {
+  try { fs.unlinkSync(SOCK_PATH); } catch {}
+  try { fs.unlinkSync(PID_PATH); } catch {}
+}
+
+async function main(): Promise<void> {
+  // Ensure run directory exists
+  fs.mkdirSync(RUN_DIR, { recursive: true });
+
+  // Clean up stale socket
+  if (fs.existsSync(SOCK_PATH)) {
+    try {
+      const client = net.createConnection(SOCK_PATH);
+      await new Promise<void>((resolve, reject) => {
+        client.on("connect", () => { client.destroy(); reject(new Error("Socket in use")); });
+        client.on("error", () => resolve());
+        setTimeout(() => { client.destroy(); resolve(); }, 500);
+      });
+      // If we get here, socket is stale — remove it
+      fs.unlinkSync(SOCK_PATH);
+    } catch (err) {
+      if ((err as Error).message === "Socket in use") {
+        log("Another daemon is already running. Exiting.");
+        process.exit(1);
+      }
+    }
+  }
+
+  // Write PID file
+  fs.writeFileSync(PID_PATH, String(process.pid));
+
+  // Load model
+  log(`Loading model from ${MODEL_PATH}...`);
+  const embedder = new Embedder(MODEL_PATH);
+  await embedder.load();
+
+  if (!embedder.isReady()) {
+    log("Model failed to load. Exiting.");
+    cleanup();
+    process.exit(1);
+  }
+
+  log("Model loaded successfully.");
+
+  // Create Unix domain socket server
+  const server = net.createServer((conn) => {
+    let buffer = "";
+
+    conn.on("data", (chunk) => {
+      buffer += chunk.toString();
+
+      // Process complete lines (NDJSON)
+      let newlineIdx: number;
+      while ((newlineIdx = buffer.indexOf("\n")) !== -1) {
+        const line = buffer.slice(0, newlineIdx).trim();
+        buffer = buffer.slice(newlineIdx + 1);
+
+        if (!line) continue;
+
+        handleRequest(line, conn, embedder);
+      }
+    });
+
+    conn.on("error", (err) => {
+      // Client disconnected — ignore
+      if ((err as NodeJS.ErrnoException).code !== "ECONNRESET") {
+        log(`Connection error: ${err.message}`);
+      }
+    });
+  });
+
+  server.listen(SOCK_PATH, () => {
+    // Make socket accessible
+    fs.chmodSync(SOCK_PATH, 0o660);
+    log(`Listening on ${SOCK_PATH} (pid=${process.pid})`);
+  });
+
+  server.on("error", (err) => {
+    log(`Server error: ${err.message}`);
+    cleanup();
+    process.exit(1);
+  });
+
+  // Graceful shutdown
+  const shutdown = async () => {
+    log("Shutting down...");
+    server.close();
+    await embedder.dispose();
+    cleanup();
+    log("Goodbye.");
+    process.exit(0);
+  };
+
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
+
+  // Handle sleep/wake — re-validate model on SIGCONT
+  process.on("SIGCONT", () => {
+    log("Received SIGCONT (wake from sleep) — model should still be resident in GPU memory.");
+  });
+}
+
+async function handleRequest(
+  line: string,
+  conn: net.Socket,
+  embedder: Embedder,
+): Promise<void> {
+  let req: EmbedRequest;
+  try {
+    req = JSON.parse(line);
+  } catch {
+    const resp: EmbedResponse = { id: "unknown", error: "Invalid JSON" };
+    conn.write(JSON.stringify(resp) + "\n");
+    return;
+  }
+
+  // Health check
+  if (req.ping) {
+    const resp: EmbedResponse = { id: req.id, pong: true };
+    conn.write(JSON.stringify(resp) + "\n");
+    return;
+  }
+
+  // Embedding request
+  if (!req.text) {
+    const resp: EmbedResponse = { id: req.id, error: "Missing 'text' field" };
+    conn.write(JSON.stringify(resp) + "\n");
+    return;
+  }
+
+  try {
+    const vector = await embedder.embed(req.text);
+    if (!vector) {
+      const resp: EmbedResponse = { id: req.id, error: "Embedding failed (model not ready)" };
+      conn.write(JSON.stringify(resp) + "\n");
+      return;
+    }
+
+    const resp: EmbedResponse = { id: req.id, vector: Array.from(vector) };
+    conn.write(JSON.stringify(resp) + "\n");
+  } catch (err) {
+    const resp: EmbedResponse = { id: req.id, error: `Embed error: ${(err as Error).message}` };
+    conn.write(JSON.stringify(resp) + "\n");
+  }
+}
+
+main().catch((err) => {
+  log(`Fatal: ${err}`);
+  cleanup();
+  process.exit(1);
+});

--- a/plugins/mc-kb/src/embedder.ts
+++ b/plugins/mc-kb/src/embedder.ts
@@ -4,11 +4,16 @@
  * Lazy-loads EmbeddingGemma-300M via node-llama-cpp.
  * Metal GPU accelerated on darwin-arm64.
  * Gracefully degrades to null if model unavailable.
+ *
+ * Daemon-aware factory: getEmbedder() tries daemon client first,
+ * falls back to in-process model loading if daemon is unavailable.
  */
 
 import * as os from "node:os";
 import * as path from "node:path";
 import * as fs from "node:fs";
+import type { IEmbedder } from "./types.js";
+import { EmbedClient } from "./embed-client.js";
 
 // Default model path from qmd cache
 const DEFAULT_MODEL_PATH = path.join(
@@ -16,16 +21,30 @@ const DEFAULT_MODEL_PATH = path.join(
   ".cache/qmd/models/hf_ggml-org_embeddinggemma-300M-Q8_0.gguf",
 );
 
-// Resolve node-llama-cpp: own dep first, then openclaw's bundled copy
+// Resolve node-llama-cpp: own dep first, then openclaw's bundled copy.
+// Returns the path to dist/index.js for ESM dynamic import() compatibility.
+import { execSync } from "node:child_process";
+
 function findLlamaPath(): string {
-  try { return path.dirname(require.resolve("node-llama-cpp/package.json")); } catch {}
+  // Try import.meta.resolve (Node 20+)
   try {
-    const { execSync } = require("node:child_process");
+    const resolved = import.meta.resolve("node-llama-cpp");
+    // Converts file:// URL to path
+    return new URL(resolved).pathname;
+  } catch {}
+
+  // Walk up from openclaw binary to find bundled node-llama-cpp
+  try {
     const ocBin = fs.realpathSync(execSync("which openclaw", { encoding: "utf-8" }).trim());
     let dir = path.dirname(ocBin);
     for (let i = 0; i < 5; i++) {
       const candidate = path.join(dir, "node_modules", "node-llama-cpp");
-      if (fs.existsSync(candidate)) return candidate;
+      if (fs.existsSync(candidate)) {
+        // Return the ESM entry point directly for dynamic import()
+        const distIndex = path.join(candidate, "dist", "index.js");
+        if (fs.existsSync(distIndex)) return distIndex;
+        return candidate;
+      }
       dir = path.dirname(dir);
     }
   } catch {}
@@ -39,7 +58,7 @@ type LlamaEmbeddingContext = {
   dispose(): Promise<void>;
 };
 
-export class Embedder {
+export class Embedder implements IEmbedder {
   private ctx: LlamaEmbeddingContext | null = null;
   private loading = false;
   private loadAttempted = false;
@@ -145,12 +164,116 @@ export class Embedder {
   }
 }
 
-// Singleton instance
-let _embedder: Embedder | null = null;
+// Singleton instance — may be EmbedClient (daemon) or Embedder (in-process)
+let _embedder: IEmbedder | null = null;
+let _daemonChecked = false;
 
-export function getEmbedder(modelPath?: string): Embedder {
-  if (!_embedder) {
-    _embedder = new Embedder(modelPath);
+/**
+ * Daemon-aware embedder factory.
+ *
+ * 1. If daemon socket exists and responds to ping → return EmbedClient
+ * 2. Otherwise → return in-process Embedder (loads 313MB model)
+ *
+ * The check is done once per process lifetime; subsequent calls return the cached instance.
+ */
+export function getEmbedder(modelPath?: string): IEmbedder {
+  if (_embedder) return _embedder;
+
+  // Synchronous check: does the socket file exist?
+  const client = new EmbedClient();
+  if (client.isReady()) {
+    // Socket file exists — optimistically use the client.
+    // If daemon is actually dead, embed() calls will fail and callers
+    // handle null returns gracefully (same as model-not-found).
+    // We also kick off an async ping to verify, and swap to in-process if needed.
+    _embedder = new DaemonAwareEmbedder(client, modelPath);
+    return _embedder;
   }
+
+  // No daemon socket — use in-process embedder
+  _embedder = new Embedder(modelPath);
   return _embedder;
 }
+
+/**
+ * Wraps EmbedClient with automatic fallback to in-process Embedder.
+ * If the first daemon call fails, transparently switches to in-process.
+ */
+class DaemonAwareEmbedder implements IEmbedder {
+  private client: EmbedClient;
+  private fallback: Embedder | null = null;
+  private useDaemon = true;
+  private daemonVerified = false;
+  private readonly modelPath?: string;
+
+  constructor(client: EmbedClient, modelPath?: string) {
+    this.client = client;
+    this.modelPath = modelPath;
+  }
+
+  isReady(): boolean {
+    if (this.useDaemon) return this.client.isReady();
+    return this.fallback?.isReady() ?? false;
+  }
+
+  getDims(): number {
+    return 768;
+  }
+
+  async load(): Promise<void> {
+    // Try to verify daemon is alive
+    if (this.useDaemon && !this.daemonVerified) {
+      const available = await this.client.isAvailable();
+      if (available) {
+        this.daemonVerified = true;
+        console.log("[mc-kb/embedder] Using embedding daemon via Unix socket");
+        return;
+      }
+      // Daemon not responding — fall back
+      console.log("[mc-kb/embedder] Daemon socket exists but not responding — falling back to in-process");
+      this.useDaemon = false;
+    }
+
+    if (!this.useDaemon) {
+      if (!this.fallback) this.fallback = new Embedder(this.modelPath);
+      await this.fallback.load();
+    }
+  }
+
+  async embed(text: string): Promise<Float32Array | null> {
+    if (this.useDaemon) {
+      // Try daemon first
+      if (!this.daemonVerified) {
+        await this.load();
+      }
+
+      if (this.useDaemon) {
+        const result = await this.client.embed(text);
+        if (result !== null) return result;
+
+        // Daemon failed — check if it's really down
+        const available = await this.client.isAvailable();
+        if (!available) {
+          console.log("[mc-kb/embedder] Daemon went away — falling back to in-process");
+          this.useDaemon = false;
+        } else {
+          // Daemon is up but embed returned null — actual embedding failure
+          return null;
+        }
+      }
+    }
+
+    // In-process fallback
+    if (!this.fallback) {
+      this.fallback = new Embedder(this.modelPath);
+      await this.fallback.load();
+    }
+    return this.fallback.embed(text);
+  }
+
+  async dispose(): Promise<void> {
+    if (this.fallback) await this.fallback.dispose();
+  }
+}
+
+export type { IEmbedder };

--- a/plugins/mc-kb/src/types.ts
+++ b/plugins/mc-kb/src/types.ts
@@ -1,0 +1,13 @@
+/**
+ * mc-kb — Shared type definitions
+ *
+ * IEmbedder: common interface for both in-process and daemon-backed embedders.
+ */
+
+export interface IEmbedder {
+  isReady(): boolean;
+  embed(text: string): Promise<Float32Array | null>;
+  load(): Promise<void>;
+  getDims(): number;
+  dispose?(): Promise<void>;
+}


### PR DESCRIPTION
## Summary

- Adds persistent embedding daemon that loads EmbeddingGemma-300M once and serves vectors over a Unix socket (`~/.openclaw/run/embedder.sock`)
- Daemon client (`embed-client.ts`) implements `IEmbedder` interface — transparent drop-in for in-process loading
- `getEmbedder()` factory auto-detects daemon availability, falls back to in-process loading
- LaunchAgent plist (`com.miniclaw.embedder.plist`) keeps daemon alive with `RunAtLoad` + `KeepAlive`
- CLI: `openclaw mc-kb embedder start|stop|status`
- Handles concurrent requests from multiple CLI processes

Closes #306

## Test plan

- [ ] Start daemon via `openclaw mc-kb embedder start`, verify socket created
- [ ] Run `mc-kb search` — confirm daemon used (no model load log)
- [ ] Kill daemon, run `mc-kb search` — confirm fallback to in-process
- [ ] Test concurrent requests from multiple terminals
- [ ] Verify LaunchAgent auto-starts on login