### PR TITLE
feat(mc-kb): add vitest coverage for store CRUD/FTS and hybridSearch

### DIFF
--- a/plugins/mc-kb/src/search.test.ts
+++ b/plugins/mc-kb/src/search.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { KBStore } from "./store.js";
+import { hybridSearch } from "./search.js";
+import type { IEmbedder } from "./types.js";
+import type { KBEntryCreate } from "./entry.js";
+
+/** Mock embedder that always returns null vectors (FTS-only path) */
+class NullEmbedder implements IEmbedder {
+  isReady(): boolean {
+    return false;
+  }
+  getDims(): number {
+    return 768;
+  }
+  async load(): Promise<void> {}
+  async embed(_text: string): Promise<Float32Array | null> {
+    return null;
+  }
+}
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "mc-kb-search-test-"));
+}
+
+function sampleEntry(overrides: Partial<KBEntryCreate> = {}): KBEntryCreate {
+  return {
+    type: "fact",
+    title: "Test Entry",
+    content: "Generic test content.",
+    tags: [],
+    ...overrides,
+  };
+}
+
+describe("hybridSearch", () => {
+  let dir: string;
+  let store: KBStore;
+  let embedder: NullEmbedder;
+
+  beforeEach(() => {
+    dir = makeTmpDir();
+    store = new KBStore(dir);
+    embedder = new NullEmbedder();
+
+    // Seed data
+    store.add(
+      sampleEntry({
+        type: "guide",
+        title: "Docker Setup Guide",
+        content: "Install Docker on macOS using Homebrew. Configure daemon settings.",
+        tags: ["docker", "setup"],
+      }),
+    );
+    store.add(
+      sampleEntry({
+        type: "fact",
+        title: "PostgreSQL Tuning",
+        content: "Optimize PostgreSQL with shared_buffers and work_mem settings.",
+        tags: ["postgres", "performance"],
+      }),
+    );
+    store.add(
+      sampleEntry({
+        type: "error",
+        title: "Docker Build Failure",
+        content: "Docker build fails when COPY references files outside context.",
+        tags: ["docker", "error"],
+      }),
+    );
+    store.add(
+      sampleEntry({
+        type: "workflow",
+        title: "CI Pipeline Setup",
+        content: "Configure GitHub Actions with Docker containers for testing.",
+        tags: ["ci", "docker"],
+      }),
+    );
+  });
+
+  afterEach(() => {
+    store.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // ── FTS-only search (null embedder) ───────────────────────────────
+
+  it("returns results via FTS when embedder returns null vectors", async () => {
+    const results = await hybridSearch(store, embedder, "Docker");
+    expect(results.length).toBeGreaterThan(0);
+    // All results should have entry, score
+    for (const r of results) {
+      expect(r.entry).toBeDefined();
+      expect(r.entry.id).toMatch(/^kb_/);
+      expect(typeof r.score).toBe("number");
+      expect(r.score).toBeGreaterThan(0);
+    }
+  });
+
+  it("returns results ranked by RRF score (higher = better)", async () => {
+    const results = await hybridSearch(store, embedder, "Docker");
+    if (results.length >= 2) {
+      expect(results[0].score).toBeGreaterThanOrEqual(results[1].score);
+    }
+  });
+
+  // ── Type / tag filtering ──────────────────────────────────────────
+
+  it("filters results by type", async () => {
+    const results = await hybridSearch(store, embedder, "Docker", {
+      type: "guide",
+    });
+    expect(results.length).toBeGreaterThan(0);
+    for (const r of results) {
+      expect(r.entry.type).toBe("guide");
+    }
+  });
+
+  it("filters results by tag", async () => {
+    const results = await hybridSearch(store, embedder, "Docker", {
+      tag: "error",
+    });
+    expect(results.length).toBeGreaterThan(0);
+    for (const r of results) {
+      expect(r.entry.tags).toContain("error");
+    }
+  });
+
+  it("filters by both type and tag", async () => {
+    const results = await hybridSearch(store, embedder, "Docker", {
+      type: "error",
+      tag: "docker",
+    });
+    expect(results.length).toBe(1);
+    expect(results[0].entry.title).toBe("Docker Build Failure");
+  });
+
+  // ── n limit ───────────────────────────────────────────────────────
+
+  it("respects n limit", async () => {
+    const results = await hybridSearch(store, embedder, "Docker", { n: 1 });
+    expect(results.length).toBeLessThanOrEqual(1);
+  });
+
+  // ── Empty query ───────────────────────────────────────────────────
+
+  it("returns fallback results for empty query (substring matches all)", async () => {
+    // Empty string query: FTS returns nothing, substring fallback matches everything
+    // since every string .includes("")
+    const results = await hybridSearch(store, embedder, "");
+    // All results come from substring fallback with score 0.1
+    for (const r of results) {
+      expect(r.score).toBe(0.1);
+    }
+  });
+
+  // ── Substring fallback ────────────────────────────────────────────
+
+  it("falls back to substring match when FTS returns nothing", async () => {
+    // Add an entry with a unique string that FTS tokenizer may not match well
+    store.add(
+      sampleEntry({
+        title: "XyZ123 Special Token",
+        content: "This entry contains the unique marker QwErTy99 for testing substring fallback.",
+        tags: ["fallback"],
+      }),
+    );
+
+    // Search for the exact unique marker — FTS porter tokenizer + multi-strategy
+    // may not find it, triggering substring fallback
+    const results = await hybridSearch(store, embedder, "QwErTy99");
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].entry.content).toContain("QwErTy99");
+  });
+
+  it("substring fallback respects type filter", async () => {
+    store.add(
+      sampleEntry({
+        type: "lesson",
+        title: "Zzz Unique Lesson",
+        content: "UniqueMarker777 lesson content.",
+        tags: [],
+      }),
+    );
+    store.add(
+      sampleEntry({
+        type: "fact",
+        title: "Zzz Unique Fact",
+        content: "UniqueMarker777 fact content.",
+        tags: [],
+      }),
+    );
+
+    const results = await hybridSearch(store, embedder, "UniqueMarker777", {
+      type: "lesson",
+    });
+    // Should find only the lesson type
+    for (const r of results) {
+      expect(r.entry.type).toBe("lesson");
+    }
+  });
+});

