### PR TITLE
feat(mc-board): add 3 health indicator dots (Web, Chat, TG)

### DIFF
--- a/plugins/mc-board/web/src/app/api/health/route.ts
+++ b/plugins/mc-board/web/src/app/api/health/route.ts
@@ -1,11 +1,13 @@
 import { NextResponse } from "next/server";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import * as net from "node:net";
 
 export const dynamic = "force-dynamic";
 
+const stateDir = process.env.OPENCLAW_STATE_DIR || path.join(process.env.HOME || "", ".openclaw");
+
 function getVersion(): string {
-  const stateDir = process.env.OPENCLAW_STATE_DIR || path.join(process.env.HOME || "", ".openclaw");
   try {
     const manifest = JSON.parse(fs.readFileSync(path.join(stateDir, "miniclaw", "MANIFEST.json"), "utf-8"));
     return manifest.version || "0.0.0";
@@ -14,6 +16,75 @@ function getVersion(): string {
   }
 }
 
-export function GET() {
-  return NextResponse.json({ ok: true, version: getVersion(), time: new Date().toISOString() });
+async function checkWeb(): Promise<{ status: "ok" | "down" }> {
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 3000);
+    const res = await fetch("http://127.0.0.1:4221/health", { signal: ctrl.signal });
+    clearTimeout(timer);
+    if (res.ok) return { status: "ok" };
+    return { status: "down" };
+  } catch {
+    return { status: "down" };
+  }
+}
+
+async function checkChat(): Promise<{ status: "ok" | "down" }> {
+  const sockPath = path.join(stateDir, "chat.sock");
+  return new Promise((resolve) => {
+    try {
+      if (!fs.existsSync(sockPath)) {
+        resolve({ status: "down" });
+        return;
+      }
+      const sock = net.createConnection(sockPath, () => {
+        sock.destroy();
+        resolve({ status: "ok" });
+      });
+      sock.on("error", () => {
+        sock.destroy();
+        resolve({ status: "down" });
+      });
+      sock.setTimeout(3000, () => {
+        sock.destroy();
+        resolve({ status: "down" });
+      });
+    } catch {
+      resolve({ status: "down" });
+    }
+  });
+}
+
+async function checkTelegram(): Promise<{ status: "ok" | "down" | "unconfigured" }> {
+  try {
+    const setupPath = path.join(stateDir, "setup-state.json");
+    if (!fs.existsSync(setupPath)) return { status: "unconfigured" };
+    const setup = JSON.parse(fs.readFileSync(setupPath, "utf-8"));
+    const token = setup?.telegram?.bot_token || setup?.telegramBotToken;
+    if (!token) return { status: "unconfigured" };
+    // Token exists — try getMe to verify
+    try {
+      const ctrl = new AbortController();
+      const timer = setTimeout(() => ctrl.abort(), 3000);
+      const res = await fetch(`https://api.telegram.org/bot${token}/getMe`, { signal: ctrl.signal });
+      clearTimeout(timer);
+      const data = await res.json();
+      return { status: data.ok ? "ok" : "down" };
+    } catch {
+      // Token exists but API unreachable — still "configured but down"
+      return { status: "down" };
+    }
+  } catch {
+    return { status: "unconfigured" };
+  }
+}
+
+export async function GET() {
+  const [web, chat, telegram] = await Promise.all([checkWeb(), checkChat(), checkTelegram()]);
+  return NextResponse.json({
+    ok: true,
+    version: getVersion(),
+    time: new Date().toISOString(),
+    services: { web, chat, telegram },
+  });
 }

