### PR TITLE
feat(mc-board): unique character per active card in pixel office

### DIFF
--- a/plugins/mc-board/web/src/components/pixel-office-tab.tsx
+++ b/plugins/mc-board/web/src/components/pixel-office-tab.tsx
@@ -27,7 +27,7 @@ function cardsToAgents(cards: Card[], activeWorkers: Record<string, string>): Ac
     .map((c) => ({
       cardId: c.id,
       title: c.title,
-      worker: activeWorkers[c.id],
+      worker: c.id,
       column: c.column,
       pickedUpAt: c.updated_at,
     }));


### PR DESCRIPTION
## Summary
- Fix deduplication bug in `cardsToAgents()` where `activeWorkers[c.id]` (the worker name) was used as character ID, causing all active cards to collapse into one character since they share the same worker name (e.g. `board-worker-in-progress`)
- Changed to use `c.id` (card ID like `crd_*`) which is always unique, so each active card spawns its own character

## Test plan
- [ ] Create 2+ in-progress cards and verify each spawns a separate character in the pixel office
- [ ] Verify characters are removed when their card leaves in-progress
- [ ] Verify no TypeScript compilation errors (Next.js build passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)