--- a/plugins/mc-kb/src/store.test.ts
+++ b/plugins/mc-kb/src/store.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { KBStore } from "./store.js";
+import type { KBEntryCreate } from "./entry.js";
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "mc-kb-test-"));
+}
+
+function sampleEntry(overrides: Partial<KBEntryCreate> = {}): KBEntryCreate {
+  return {
+    type: "fact",
+    title: "Test Entry",
+    content: "This is test content about knowledge base operations.",
+    tags: ["test", "sample"],
+    ...overrides,
+  };
+}
+
+describe("KBStore", () => {
+  let dir: string;
+  let store: KBStore;
+
+  beforeEach(() => {
+    dir = makeTmpDir();
+    store = new KBStore(dir);
+  });
+
+  afterEach(() => {
+    store.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // ── CRUD ──────────────────────────────────────────────────────────
+
+  describe("CRUD", () => {
+    it("add creates and returns an entry with generated ID", () => {
+      const entry = store.add(sampleEntry());
+      expect(entry.id).toMatch(/^kb_[0-9a-f]{8}$/);
+      expect(entry.title).toBe("Test Entry");
+      expect(entry.tags).toEqual(["test", "sample"]);
+      expect(entry.created_at).toBeTruthy();
+      expect(entry.updated_at).toBeTruthy();
+    });
+
+    it("add uses provided ID when given", () => {
+      const entry = store.add(sampleEntry({ id: "kb_custom01" } as any));
+      expect(entry.id).toBe("kb_custom01");
+    });
+
+    it("get retrieves an existing entry by ID", () => {
+      const created = store.add(sampleEntry());
+      const fetched = store.get(created.id);
+      expect(fetched).toBeDefined();
+      expect(fetched!.id).toBe(created.id);
+      expect(fetched!.title).toBe(created.title);
+      expect(fetched!.content).toBe(created.content);
+      expect(fetched!.tags).toEqual(created.tags);
+    });
+
+    it("get returns undefined for missing ID", () => {
+      const result = store.get("kb_nonexist");
+      expect(result).toBeUndefined();
+    });
+
+    it("update modifies an existing entry", () => {
+      const created = store.add(
+        sampleEntry({ created_at: "2025-01-01T00:00:00.000Z", updated_at: "2025-01-01T00:00:00.000Z" }),
+      );
+      const updated = store.update(created.id, {
+        title: "Updated Title",
+        content: "Updated content.",
+      });
+      expect(updated.title).toBe("Updated Title");
+      expect(updated.content).toBe("Updated content.");
+      expect(updated.tags).toEqual(created.tags); // unchanged
+      // updated_at should be newer than the fixed old timestamp
+      expect(updated.updated_at).not.toBe("2025-01-01T00:00:00.000Z");
+    });
+
+    it("update throws for non-existent entry", () => {
+      expect(() => store.update("kb_nonexist", { title: "nope" })).toThrow(
+        "Entry not found",
+      );
+    });
+
+    it("remove deletes an entry", () => {
+      const created = store.add(sampleEntry());
+      store.remove(created.id);
+      expect(store.get(created.id)).toBeUndefined();
+    });
+
+    it("remove is idempotent for missing ID", () => {
+      // Should not throw
+      store.remove("kb_nonexist");
+    });
+  });
+
+  // ── List / Filter ─────────────────────────────────────────────────
+
+  describe("list", () => {
+    beforeEach(() => {
+      store.add(sampleEntry({ type: "fact", title: "Fact A", tags: ["alpha"] }));
+      store.add(sampleEntry({ type: "guide", title: "Guide B", tags: ["beta"] }));
+      store.add(sampleEntry({ type: "fact", title: "Fact C", tags: ["alpha", "beta"] }));
+      store.add(sampleEntry({ type: "error", title: "Error D", tags: ["gamma"] }));
+    });
+
+    it("returns all entries when no filter", () => {
+      const all = store.list();
+      expect(all.length).toBe(4);
+    });
+
+    it("filters by type", () => {
+      const facts = store.list({ type: "fact" });
+      expect(facts.length).toBe(2);
+      expect(facts.every((e) => e.type === "fact")).toBe(true);
+    });
+
+    it("filters by tag", () => {
+      const alphas = store.list({ tag: "alpha" });
+      expect(alphas.length).toBe(2);
+      expect(alphas.every((e) => e.tags.includes("alpha"))).toBe(true);
+    });
+
+    it("filters by type and tag together", () => {
+      const results = store.list({ type: "fact", tag: "beta" });
+      expect(results.length).toBe(1);
+      expect(results[0].title).toBe("Fact C");
+    });
+
+    it("respects limit", () => {
+      const limited = store.list({ limit: 2 });
+      expect(limited.length).toBe(2);
+    });
+  });
+
+  // ── Stats ─────────────────────────────────────────────────────────
+
+  describe("stats", () => {
+    it("returns correct counts by type", () => {
+      store.add(sampleEntry({ type: "fact" }));
+      store.add(sampleEntry({ type: "fact" }));
+      store.add(sampleEntry({ type: "guide" }));
+
+      const s = store.stats();
+      expect(s.total).toBe(3);
+      expect(s.fact).toBe(2);
+      expect(s.guide).toBe(1);
+    });
+
+    it("returns zero total for empty store", () => {
+      const s = store.stats();
+      expect(s.total).toBe(0);
+    });
+  });
+
+  // ── FTS Search ────────────────────────────────────────────────────
+
+  describe("ftsSearch", () => {
+    beforeEach(() => {
+      store.add(
+        sampleEntry({
+          title: "Docker Setup Guide",
+          content: "How to install and configure Docker containers for deployment.",
+        }),
+      );
+      store.add(
+        sampleEntry({
+          title: "PostgreSQL Backup",
+          content: "Running pg_dump to create database backups on a schedule.",
+        }),
+      );
+      store.add(
+        sampleEntry({
+          title: "Kubernetes Orchestration",
+          content: "Deploy containers with Kubernetes and manage Docker images.",
+        }),
+      );
+    });
+
+    it("finds entries by single keyword", () => {
+      const results = store.ftsSearch("Docker");
+      expect(results.length).toBeGreaterThan(0);
+      // All results should have an id and rank
+      for (const r of results) {
+        expect(r.id).toMatch(/^kb_/);
+        expect(typeof r.rank).toBe("number");
+      }
+    });
+
+    it("finds entries matching multiple keywords (AND)", () => {
+      const results = store.ftsSearch("Docker containers");
+      expect(results.length).toBeGreaterThan(0);
+    });
+
+    it("falls back to OR when AND returns nothing", () => {
+      // "PostgreSQL" + "containers" won't both appear in any single entry
+      // AND fails, OR should find entries with either word
+      const results = store.ftsSearch("PostgreSQL containers");
+      expect(results.length).toBeGreaterThan(0);
+    });
+
+    it("returns empty array for empty query", () => {
+      const results = store.ftsSearch("");
+      expect(results).toEqual([]);
+    });
+
+    it("returns empty array for whitespace-only query", () => {
+      const results = store.ftsSearch("   ");
+      expect(results).toEqual([]);
+    });
+
+    it("handles special characters gracefully", () => {
+      // Should not throw, may return empty
+      const results = store.ftsSearch("docker's [v2.0] {config}");
+      // Just verify no crash — results depend on tokenizer handling
+      expect(Array.isArray(results)).toBe(true);
+    });
+
+    it("porter stemming matches word variants", () => {
+      // 'running' should match 'Running' in the pg_dump entry via porter stemmer
+      const results = store.ftsSearch("running");
+      expect(results.length).toBeGreaterThan(0);
+    });
+
+    it("respects limit parameter", () => {
+      const results = store.ftsSearch("Docker", 1);
+      expect(results.length).toBeLessThanOrEqual(1);
+    });
+
+    it("ranks results by BM25 (negative, lower = better)", () => {
+      const results = store.ftsSearch("Docker");
+      if (results.length >= 2) {
+        // Results should be ordered by rank ascending (more negative = better match)
+        expect(results[0].rank).toBeLessThanOrEqual(results[1].rank);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `store.test.ts` — 24 tests covering KBStore CRUD (add, get, update, remove), list filters (by type, tag, limit), FTS search (keyword, multi-word, OR fallback, empty query, special chars, porter stemming, BM25 ranking), and stats
- Add `search.test.ts` — 9 tests covering hybridSearch with mocked NullEmbedder (FTS-only path), type/tag filtering, n limit, substring fallback, and RRF score ordering
- All 33 tests pass via vitest

Closes card crd_ea9364f0

## Test plan
- [x] `npx vitest run` passes all 35 tests (33 new + 2 existing smoke)
- [x] Tests use tmpdir isolation with proper cleanup
- [x] No external dependencies required (sqlite-vec gracefully disabled in test env)