--- a/plugins/mc-board/web/src/app/globals.css
+++ b/plugins/mc-board/web/src/app/globals.css
@@ -1022,3 +1022,42 @@ a { color: inherit; }
 .card-markdown th { background: #27272a; color: #e4e4e7; font-weight: 600; }
 .card-markdown img { max-width: 100%; border-radius: 6px; margin: 1rem 0; }
 .card-markdown > h1 + *, .card-markdown > h2 + *, .card-markdown > h3 + * { margin-top: 0.4rem; }
+
+/* ── Health indicator dots ── */
+.health-dots {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 12px;
+  border-left: 1px solid #27272a;
+  height: 100%;
+  flex-shrink: 0;
+}
+.health-dot-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: default;
+}
+.health-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  transition: background .3s;
+}
+.health-dot-label {
+  font-size: 10px;
+  color: #71717a;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+/* Hide health dot labels at narrow widths, keep dots */
+@media (max-width: 1100px) {
+  .health-dot-label { display: none; }
+  .health-dots { gap: 6px; padding: 0 8px; }
+}
+@media (max-width: 768px) {
+  .health-dots { display: none; }
+}

--- a/plugins/mc-board/web/src/components/app-shell.tsx
+++ b/plugins/mc-board/web/src/components/app-shell.tsx
@@ -8,6 +8,7 @@ import { AgentsTab } from "./agents-tab";
 import { Modal } from "./modal";
 import { ChatPanel } from "./chat-panel";
 import { WelcomeWizard, useWelcomeWizard } from "./welcome-wizard";
+import { HealthDots } from "./health-dots";
 import { Project, BoardCard } from "@/lib/types";
 
 import useSWR from "swr";
@@ -75,7 +76,14 @@ export function AppShell({ initialTab, initialCardId, initialProjectId }: { init
   const [assistantName, setAssistantName] = useState("Am");
   const { data: rolodexCount } = useSWR<{ count: number }>("/api/rolodex/count", fetcher, { refreshInterval: 60000 });
   const { data: memoryStats } = useSWR<{ memoryFiles: number; kbEntries: number; total: number }>("/api/memory/stats", fetcher, { refreshInterval: 60000 });
-  const { data: health } = useSWR<{ version: string }>("/api/health", fetcher, { refreshInterval: 300000 });
+  const { data: health } = useSWR<{
+    ok: boolean; version: string; time: string;
+    services?: {
+      web: { status: "ok" | "down" | "unconfigured" };
+      chat: { status: "ok" | "down" | "unconfigured" };
+      telegram: { status: "ok" | "down" | "unconfigured" };
+    };
+  }>("/api/health", fetcher, { refreshInterval: 60000 });
 
   // Fetch assistant name for empty-state message
   useEffect(() => {
@@ -294,6 +302,9 @@ export function AppShell({ initialTab, initialCardId, initialProjectId }: { init
               fill="currentColor" />
           </svg>
         </button>
+        {/* Health indicator dots */}
+        <HealthDots services={health?.services} />
+
         {health?.version && (
           <span className="flex items-center px-3 border-l border-zinc-800 text-zinc-500 text-xs font-mono shrink-0 h-full">
             v{health.version}

--- a/plugins/mc-board/web/src/components/health-dots.tsx
+++ b/plugins/mc-board/web/src/components/health-dots.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+interface ServiceStatus {
+  status: "ok" | "down" | "unconfigured";
+}
+
+interface HealthDotsProps {
+  services?: {
+    web: ServiceStatus;
+    chat: ServiceStatus;
+    telegram: ServiceStatus;
+  };
+}
+
+function dotColor(s?: ServiceStatus): string {
+  if (!s) return "#71717a"; // gray — loading
+  if (s.status === "ok") return "#4ade80";
+  if (s.status === "down") return "#ef4444";
+  return "#71717a"; // unconfigured
+}
+
+function dotLabel(s?: ServiceStatus): string {
+  if (!s) return "checking...";
+  if (s.status === "ok") return "connected";
+  if (s.status === "down") return "unreachable";
+  return "not configured";
+}
+
+export function HealthDots({ services }: HealthDotsProps) {
+  const dots: { key: string; label: string; svc?: ServiceStatus }[] = [
+    { key: "Web", label: "Web", svc: services?.web },
+    { key: "Chat", label: "Chat", svc: services?.chat },
+    { key: "TG", label: "TG", svc: services?.telegram },
+  ];
+
+  return (
+    <div className="health-dots">
+      {dots.map(({ key, label, svc }) => (
+        <span key={key} className="health-dot-item" title={`${label}: ${dotLabel(svc)}`}>
+          <span
+            className="health-dot"
+            style={{ background: dotColor(svc) }}
+          />
+          <span className="health-dot-label">{label}</span>
+        </span>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Extend `/api/health` endpoint to check Web (mc-web-chat at :4221), Chat (unix socket), and Telegram (bot token + getMe API) services
- New `HealthDots` component renders 3 colored dots (green=ok, red=down, gray=unconfigured) with tooltip labels in the top bar
- Auto-refreshes via existing SWR polling at 60s interval; responsive CSS hides labels <1100px and dots entirely <768px

## Test plan
- [ ] Verify health endpoint returns `services.web`, `services.chat`, `services.telegram` fields
- [ ] Confirm 3 dots visible in top bar with correct colors based on service state
- [ ] Check tooltips show service name + status on hover
- [ ] Verify responsive behavior at narrow widths

Card: crd_18e9856f