### PR TITLE
feat(mc-board): move version pill to stats row, group chat+alert

### DIFF
--- a/mc-board/web/src/components/app-shell.tsx
+++ b/mc-board/web/src/components/app-shell.tsx
@@ -310,10 +310,18 @@ export function AppShell({ initialTab, initialCardId, initialProjectId }: { init
             <span className="stat-pill" data-col="in-review"><span className="pill-label">in&nbsp;review</span><b>{counts.inReview}</b></span>
             <span className="stat-pill" data-col="shipped"><span className="pill-label">shipped</span><b>{counts.shipped}</b></span>
             <DailyStats />
+            {healthData?.version && (
+              <span className="stat-pill" data-col="version" title={`Version ${healthData.version}`}>
+                <span className="pill-label">version</span><b>v{healthData.version}</b>
+              </span>
+            )}
           </div>
         )}
 
-        {/* Chat toggle */}
+        {/* Health indicator dots */}
+        <HealthDots services={healthData?.services} />
+
+        {/* Chat toggle + Alert button (grouped) */}
         <button
           onClick={toggleChat}
           className="top-bar-icon-btn"
@@ -324,14 +332,6 @@ export function AppShell({ initialTab, initialCardId, initialProjectId }: { init
             <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
           </svg>
         </button>
-
-        {/* Health indicator dots */}
-        <HealthDots services={healthData?.services} />
-
-        {/* Far right: version badge + alerts icon */}
-        <span className="version-badge">
-          {healthData?.version && <>v{healthData.version}</>}
-        </span>
         <button
           onClick={toggleNotifs}
           className="top-bar-icon-btn"


### PR DESCRIPTION
## Summary
- Replace memory stat-pill with version badge in the stat-pills row (sourced from /api/health)
- Remove standalone version-badge that sat between chat toggle and alert button
- Move HealthDots before the chat+alert group so buttons are adjacent

## Test plan
- [ ] Verify version pill appears in stat-pills row with correct version from /api/health
- [ ] Verify memory pill is no longer shown in stats bar
- [ ] Verify chat toggle and alert button are directly adjacent
- [ ] Verify mobile menu layout is unaffected