### PR TITLE
fix(mc-email): correct email-triage script and prompt paths

### DIFF
--- a/cron/scripts/email-triage.py
+++ b/cron/scripts/email-triage.py
@@ -35,7 +35,7 @@ VAULT_BIN        = os.path.join(_STATE_DIR, "miniclaw", "system", "bin", "mc-vau
 SEND_ALERT       = os.path.join(_STATE_DIR, "miniclaw", "system", "bin", "send-alert")
 MC_BIN           = "/opt/homebrew/bin/openclaw"
 SETUP_STATE_FILE = os.path.join(_STATE_DIR, "USER", "setup-state.json")
-PROMPT_FILE      = os.path.join(_STATE_DIR, "cron", "prompts", "email-triage.md")
+PROMPT_FILE      = os.path.join(_STATE_DIR, "miniclaw", "cron", "prompts", "email-triage.md")
 MODEL            = "haiku"  # openclaw model alias for haiku
 MAX_BODY_CHARS   = 2000
 # OpenClaw local gateway — exposes OpenAI-compatible endpoint

--- a/plugins/mc-email/cli/commands.ts
+++ b/plugins/mc-email/cli/commands.ts
@@ -218,7 +218,7 @@ export function registerEmailCommands(ctx: Ctx): void {
 
       // If --test-set, skip state tracking entirely
       if (opts.testSet) {
-        const scriptPath = path.join(stateDir, "cron/scripts/email-triage.py");
+        const scriptPath = path.join(stateDir, "miniclaw/cron/scripts/email-triage.py");
         const args = ["python3", scriptPath, "--test-set", "--limit", opts.limit];
         const result = spawnSync(args[0], args.slice(1), {
           stdio: "inherit",
@@ -254,7 +254,7 @@ export function registerEmailCommands(ctx: Ctx): void {
       }
 
       // Build skip-uids arg for the triage script
-      const scriptPath = path.join(stateDir, "cron/scripts/email-triage.py");
+      const scriptPath = path.join(stateDir, "miniclaw/cron/scripts/email-triage.py");
       const args = ["python3", scriptPath];
       if (opts.dryRun) args.push("--dry-run");
       args.push("--limit", opts.limit);


### PR DESCRIPTION
## Summary
- Fix `commands.ts` script path: `cron/scripts/email-triage.py` → `miniclaw/cron/scripts/email-triage.py` (2 occurrences)
- Fix `email-triage.py` PROMPT_FILE path: `cron/prompts/` → `miniclaw/cron/prompts/`

Both paths were missing the `miniclaw/` prefix, causing the email-triage command to look for files in the wrong directory under the state dir.

## Test plan
- [x] All 25 tests pass in plugins/mc-email (1 pre-existing failure from merge conflict in client.test.ts on main)
- [x] Verified paths now correctly include `miniclaw/` prefix

🤖 Card: crd_02c9f104