### PR TITLE
feat(mc-memory): paginate list command

### DIFF
--- a/plugins/mc-memory/cli/commands.ts
+++ b/plugins/mc-memory/cli/commands.ts
@@ -131,8 +131,10 @@ export function registerMemoryCommands(
     .command("list")
     .description("List individual episodic memory entries")
     .option("--days <daysBack>", "Days of memory to show", "7")
+    .option("--page <page>", "Page number (default 1)", "1")
+    .option("--limit <limit>", "Entries per page (default 10)", "10")
     .option("--json", "Output as JSON")
-    .action(async (opts: { days: string; json?: boolean }) => {
+    .action(async (opts: { days: string; page: string; limit: string; json?: boolean }) => {
       try {
         const fs = await import("node:fs");
         const path = await import("node:path");
@@ -144,17 +146,34 @@ export function registerMemoryCommands(
 
         const now = new Date();
         const daysBack = parseInt(opts.days, 10);
+        const page = Math.max(1, parseInt(opts.page, 10));
+        const limit = Math.max(1, parseInt(opts.limit, 10));
         const cutoff = new Date(now.getTime() - daysBack * 24 * 60 * 60 * 1000);
         const cutoffStr = cutoff.toISOString().slice(0, 10);
 
-        const files = fs.readdirSync(episodicDir)
+        const allFiles = fs.readdirSync(episodicDir)
           .filter((f: string) => f.endsWith(".md"))
           .filter((f: string) => f.slice(0, 10) >= cutoffStr)
           .sort()
           .reverse();
 
-        if (files.length === 0) {
+        const total = allFiles.length;
+
+        if (total === 0) {
           console.log("No episodic memories found in the last " + daysBack + " days.");
+          return;
+        }
+
+        const totalPages = Math.ceil(total / limit);
+        const start = (page - 1) * limit;
+        const files = allFiles.slice(start, start + limit);
+
+        if (files.length === 0) {
+          if (opts.json) {
+            console.log(JSON.stringify({ entries: [], page, totalPages, total }, null, 2));
+          } else {
+            console.log("No entries on this page.");
+          }
           return;
         }
 
@@ -169,7 +188,7 @@ export function registerMemoryCommands(
               preview: body.trim().slice(0, 120).replace(/\n/g, " "),
             };
           });
-          console.log(JSON.stringify(entries, null, 2));
+          console.log(JSON.stringify({ entries, page, totalPages, total }, null, 2));
           return;
         }
 
@@ -182,6 +201,11 @@ export function registerMemoryCommands(
           console.log(`[${date}] ${slug}`);
           console.log(`  ${body.trim().slice(0, 120).replace(/\n/g, " ")}`);
           console.log();
+        }
+
+        if (totalPages > 1) {
+          console.log(`Page ${page} of ${totalPages} (${total} total entries)`);
+          console.log(`Use --page N to see more`);
         }
       } catch (e) {
         console.error(`Error: ${e instanceof Error ? e.message : e}`);


### PR DESCRIPTION
## Summary
- Adds `--page` (default 1) and `--limit` (default 10) options to the episodic memory `list` command
- Text output shows pagination footer ("Page X of Y (Z total entries)") when multiple pages exist
- JSON output wraps entries in `{ entries, page, totalPages, total }` metadata object
- Pages beyond range return "No entries on this page" message

Card: crd_7cc72c4e

## Test plan
- [x] `openclaw list --days 30` shows max 10 entries with pagination footer
- [x] `openclaw list --days 30 --limit 3 --page 1` shows 3 entries
- [x] `openclaw list --days 30 --page 999` shows "No entries on this page"
- [x] `openclaw list --days 30 --json` returns `{ entries, page, totalPages, total }` shape
- [x] Default behavior (no flags) limits to 10 entries