### PR TITLE
docs: Add plugin documentation for 17 undocumented plugins

### DIFF
--- a/docs/mc-calendar.md
+++ b/docs/mc-calendar.md
@@ -1,0 +1,115 @@
+# mc-calendar
+
+> Apple Calendar integration via macOS EventKit — list, create, update, delete, and search events.
+
+## Overview
+
+mc-calendar bridges the macOS Calendar app (EventKit) with the MiniClaw agent runtime.
+It lets the agent manage calendars and events through CLI commands and agent tools,
+enabling scheduling workflows without leaving the terminal.
+
+## Installation
+
+```bash
+cd ~/.openclaw/miniclaw/plugins/mc-calendar
+npm install
+npm run build
+```
+
+### Prerequisites
+
+- macOS with EventKit access granted (System Settings → Privacy & Security → Calendars)
+- EventKit helper binary (bundled)
+
+## CLI Usage
+
+```bash
+# List all calendars
+openclaw mc-calendar list
+
+# Show upcoming events (default 7 days)
+openclaw mc-calendar events [-d DAYS] [-c CALENDAR]
+
+# Search events by text
+openclaw mc-calendar search QUERY [-d DAYS] [-c CALENDAR]
+
+# Read full event details
+openclaw mc-calendar read UID
+
+# Create a new event
+openclaw mc-calendar create -c NAME -s TITLE --start DATE --end DATE [--location LOC] [--notes NOTES]
+
+# Delete an event
+openclaw mc-calendar delete UID
+
+# Check EventKit access
+openclaw mc-calendar status
+```
+
+### Command Reference
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `list` | List all calendars with read/write status | `openclaw mc-calendar list` |
+| `events` | List upcoming events | `openclaw mc-calendar events -d 14` |
+| `search` | Search events by title, location, or notes | `openclaw mc-calendar search "standup" -d 30` |
+| `read` | Show full event details including recurrence | `openclaw mc-calendar read ABC-123-DEF` |
+| `create` | Create a new event | `openclaw mc-calendar create -c Work -s "Team Sync" --start "2026-03-20 10:00" --end "2026-03-20 11:00"` |
+| `delete` | Delete an event by UID | `openclaw mc-calendar delete ABC-123-DEF` |
+| `status` | Check EventKit access and list calendars | `openclaw mc-calendar status` |
+
+## Tool API
+
+| Tool | Description | Required Params | Optional Params |
+|------|-------------|-----------------|-----------------|
+| `calendar_list` | List all calendars with writable status | — | — |
+| `calendar_events` | List upcoming events | — | `days_ahead` (default 7), `calendar` |
+| `calendar_search` | Search events by text (case-insensitive) | `query` | `days_ahead` (default 30), `calendar` |
+| `calendar_read` | Read full event details by UID | `event_uid` | `calendar` |
+| `calendar_create` | Create a new event | `calendar`, `summary`, `start_date`, `end_date` | `location`, `description`, `all_day` |
+| `calendar_update` | Update existing event properties | `event_uid` | `calendar`, `summary`, `start_date`, `end_date`, `location`, `description`, `all_day` |
+| `calendar_delete` | Delete event by UID | `event_uid` | — |
+
+### Example tool call (agent perspective)
+
+```
+Use the calendar_events tool to check what meetings are scheduled for the next 3 days.
+```
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `defaultCalendar` | `string` | `(auto)` | Default calendar name for operations |
+
+## Examples
+
+### Example 1 — Check today's schedule
+
+```bash
+openclaw mc-calendar events -d 1
+```
+
+### Example 2 — Create a recurring standup reminder
+
+```bash
+openclaw mc-calendar create -c Work -s "Daily Standup" \
+  --start "2026-03-20 09:00" --end "2026-03-20 09:15" \
+  --notes "Team sync — review board and blockers"
+```
+
+## Architecture
+
+- `index.ts` — Plugin entry point, registers CLI commands and agent tools
+- `cli/commands.ts` — CLI command definitions
+- `tools/definitions.ts` — Agent tool definitions
+- `src/config.ts` — Configuration resolver
+- `src/helper.ts` — EventKit helper interface
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| "EventKit access denied" | Grant Calendar access in System Settings → Privacy & Security → Calendars |
+| Calendar not found | Run `openclaw mc-calendar list` to see available calendar names |
+| Events not showing | Check the `-d` flag — default is 7 days ahead |

--- a/docs/mc-devlog.md
+++ b/docs/mc-devlog.md
@@ -1,0 +1,106 @@
+# mc-devlog
+
+> Daily devlog cron — aggregates yesterday's git activity, credits contributors, and publishes to multiple targets.
+
+## Overview
+
+mc-devlog gathers the previous day's git commits, merged PRs, closed issues, and shipped board cards,
+then formats them into a markdown devlog post. It publishes to GitHub Discussions, mc-blog, mc-substack,
+and queues a weekly digest flag for mc-reddit.
+
+## Installation
+
+```bash
+cd ~/.openclaw/miniclaw/plugins/mc-devlog
+npm install
+npm run build
+```
+
+### Prerequisites
+
+- Git repository with commit history
+- `gh` CLI authenticated for GitHub Discussions
+- mc-blog and mc-substack plugins (optional, for cross-posting)
+
+## CLI Usage
+
+```bash
+# Generate and publish yesterday's devlog
+openclaw mc-devlog run
+
+# Preview without publishing (dry run)
+openclaw mc-devlog preview
+```
+
+### Command Reference
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `run` | Generate and publish devlog to all targets | `openclaw mc-devlog run` |
+| `preview` | Dry-run — show devlog without publishing | `openclaw mc-devlog preview` |
+
+## Tool API
+
+| Tool | Description | Required Params | Optional Params |
+|------|-------------|-----------------|-----------------|
+| `devlog_preview` | Gather yesterday's activity and format without publishing | — | — |
+| `devlog_publish` | Gather, format, and publish to all configured targets | — | — |
+
+### Example tool call (agent perspective)
+
+```
+Use the devlog_preview tool to see what yesterday's activity looks like before publishing.
+```
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `repoDir` | `string` | `~/.openclaw/projects/miniclaw-os` | Git repository path |
+| `githubRepo` | `string` | `miniclaw-official/miniclaw-os` | GitHub owner/repo for Discussions |
+| `discussionCategory` | `string` | `Devlog` | GitHub Discussions category |
+| `postsDir` | `string` | `~/.openclaw/USER/blog/posts` | Directory for mc-blog posts |
+| `contributorMap` | `object` | `{}` | Map git author names → display names |
+| `substackEnabled` | `boolean` | `false` | Cross-post to Substack |
+| `redditDigestDir` | `string` | `~/.openclaw/USER/devlog/reddit-queue` | Weekly digest queue directory |
+| `timezone` | `string` | `America/Chicago` | Timezone for date display |
+
+## Examples
+
+### Example 1 — Preview before publishing
+
+```bash
+openclaw mc-devlog preview
+# Review the output, then:
+openclaw mc-devlog run
+```
+
+### Example 2 — Configure contributor names
+
+Set `contributorMap` in `openclaw.plugin.json`:
+```json
+{
+  "contributorMap": {
+    "mike@example.com": "Mike O'Neal",
+    "bot@miniclaw.dev": "Am (MiniClaw Agent)"
+  }
+}
+```
+
+## Architecture
+
+- `index.ts` — Plugin entry point, registers CLI and cron job
+- `cli/commands.ts` — Devlog run and preview commands
+- `tools/definitions.ts` — Agent tools for preview and publish
+- `src/gather.js` — Gathers git commits, PRs, issues, shipped cards
+- `src/format.js` — Formats activity into markdown
+- `src/publish.js` — Publishes to GitHub Discussions, mc-blog, mc-substack
+- `src/types.ts` — Configuration types
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Empty devlog | Ensure `repoDir` points to a repo with recent commits |
+| GitHub Discussions post fails | Verify `gh` CLI is authenticated and the Discussion category exists |
+| Substack cross-post skipped | Set `substackEnabled: true` in config |

--- a/docs/mc-fan.md
+++ b/docs/mc-fan.md
@@ -1,0 +1,106 @@
+# mc-fan
+
+> Follow and authentically engage with people, agents, and projects the agent admires.
+
+## Overview
+
+mc-fan maintains a registry of people, agents, and projects to follow. It tracks engagement
+history, checks for new content on YouTube, GitHub, and Substack, and supports authentic
+interactions like commenting on Substack posts. Context is injected on cards tagged with
+`fan`, `social`, `engagement`, `content`, or `networking`.
+
+## Installation
+
+```bash
+cd ~/.openclaw/miniclaw/plugins/mc-fan
+npm install
+npm run build
+```
+
+### Prerequisites
+
+- `yt-dlp` for YouTube content checks
+- `gh` CLI for GitHub activity checks
+- Substack SID in vault for commenting (`mc-vault set substack.sid <value>`)
+
+## CLI Usage
+
+```bash
+# List all fans
+openclaw fan list [-p PLATFORM]
+
+# Add a new fan
+openclaw fan add -n NAME -p PLATFORM -u URL1 URL2 -w "Why we follow" [--style intellectual-peer]
+
+# Check a fan's latest content
+openclaw fan check ID
+
+# Show engagement overview
+openclaw fan status
+```
+
+### Command Reference
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `list` | List all fans with details | `openclaw fan list -p youtube` |
+| `add` | Add person/project to registry | `openclaw fan add -n "Andrej Karpathy" -p youtube -u https://youtube.com/@karpathy -w "Leading AI educator"` |
+| `check` | Show details and latest content for a fan | `openclaw fan check andrej-karpathy` |
+| `status` | Engagement overview for all fans | `openclaw fan status` |
+
+## Tool API
+
+| Tool | Description | Required Params | Optional Params |
+|------|-------------|-----------------|-----------------|
+| `fan_add` | Add person/agent/project to registry | `name`, `platform`, `urls`, `whyWeFollow`, `engagementStyle` | `tags`, `notes` |
+| `fan_list` | List all fans | — | `platform` |
+| `fan_remove` | Remove fan from registry | `id` | — |
+| `fan_check` | Check fan's latest content | `id` | `limit` (default 5) |
+| `fan_engage` | Log engagement with content | `fanId`, `action`, `contentUrl`, `contentTitle` | `notes` |
+| `fan_read_substack` | Read full Substack post as plain text | `postUrl` | — |
+| `fan_comment_substack` | Post comment on Substack (min 50 chars, no generic praise) | `postId`, `body`, `fanId`, `postTitle`, `postUrl` | `substackDomain` |
+| `fan_digest` | Summarize recent engagement | — | `fanId`, `days` (default 7) |
+| `fan_status` | Overview with engagement stats | — | — |
+
+### Example tool call (agent perspective)
+
+```
+Use the fan_check tool to see if Andrej Karpathy has posted any new YouTube videos.
+```
+
+## Configuration
+
+No configuration keys required. Fan registry is stored as a JSON file managed by the plugin.
+
+## Examples
+
+### Example 1 — Add a fan and check their content
+
+```bash
+openclaw fan add -n "Simon Willison" -p blog -u https://simonwillison.net -w "AI tooling thought leader" --style intellectual-peer
+openclaw fan check simon-willison
+```
+
+### Example 2 — Log engagement after watching a video
+
+```bash
+# After watching, log the engagement
+openclaw fan engage --fan andrej-karpathy --action watched \
+  --url "https://youtube.com/watch?v=abc123" \
+  --title "Building GPT from Scratch"
+```
+
+## Architecture
+
+- `index.ts` — Plugin entry point, context injection via `before_prompt_build` hook
+- `cli/commands.ts` — Fan registry CLI (list, add, check, status)
+- `tools/definitions.ts` — Agent tools for fan management and engagement
+- `shared.ts` — Fan registry and engagement log persistence
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| YouTube check returns no results | Ensure `yt-dlp` is installed and the channel URL is correct |
+| Substack comment fails | Verify `substack.sid` is set in mc-vault |
+| Fan ID not found | IDs are slugified names — use `openclaw fan list` to see IDs |

--- a/docs/mc-github.md
+++ b/docs/mc-github.md
@@ -1,0 +1,104 @@
+# mc-github
+
+> Manage GitHub issues, PRs, releases, and Actions workflows via the gh CLI.
+
+## Overview
+
+mc-github wraps the GitHub CLI to provide issue, pull request, release, and Actions management
+as both CLI commands and agent tools. It injects GitHub workflow context into every prompt,
+loads `CODING_AXIOMS.md` from repos when available, auto-stars configured repositories, and
+enforces repository protection policies via an hourly cron.
+
+## Installation
+
+```bash
+cd ~/.openclaw/miniclaw/plugins/mc-github
+npm install
+npm run build
+```
+
+### Prerequisites
+
+- `gh` CLI installed and authenticated (`gh auth login`)
+
+## CLI Usage
+
+```bash
+# List open issues
+openclaw github issues [-s STATE] [-l LABEL] [--limit N]
+
+# Show issue details
+openclaw github issue NUMBER
+
+# List open pull requests
+openclaw github prs [-s STATE] [--limit N]
+
+# Show PR details
+openclaw github pr NUMBER
+```
+
+### Command Reference
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `issues` | List open issues with optional filters | `openclaw github issues -l bug --limit 10` |
+| `issue` | Show issue details | `openclaw github issue 42` |
+| `prs` | List open pull requests | `openclaw github prs -s closed` |
+| `pr` | Show pull request details | `openclaw github pr 99` |
+
+## Tool API
+
+| Tool | Description | Required Params | Optional Params |
+|------|-------------|-----------------|-----------------|
+| `github_issue_create` | Create a GitHub issue | `title`, `body` | `labels` |
+| `github_issue_update` | Update issue properties | `issueNumber` | `title`, `body`, `state`, `addLabels`, `removeLabels`, `assignees` |
+| `github_issue_list` | List issues with filters | — | `state` (default open), `labels`, `assignee`, `limit` (default 30) |
+| `github_issue_comment` | Add comment to an issue | `issueNumber`, `body` | — |
+| `github_pr_create` | Create a pull request | `title`, `body` | `base` (default main), `draft` |
+| `github_pr_list` | List PRs with filters | — | `state` (default open), `base`, `author`, `limit` (default 30) |
+| `github_pr_merge` | Merge a pull request | `prNumber` | `method` (merge/squash/rebase), `deleteRemoteBranch` (default true) |
+| `github_release_create` | Create a release | `tag`, `title` | `body`, `draft`, `prerelease`, `target` |
+| `github_actions_status` | Check workflow run status | — | `branch`, `limit` |
+
+### Example tool call (agent perspective)
+
+```
+Use the github_issue_list tool to find all open issues labeled "bug".
+```
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `defaultRepo` | `string` | `(auto-detect from git remote)` | Default GitHub repo (owner/name) |
+
+## Examples
+
+### Example 1 — Triage new issues
+
+```bash
+openclaw github issues -s open --limit 20
+openclaw github issue 315
+```
+
+### Example 2 — Create a PR from a feature branch
+
+```bash
+# Agent creates PR via tool
+openclaw github pr NUMBER
+```
+
+## Architecture
+
+- `index.ts` — Plugin entry point, context injection, auto-star, repo protection cron
+- `cli/commands.ts` — GitHub CLI commands (issues, PRs)
+- `tools/definitions.ts` — Comprehensive agent tools for GitHub operations
+- `src/repo-protection.js` — Enforces repository protection policies
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| "gh: command not found" | Install GitHub CLI: `brew install gh` |
+| Authentication error | Run `gh auth login` to re-authenticate |
+| Wrong repo detected | Set `defaultRepo` in plugin config |

--- a/docs/mc-guardian.md
+++ b/docs/mc-guardian.md
@@ -1,0 +1,79 @@
+# mc-guardian
+
+> Absorbs non-fatal uncaught exceptions to prevent plugin errors from crashing the gateway process.
+
+## Overview
+
+mc-guardian replaces the default `uncaughtException` and `unhandledRejection` handlers with
+resilient alternatives. Non-fatal errors are logged to a file instead of crashing the process,
+while truly fatal errors (out of memory, stack overflow) are allowed to propagate normally.
+
+## Installation
+
+```bash
+cd ~/.openclaw/miniclaw/plugins/mc-guardian
+npm install
+npm run build
+```
+
+### Prerequisites
+
+- No external dependencies required
+
+## CLI Usage
+
+```bash
+# Check guardian status
+openclaw guardian_status
+```
+
+### Command Reference
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `guardian_status` | Show absorbed error count and log file location | `openclaw guardian_status` |
+
+## Tool API
+
+No agent tools. mc-guardian is a utility plugin for process resilience.
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | `boolean` | `true` | Enable/disable guardian error handling |
+
+## Examples
+
+### Example 1 — Check how many errors have been absorbed
+
+```bash
+openclaw guardian_status
+```
+
+### Example 2 — Review absorbed errors
+
+```bash
+cat ~/.openclaw/guardian.log | tail -20
+```
+
+## Architecture
+
+- `index.ts` — Replaces `uncaughtException` and `unhandledRejection` handlers, registers status command
+
+### Fatal Error Patterns (allowed to crash)
+
+- `out of memory`
+- `allocation failed`
+- `maximum call stack`
+- `FATAL ERROR`
+
+All other uncaught errors are absorbed and logged to `~/.openclaw/guardian.log`.
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Process still crashing | Check if the error matches a fatal pattern — those are intentionally not caught |
+| Log file growing too large | Rotate or truncate `~/.openclaw/guardian.log` |
+| Want to disable guardian | Set `enabled: false` in plugin config |

--- a/docs/mc-memory.md
+++ b/docs/mc-memory.md
@@ -1,0 +1,106 @@
+# mc-memory
+
+> Unified memory gateway — smart routing, unified recall, and memo-to-KB promotion.
+
+## Overview
+
+mc-memory provides a single interface over three memory stores: mc-kb (long-term knowledge base),
+mc-memo (card-scoped memos), and episodic memory (daily observations). It auto-routes writes to the
+appropriate store, searches all stores with a single query, and promotes short-term memories to
+permanent KB entries. Relevant memories are injected before each prompt via the `before_prompt_build` hook.
+
+## Installation
+
+```bash
+cd ~/.openclaw/miniclaw/plugins/mc-memory
+npm install
+npm run build
+```
+
+### Prerequisites
+
+- mc-kb plugin installed (provides SQLite + vector search backend)
+- Embedding model GGUF file (auto-downloaded on first use)
+
+## CLI Usage
+
+```bash
+# Write to memory (auto-routes to memo/kb/episodic)
+openclaw mc-memory write "content here" [--card ID] [--force memo|kb|episodic] [--source SRC]
+
+# Search all memory stores
+openclaw mc-memory recall "query" [--card ID] [-n COUNT] [--days DAYS] [--type TYPE] [--tag TAG] [--json]
+
+# List episodic memory entries
+openclaw mc-memory list [--days DAYS] [--page N] [--limit N] [--json]
+
+# Promote memo or episodic entry to KB
+openclaw mc-memory promote --content TEXT --from memo|episodic --ref ID|DATE [--title T] [--type T] [--tags TAGS]
+```
+
+### Command Reference
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `write` | Write to memory with auto-routing | `openclaw mc-memory write "Next.js 14 requires Node 18+" --force kb` |
+| `recall` | Search all memory stores | `openclaw mc-memory recall "database migration" -n 5` |
+| `list` | List episodic memory entries | `openclaw mc-memory list --days 3` |
+| `promote` | Promote to permanent KB entry | `openclaw mc-memory promote --content "..." --from memo --ref crd_abc123` |
+
+## Tool API
+
+| Tool | Description | Required Params | Optional Params |
+|------|-------------|-----------------|-----------------|
+| `memory_write` | Write with auto-routing (memo for card-scoped, KB for generalizable, episodic for daily) | `content` | `cardId`, `forceTarget`, `source` |
+| `memory_recall` | Unified search across KB + memos + episodic | `query` | `cardId`, `type`, `tag`, `n` (default 10), `daysBack` (default 7) |
+| `memory_promote` | Graduate memo/episodic to permanent KB | `content`, `source_type`, `source_ref` | `title`, `type`, `tags` |
+
+### Example tool call (agent perspective)
+
+```
+Use the memory_recall tool to search for any past notes about deploying to Tailscale.
+```
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `memoDir` | `string` | `~/.openclaw/USER/memos` | Directory for per-card memo files |
+| `kbDbDir` | `string` | `~/.openclaw/USER/kb` | Directory for KB SQLite database |
+| `episodicDir` | `string` | `~/.openclaw/USER/memory` | Directory for daily episodic memory files |
+| `modelPath` | `string` | `~/.cache/qmd/models/...embeddinggemma-300M-Q8_0.gguf` | Path to embedding model |
+| `contextN` | `number` | `5` | Number of memory entries injected into context |
+| `contextThreshold` | `number` | `0.75` | Cosine distance threshold for context injection (0–2) |
+
+## Examples
+
+### Example 1 — Write a card-scoped memo
+
+```bash
+openclaw mc-memory write "Tried SQLite — works, no Docker needed" --card crd_abc123
+```
+
+### Example 2 — Search and promote
+
+```bash
+openclaw mc-memory recall "tailscale funnel setup" -n 3
+openclaw mc-memory promote --content "Homebrew Tailscale doesn't support Funnel" \
+  --from episodic --ref 2026-03-15 --tags "tailscale,gotcha"
+```
+
+## Architecture
+
+- `index.ts` — Plugin entry point, `before_prompt_build` hook for context injection
+- `cli/commands.ts` — Write, recall, list, promote commands
+- `tools/definitions.ts` — Three primary agent tools
+- `src/writer.js` — Smart routing logic (memo/kb/episodic)
+- `src/recall.js` — Unified search across all memory stores
+- `src/promote.js` — Graduates short-term to long-term memory
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Vector search not working | Ensure embedding model GGUF exists at `modelPath` |
+| No memories injected | Check `contextThreshold` — lower values (e.g. 0.5) are more permissive |
+| Wrong store targeted | Use `--force` flag to override auto-routing |

--- a/docs/mc-moltbook.md
+++ b/docs/mc-moltbook.md
@@ -1,0 +1,113 @@
+# mc-moltbook
+
+> Moltbook social network integration — post, reply, vote, and read the agent feed.
+
+## Overview
+
+mc-moltbook connects the agent to the Moltbook social network. It handles auto-registration,
+posting, replying, voting, searching, and reading feeds. Agents can engage with communities
+(submolts) and interact with other agents on the platform.
+
+## Installation
+
+```bash
+cd ~/.openclaw/miniclaw/plugins/mc-moltbook
+npm install
+npm run build
+```
+
+### Prerequisites
+
+- Network access to the Moltbook API
+- API credentials stored in mc-vault (auto-registered on first run)
+
+## CLI Usage
+
+```bash
+# Check connection status and profile
+openclaw mc-moltbook status
+
+# Register agent on Moltbook
+openclaw mc-moltbook register
+
+# Create a new post
+openclaw mc-moltbook post -s SUBMOLT -t "Title" -c "Content"
+
+# Read the feed
+openclaw mc-moltbook feed [--sort hot|new|top|rising] [--limit N]
+
+# Reply to a post
+openclaw mc-moltbook reply -p POST_ID -c "Reply content" [--parent COMMENT_ID]
+
+# List available communities
+openclaw mc-moltbook communities
+```
+
+### Command Reference
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `status` | Check connection and profile | `openclaw mc-moltbook status` |
+| `register` | Register agent on Moltbook | `openclaw mc-moltbook register` |
+| `post` | Create a new post | `openclaw mc-moltbook post -s general -t "Hello World" -c "First post!"` |
+| `feed` | Read the Moltbook feed | `openclaw mc-moltbook feed --sort new --limit 20` |
+| `reply` | Reply to a post | `openclaw mc-moltbook reply -p abc123 -c "Great point"` |
+| `communities` | List available submolts | `openclaw mc-moltbook communities` |
+
+## Tool API
+
+| Tool | Description | Required Params | Optional Params |
+|------|-------------|-----------------|-----------------|
+| `moltbook_feed` | Read the Moltbook feed | — | `sort`, `limit` |
+| `moltbook_post` | Create a new post | `submolt`, `title`, `content` | — |
+| `moltbook_reply` | Reply to a post | `post_id`, `content` | `parent_id` |
+| `moltbook_vote` | Upvote or downvote a post | `post_id`, `direction` (up/down) | — |
+| `moltbook_read_post` | Read a specific post and comments | `post_id` | — |
+| `moltbook_profile` | Get your Moltbook profile | — | — |
+| `moltbook_search` | Search Moltbook | `query` | — |
+
+### Example tool call (agent perspective)
+
+```
+Use the moltbook_feed tool to read the latest posts sorted by new.
+```
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `apiUrl` | `string` | `https://api.moltbook.com` | Moltbook API base URL |
+| `vaultBin` | `string` | `(auto)` | Path to mc-vault binary |
+
+## Examples
+
+### Example 1 — Post to a community
+
+```bash
+openclaw mc-moltbook post -s ai-agents -t "MiniClaw Plugin Architecture" \
+  -c "Here's how our plugin system works..."
+```
+
+### Example 2 — Read and engage with posts
+
+```bash
+openclaw mc-moltbook feed --sort hot --limit 10
+openclaw mc-moltbook reply -p POST_ID -c "Interesting approach — have you considered..."
+```
+
+## Architecture
+
+- `index.ts` — Plugin entry point, auto-registration on load
+- `cli/commands.ts` — CLI command registration for all subcommands
+- `tools/definitions.ts` — 7 agent tools
+- `src/client.js` — MoltbookClient for API interaction
+- `src/config.js` — Configuration resolution
+- `src/onboarding.js` — Auto-registration flow
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Registration fails | Check network access to api.moltbook.com |
+| Auth error on post | Re-run `openclaw mc-moltbook register` to refresh credentials |
+| Feed returns empty | Try different sort options: `--sort new` |

--- a/docs/mc-oauth-guard.md
+++ b/docs/mc-oauth-guard.md
@@ -1,0 +1,92 @@
+# mc-oauth-guard
+
+> Monitors OAuth token refresh failures, auto-disables failing profiles, and attempts keychain recovery.
+
+## Overview
+
+mc-oauth-guard watches for OAuth token refresh failures across agent profiles. After repeated
+failures it auto-disables the failing profile to prevent cascading errors, applies exponential
+backoff, and attempts to recover Anthropic tokens from the macOS keychain. It operates via
+event hooks — no agent tools are exposed.
+
+## Installation
+
+```bash
+cd ~/.openclaw/miniclaw/plugins/mc-oauth-guard
+npm install
+npm run build
+```
+
+### Prerequisites
+
+- macOS keychain access (for Anthropic token recovery)
+- Auth profiles at `~/.openclaw/agents/main/agent/auth-profiles.json`
+
+## CLI Usage
+
+```bash
+# Show failure tracking status
+openclaw oauth_guard_status
+
+# Reset failure state for a profile
+openclaw oauth_guard_reset [profileId]
+
+# Attempt keychain recovery for Anthropic OAuth
+openclaw oauth_guard_recover [profileId]
+```
+
+### Command Reference
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `oauth_guard_status` | Show failure counts and backoff state | `openclaw oauth_guard_status` |
+| `oauth_guard_reset` | Reset failure state for a profile | `openclaw oauth_guard_reset default` |
+| `oauth_guard_recover` | Attempt keychain recovery | `openclaw oauth_guard_recover default` |
+
+## Tool API
+
+No agent tools. mc-oauth-guard operates via event hooks (`agent_end`, `before_model_resolve`).
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | `boolean` | `true` | Enable/disable OAuth guard |
+| `maxConsecutiveFailures` | `number` | `3` | Failures before disabling a profile |
+| `minBackoffMs` | `number` | `300000` | Minimum backoff interval (5 min) |
+| `maxBackoffMs` | `number` | `3600000` | Maximum backoff interval (1 hour) |
+| `keychainRecovery` | `boolean` | `true` | Attempt macOS keychain recovery for Anthropic tokens |
+
+## Examples
+
+### Example 1 — Check which profiles have failures
+
+```bash
+openclaw oauth_guard_status
+```
+
+### Example 2 — Reset after fixing credentials
+
+```bash
+# After updating OAuth credentials:
+openclaw oauth_guard_reset default
+```
+
+## Architecture
+
+- `index.ts` — Plugin entry point, event hooks, CLI commands
+- `src/guard.js` — OAuthGuard class for state tracking and backoff logic
+- `src/keychain.js` — macOS keychain credential recovery
+
+### Hook Flow
+
+1. `agent_end` — Detects OAuth failures from agent session results
+2. `before_model_resolve` — Blocks retries during backoff period
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Profile auto-disabled | Run `openclaw oauth_guard_reset <profileId>` after fixing credentials |
+| Keychain recovery fails | Ensure macOS keychain access is granted in System Settings |
+| Backoff too aggressive | Increase `maxConsecutiveFailures` or decrease `minBackoffMs` |

--- a/docs/mc-research.md
+++ b/docs/mc-research.md
@@ -1,0 +1,121 @@
+# mc-research
+
+> Competitive intelligence and deep research — query Perplexity, search the web, track competitors, and generate reports.
+
+## Overview
+
+mc-research provides deep research capabilities via the Perplexity sonar API, multi-provider
+web search (Google, SerpAPI, Bing), competitor tracking with change detection, and comprehensive
+report generation. Research history is stored in a SQLite database.
+
+## Installation
+
+```bash
+cd ~/.openclaw/miniclaw/plugins/mc-research
+npm install
+npm run build
+```
+
+### Prerequisites
+
+- Perplexity API key in mc-vault: `openclaw mc-vault set research-perplexity-api-key <key>`
+- Web search API key (one of): Google Custom Search, SerpAPI, or Bing
+- Network access to search providers
+
+## CLI Usage
+
+```bash
+# Deep research via Perplexity
+openclaw mc-research query "What are the latest LLM benchmarks?" [--focus web|news|academic]
+
+# Web search
+openclaw mc-research search "keyword" [--num N]
+
+# Competitor tracking
+openclaw mc-research watch add <name> <domain> [--notes "..."]
+openclaw mc-research watch remove <domain>
+openclaw mc-research watch list
+
+# Scrape competitor pages
+openclaw mc-research snapshot <domain> [--pages pricing,about,features]
+
+# Full competitive intelligence report
+openclaw mc-research report "query" [--competitor domain]
+
+# View past research
+openclaw mc-research history [--num N]
+```
+
+### Command Reference
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `query` | Deep research via Perplexity sonar | `openclaw mc-research query "React vs Svelte 2026" --focus web` |
+| `search` | Web search | `openclaw mc-research search "agent frameworks" --num 10` |
+| `watch add` | Register a competitor | `openclaw mc-research watch add "Acme" acme.dev` |
+| `watch remove` | Remove a competitor | `openclaw mc-research watch remove acme.dev` |
+| `watch list` | List tracked competitors | `openclaw mc-research watch list` |
+| `snapshot` | Scrape competitor pages | `openclaw mc-research snapshot acme.dev --pages pricing,features` |
+| `report` | Full intelligence report | `openclaw mc-research report "AI agent market" --competitor acme.dev` |
+| `history` | List past research | `openclaw mc-research history --num 5` |
+
+## Tool API
+
+| Tool | Description | Required Params | Optional Params |
+|------|-------------|-----------------|-----------------|
+| `research_query` | Deep research via Perplexity | `query` | `focus` (web/news/academic), `card_id` |
+| `research_web_search` | Search the web | `query` | `num_results` (default 5), `card_id` |
+| `research_competitor_watch` | Register/list/remove competitors | `action` (add/remove/list) | `name`, `domain`, `notes` |
+| `research_competitor_snapshot` | Scrape competitor pages | `domain` | `pages` |
+| `research_report` | Generate comprehensive report | `query` | `competitor_domain`, `card_id` |
+
+### Example tool call (agent perspective)
+
+```
+Use the research_query tool to find out what agent benchmarks are trending in 2026.
+```
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `stateDir` | `string` | `~/.openclaw/USER/research` | Directory for research.db |
+| `perplexityModel` | `string` | `sonar` | Perplexity model to use |
+| `searchProvider` | `string` | `google` | Search provider: serp, google, or bing |
+| `maxSnapshotPages` | `number` | `5` | Max pages to scrape per snapshot |
+
+## Examples
+
+### Example 1 — Research a topic
+
+```bash
+openclaw mc-research query "What are the best practices for LLM agent memory systems?" --focus academic
+```
+
+### Example 2 — Track and monitor a competitor
+
+```bash
+openclaw mc-research watch add "LangChain" langchain.com --notes "Python agent framework"
+openclaw mc-research snapshot langchain.com --pages pricing,docs,changelog
+openclaw mc-research report "agent framework comparison" --competitor langchain.com
+```
+
+## Architecture
+
+- `index.ts` — Plugin entry point
+- `cli/commands.ts` — CLI command registration
+- `tools/definitions.ts` — 5 agent tools with optional board card attachment
+- `src/config.js` — Configuration resolution
+- `src/db.js` — SQLite research database (reports, searches, competitors, snapshots)
+- `src/perplexity.js` — Perplexity API client
+- `src/search.js` — Multi-provider web search (Google, SerpAPI, Bing)
+- `src/scraper.js` — Page scraping and change detection
+- `src/vault.js` — API key retrieval from mc-vault
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| "Perplexity API key not found" | Run `openclaw mc-vault set research-perplexity-api-key <key>` |
+| Search returns no results | Check which `searchProvider` is configured and ensure its API key is in vault |
+| Snapshot fails | Verify the domain is accessible and `maxSnapshotPages` is sufficient |

--- a/docs/mc-social.md
+++ b/docs/mc-social.md
@@ -1,0 +1,97 @@
+# mc-social
+
+> Outbound GitHub social engagement — track repos, find contribution opportunities, and log activity.
+
+## Overview
+
+mc-social enables the agent to engage with the GitHub community by scanning repos for contribution
+opportunities, starring projects, creating issues, commenting on discussions, and tracking engagement
+metrics. Context is injected on cards tagged with relevant social/engagement tags.
+
+## Installation
+
+```bash
+cd ~/.openclaw/miniclaw/plugins/mc-social
+npm install
+npm run build
+```
+
+### Prerequisites
+
+- `gh` CLI authenticated (`gh auth login`)
+- Target repos list in knowledge base (KB article ID: `github-social-targets`)
+
+## CLI Usage
+
+```bash
+# Show engagement metrics summary
+openclaw social status
+```
+
+### Command Reference
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `status` | Show total actions, weekly stats, by type, by repo, recent activity | `openclaw social status` |
+
+## Tool API
+
+| Tool | Description | Required Params | Optional Params |
+|------|-------------|-----------------|-----------------|
+| `social_scan_opportunities` | Scan a GitHub repo for contribution opportunities | `repo` (owner/name) | — |
+| `social_star_repo` | Star a GitHub repository | `repo` | — |
+| `social_create_issue` | Create an issue on a repo | `repo`, `title`, `body` | `labels` |
+| `social_create_discussion_comment` | Comment on a GitHub Discussion | `repo`, `discussionNumber`, `body` | — |
+| `social_log_engagement` | Log an engagement action | `repo`, `action`, `url`, `description` | — |
+| `social_metrics` | View engagement metrics | — | — |
+| `social_traffic` | Track engagement by repo | — | — |
+| `social_list_targets` | List target repos to engage with | — | — |
+
+### Example tool call (agent perspective)
+
+```
+Use the social_scan_opportunities tool to find good-first-issue items in the langchain repo.
+```
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `targetListKbId` | `string` | `github-social-targets` | KB article ID for target repo list |
+
+## Examples
+
+### Example 1 — Scan for contribution opportunities
+
+```bash
+# Via agent tool:
+# "Scan langchain-ai/langchain for contribution opportunities"
+openclaw social status
+```
+
+### Example 2 — Log engagement after contributing
+
+```bash
+# Agent logs engagement automatically after starring, commenting, or creating issues
+openclaw social status
+```
+
+## Architecture
+
+- `index.ts` — Plugin entry point, `before_prompt_build` hook for context injection on tagged cards
+- `cli/commands.ts` — Social status CLI command
+- `tools/definitions.ts` — Social tools (scan, star, issue, comment, log, metrics)
+- `shared.ts` — Engagement log path and JSON file I/O utilities
+
+### Data Storage
+
+- Engagement log: `~/.openclaw/USER/engagement.jsonl`
+- Target repos: stored in mc-kb (article ID from `targetListKbId` config)
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| "gh: command not found" | Install GitHub CLI: `brew install gh` |
+| No target repos | Add a KB article with ID `github-social-targets` listing repos to engage with |
+| Engagement log missing | Log is created on first engagement action |

--- a/docs/mc-tailscale.md
+++ b/docs/mc-tailscale.md
@@ -1,0 +1,104 @@
+# mc-tailscale
+
+> Tailscale management — diagnostics, status, hardening, Serve/Funnel wrappers, and custom domain setup.
+
+## Overview
+
+mc-tailscale manages the Tailscale VPN mesh network from the agent runtime. It provides diagnostics
+to detect common issues (daemon state, socket connectivity, zombie processes), status monitoring,
+and a hardening wizard to apply security best practices. It detects Homebrew installs that don't
+support Funnel.
+
+## Installation
+
+```bash
+cd ~/.openclaw/miniclaw/plugins/mc-tailscale
+npm install
+npm run build
+```
+
+### Prerequisites
+
+- Tailscale installed (Homebrew, App Store, or standalone)
+- Valid tailscaled state directory with daemon socket
+- Tailscale API token in mc-vault: `openclaw mc-vault set tailscale-api-token <token>`
+
+## CLI Usage
+
+```bash
+# Diagnose Tailscale issues
+openclaw mc-tailscale doctor
+
+# Show current Tailscale state
+openclaw mc-tailscale status
+
+# Apply hardening settings
+openclaw mc-tailscale harden
+```
+
+### Command Reference
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `doctor` | Diagnose binary, daemon, socket, zombie processes, connection state | `openclaw mc-tailscale doctor` |
+| `status` | Show connection status, hostname, IPs, peers, serve/funnel config, key expiry | `openclaw mc-tailscale status` |
+| `harden` | Apply shields-up, disable route acceptance, auto-updates, SSH | `openclaw mc-tailscale harden` |
+
+## Tool API
+
+| Tool | Description | Required Params | Optional Params |
+|------|-------------|-----------------|-----------------|
+| `tailscale_doctor` | Diagnose Tailscale issues | — | — |
+| `tailscale_status` | Show current Tailscale state | — | — |
+| `tailscale_harden` | Apply hardening settings | — | `dry_run` (boolean) |
+
+### Example tool call (agent perspective)
+
+```
+Use the tailscale_doctor tool to check if Tailscale is configured correctly.
+```
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `tailscaleBin` | `string` | `/opt/homebrew/bin/tailscale` | Path to tailscale CLI binary |
+| `tailnetName` | `string` | `(auto)` | Name of the tailnet (e.g. example.ts.net) |
+| `apiTokenVaultKey` | `string` | `tailscale-api-token` | mc-vault key for API OAuth token |
+| `stateDir` | `string` | `~/.openclaw/.tailscale/` | Directory for tailscaled state files |
+
+## Examples
+
+### Example 1 — Full diagnostic check
+
+```bash
+openclaw mc-tailscale doctor
+# Checks: binary exists, install method, version, state dir, socket, zombies, connection
+```
+
+### Example 2 — Harden a new installation
+
+```bash
+openclaw mc-tailscale harden
+# Applies: shields-up, disable route acceptance, enable auto-updates, configure SSH
+```
+
+## Architecture
+
+- `index.ts` — Plugin entry point with config resolution
+- `cli/commands.ts` — Doctor command with detailed checks
+- `tools/definitions.ts` — 3 agent tools (doctor, status, harden)
+
+### Install Detection
+
+The doctor command detects Homebrew installs (which don't support Funnel) and warns accordingly.
+It communicates with tailscaled via socket-based IPC.
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| "tailscale binary not found" | Set `tailscaleBin` to the correct path or install via `brew install tailscale` |
+| Socket connection failed | Ensure tailscaled daemon is running: `sudo tailscaled` |
+| Funnel not working | Homebrew installs don't support Funnel — use the standalone or App Store version |
+| Key expired | Run `tailscale up --reset` to re-authenticate |

--- a/docs/mc-update.md
+++ b/docs/mc-update.md
@@ -1,0 +1,116 @@
+# mc-update
+
+> Nightly self-update system — checks for stable tags, pulls updates, rebuilds, and verifies with smoke tests.
+
+## Overview
+
+mc-update automates keeping MiniClaw up to date. It runs as a nightly cron job (3 AM by default),
+checking for new stable-tagged versions of the miniclaw-os fork, all plugins, and the openclaw core.
+It updates everything except `workspace/` and `USER/` directories, runs mc-smoke to verify,
+and auto-rolls back if smoke tests fail.
+
+## Installation
+
+```bash
+cd ~/.openclaw/miniclaw/plugins/mc-update
+npm install
+npm run build
+```
+
+### Prerequisites
+
+- Git repositories with stable tags
+- mc-backup plugin (for pre-update snapshots)
+- mc-smoke for post-update verification
+
+## CLI Usage
+
+```bash
+# Check for updates without applying
+openclaw mc-update check
+
+# Fetch, pull, rebuild, and verify
+openclaw mc-update now
+
+# Rollback to pre-update state
+openclaw mc-update rollback
+
+# Show last update time, versions, schedule
+openclaw mc-update status
+```
+
+### Command Reference
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `check` | Dry run — check for available updates | `openclaw mc-update check` |
+| `now` | Fetch stable tags, pull, rebuild, verify | `openclaw mc-update now` |
+| `rollback` | Revert to pre-update refs | `openclaw mc-update rollback` |
+| `status` | Show update history and schedule | `openclaw mc-update status` |
+
+## Tool API
+
+| Tool | Description | Required Params | Optional Params |
+|------|-------------|-----------------|-----------------|
+| `update_check` | Check for available updates without applying | — | — |
+| `update_now` | Fetch, pull, rebuild, and verify | — | — |
+| `update_status` | Query last update time, versions, schedule | — | — |
+
+### Example tool call (agent perspective)
+
+```
+Use the update_check tool to see if any new versions are available.
+```
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `updateTime` | `string` | `0 3 * * *` | Cron expression for scheduled updates |
+| `autoRollback` | `boolean` | `true` | Rollback if mc-smoke fails |
+| `notifyOnUpdate` | `boolean` | `true` | Log notification when updates applied |
+| `smokeTimeout` | `number` | `60000` | Timeout for mc-smoke verification (ms) |
+| `repos` | `array` | `(auto-discovered)` | Repositories to check (name, path, remote, stableTag) |
+
+## Examples
+
+### Example 1 — Manual update
+
+```bash
+openclaw mc-update check
+# If updates available:
+openclaw mc-update now
+```
+
+### Example 2 — Rollback after a bad update
+
+```bash
+openclaw mc-update rollback
+openclaw mc-update status
+```
+
+## Architecture
+
+- `index.ts` — Plugin entry point, config resolution, cron job registration (`mc-update-nightly`)
+- `cli/commands.ts` — CLI commands (check, now, rollback, status)
+- `tools/definitions.ts` — 3 agent tools
+- `src/updater.js` — Git operations (fetch, checkout stable tags, rebuild)
+- `src/orchestrator.js` — Full update flow (backup → check → pull → rebuild → smoke → rollback)
+- `src/state.js` — Update state persistence (lastCheck, lastUpdate, versions, rollbackRefs)
+
+### Update Flow
+
+1. Pre-update backup via mc-backup
+2. Fetch stable tags from all configured repos
+3. Checkout new stable tags and rebuild
+4. Run mc-smoke to verify
+5. Auto-rollback if smoke tests fail (when `autoRollback: true`)
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Update stuck | Check for lock files in state directory |
+| Smoke test fails | Run `openclaw mc-update rollback` then investigate manually |
+| Cron not running | Verify cron job with `openclaw mc-update status` |
+| No updates found | Ensure repos have new stable tags pushed to remote |

--- a/docs/mc-vending-bench.md
+++ b/docs/mc-vending-bench.md
@@ -1,0 +1,98 @@
+# mc-vending-bench
+
+> Run MiniClaw against the VendingBench 2 autonomous agent benchmark.
+
+## Overview
+
+mc-vending-bench integrates the VendingBench 2 benchmark into MiniClaw. The benchmark simulates
+running a vending machine business for 1 year, scored on final bank balance. It validates that
+MiniClaw's agent tools (mc-kb, mc-memo, mc-memory, mc-board) work correctly under sustained
+autonomous operation.
+
+## Installation
+
+```bash
+cd ~/.openclaw/miniclaw/plugins/mc-vending-bench
+npm install
+npm run build
+
+# Install Python dependencies
+openclaw mc-vending-bench setup
+```
+
+### Prerequisites
+
+- Python 3
+- `inspect-ai` Python package
+- `multiagent-inspect` Python package
+- MiniClaw tools: mc-kb, mc-memo, mc-memory, mc-board
+
+## CLI Usage
+
+```bash
+# Check prerequisites
+openclaw mc-vending-bench doctor
+
+# Install Python dependencies
+openclaw mc-vending-bench setup
+
+# Start a benchmark run
+openclaw mc-vending-bench run [--model MODEL] [--max-messages N] [--dry-run]
+
+# Show past results
+openclaw mc-vending-bench results
+```
+
+### Command Reference
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `doctor` | Check VendingBench 2 prerequisites | `openclaw mc-vending-bench doctor` |
+| `setup` | Install Python dependencies | `openclaw mc-vending-bench setup` |
+| `run` | Start a benchmark run | `openclaw mc-vending-bench run --model anthropic/claude-sonnet-4-6 --dry-run` |
+| `results` | Show past benchmark results | `openclaw mc-vending-bench results` |
+
+## Tool API
+
+No agent tools. mc-vending-bench is a CLI-only benchmarking plugin.
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `model` | `string` | `anthropic/claude-sonnet-4-6` | Model to use for benchmarking |
+| `maxSteps` | `number` | `500` | Maximum benchmark steps |
+| `contextWindow` | `number` | `30000` | Context window size |
+| `outputDir` | `string` | `~/.openclaw/USER/benchmarks/vending-bench` | Output directory for results |
+
+## Examples
+
+### Example 1 — Run a benchmark
+
+```bash
+openclaw mc-vending-bench doctor
+openclaw mc-vending-bench run --model anthropic/claude-sonnet-4-6
+```
+
+### Example 2 — Dry run to validate setup
+
+```bash
+openclaw mc-vending-bench run --dry-run
+```
+
+## Architecture
+
+- `index.ts` — Plugin entry point, registers CLI commands
+- `harness/` — VendingBench 2 Python implementation
+  - `vending_bench_task.py` — Benchmark task definition
+  - `requirements.txt` — Python dependencies
+  - `.venv/` — Python virtual environment
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Python not found | Install Python 3: `brew install python` |
+| inspect-ai missing | Run `openclaw mc-vending-bench setup` to install dependencies |
+| Benchmark times out | Increase `maxSteps` in config |
+| Missing MiniClaw tools | Ensure mc-kb, mc-memo, mc-memory, mc-board plugins are installed |

--- a/docs/mc-voice.md
+++ b/docs/mc-voice.md
@@ -1,0 +1,105 @@
+# mc-voice
+
+> Local speech-to-text via whisper.cpp — record and transcribe audio files.
+
+## Overview
+
+mc-voice provides local speech-to-text transcription using whisper.cpp. It can record audio
+from the microphone via sox, transcribe audio files, and combine both into a dictation workflow.
+All processing happens locally — no API calls required.
+
+## Installation
+
+```bash
+cd ~/.openclaw/miniclaw/plugins/mc-voice
+npm install
+npm run build
+```
+
+### Prerequisites
+
+- whisper.cpp binary (bundled in `SYSTEM/bin/whisper-cpp` or from Homebrew)
+- sox command-line tool for audio recording: `brew install sox`
+- Whisper model files in `~/.openclaw/miniclaw/SYSTEM/whisper-models/`
+
+## CLI Usage
+
+```bash
+# Transcribe an audio file
+openclaw mc-voice transcribe <file> [-m MODEL] [-l LANGUAGE]
+
+# Record audio from microphone
+openclaw mc-voice record [-d SECONDS] [-o OUTPUT]
+
+# Record then transcribe (press Ctrl+C to stop)
+openclaw mc-voice dictate [-m MODEL] [-l LANGUAGE] [-d SECONDS]
+
+# Download a whisper model
+openclaw mc-voice download-model [-m MODEL]
+
+# Check whisper.cpp and model availability
+openclaw mc-voice status
+```
+
+### Command Reference
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `transcribe` | Transcribe an audio file to text | `openclaw mc-voice transcribe recording.wav -m base` |
+| `record` | Record audio from microphone (16kHz mono WAV) | `openclaw mc-voice record -d 30 -o meeting.wav` |
+| `dictate` | Record from mic then transcribe | `openclaw mc-voice dictate -m small` |
+| `download-model` | Download a whisper.cpp model | `openclaw mc-voice download-model -m small` |
+| `status` | Check whisper.cpp and model availability | `openclaw mc-voice status` |
+
+## Tool API
+
+| Tool | Description | Required Params | Optional Params |
+|------|-------------|-----------------|-----------------|
+| `voice_transcribe` | Transcribe an audio file to text | `file` (absolute path) | `model` (tiny/base/small/medium/large) |
+| `voice_record` | Record audio from microphone | `duration` (seconds) | — |
+
+### Example tool call (agent perspective)
+
+```
+Use the voice_transcribe tool to transcribe the meeting recording at /tmp/meeting.wav.
+```
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `model` | `string` | `base` | Whisper model (tiny, base, small, medium, large) |
+| `language` | `string` | `en` | Language code for transcription |
+
+## Examples
+
+### Example 1 — Transcribe a meeting recording
+
+```bash
+openclaw mc-voice transcribe ~/recordings/standup-2026-03-19.wav -m small
+```
+
+### Example 2 — Quick dictation
+
+```bash
+openclaw mc-voice dictate -d 60
+# Speak for up to 60 seconds, then get transcription
+```
+
+## Architecture
+
+- `index.ts` — Plugin entry point, registers CLI and tools
+- `cli/commands.ts` — CLI command registrations
+- `tools/definitions.ts` — Agent tool definitions
+- `src/config.ts` — Configuration resolution (locates whisper binary with fallback chain)
+- `src/whisper.js` — Whisper transcription and model management
+- `src/recorder.js` — Audio recording via sox
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| "whisper binary not found" | Install via Homebrew or check `SYSTEM/bin/whisper-cpp` |
+| "sox: command not found" | Install sox: `brew install sox` |
+| Model not found | Run `openclaw mc-voice download-model -m base` |
+| Poor transcription quality | Use a larger model: `-m small` or `-m medium` |

--- a/docs/mc-vpn.md
+++ b/docs/mc-vpn.md
@@ -1,0 +1,106 @@
+# mc-vpn
+
+> VPN management — Mullvad CLI support with country switching, connection management, and diagnostics.
+
+## Overview
+
+mc-vpn wraps the Mullvad VPN CLI to provide connection management, country switching, and
+diagnostics as both CLI commands and agent tools. The agent can connect, disconnect, switch
+relay locations, and diagnose issues without leaving the runtime.
+
+## Installation
+
+```bash
+cd ~/.openclaw/miniclaw/plugins/mc-vpn
+npm install
+npm run build
+```
+
+### Prerequisites
+
+- Mullvad CLI binary (`/usr/local/bin/mullvad`, `/opt/homebrew/bin/mullvad`, or `/opt/local/bin/mullvad`)
+- Mullvad daemon running
+- Valid Mullvad account
+
+## CLI Usage
+
+```bash
+# Show current VPN state
+openclaw mc-vpn status
+
+# Connect to VPN
+openclaw mc-vpn connect [--country CODE]
+
+# Disconnect
+openclaw mc-vpn disconnect
+
+# List available relay countries
+openclaw mc-vpn countries
+
+# Diagnose Mullvad issues
+openclaw mc-vpn doctor
+```
+
+### Command Reference
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `status` | Show connection state, relay location, IP | `openclaw mc-vpn status` |
+| `connect` | Connect to VPN | `openclaw mc-vpn connect --country de` |
+| `disconnect` | Disconnect from VPN | `openclaw mc-vpn disconnect` |
+| `countries` | List available relay countries | `openclaw mc-vpn countries` |
+| `doctor` | Diagnose binary, daemon, account status | `openclaw mc-vpn doctor` |
+
+## Tool API
+
+| Tool | Description | Required Params | Optional Params |
+|------|-------------|-----------------|-----------------|
+| `vpn_status` | Get connection state, relay location, country, IP | — | — |
+| `vpn_connect` | Connect to Mullvad VPN | — | `country` (country code) |
+| `vpn_disconnect` | Disconnect from Mullvad VPN | — | — |
+| `vpn_switch_country` | Switch relay location and reconnect | `country` (country code) | — |
+
+### Example tool call (agent perspective)
+
+```
+Use the vpn_connect tool to connect through a German relay.
+```
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `mullvadBin` | `string` | `(auto-detect)` | Path to the mullvad CLI binary |
+| `stateDir` | `string` | `~/.openclaw/.vpn/` | Directory for VPN state files and logs |
+| `defaultCountry` | `string` | — | Default country code for VPN relay |
+
+## Examples
+
+### Example 1 — Connect through a specific country
+
+```bash
+openclaw mc-vpn connect --country us
+openclaw mc-vpn status
+```
+
+### Example 2 — Diagnose connection issues
+
+```bash
+openclaw mc-vpn doctor
+# Checks: binary exists, daemon running, account valid
+```
+
+## Architecture
+
+- `index.ts` — Plugin entry point, config resolution, registers CLI and tools
+- `cli/commands.ts` — CLI command registrations (status, connect, disconnect, countries, doctor)
+- `tools/definitions.ts` — Agent tool definitions (vpn_status, vpn_connect, vpn_disconnect, vpn_switch_country)
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| "mullvad: command not found" | Install Mullvad or set `mullvadBin` to the correct path |
+| Daemon not running | Start the daemon: `sudo mullvad-daemon` |
+| Connection fails | Run `openclaw mc-vpn doctor` to diagnose |
+| Country code unknown | Run `openclaw mc-vpn countries` to list available codes |

--- a/docs/mc-web-chat.md
+++ b/docs/mc-web-chat.md
@@ -1,0 +1,84 @@
+# mc-web-chat
+
+> WebSocket server for browser-based Claude Code chat — powers the board's chat panel.
+
+## Overview
+
+mc-web-chat runs a WebSocket server that enables browser-based chat with Claude Code.
+It spawns a claude process per session, manages streaming responses, and optionally injects
+workspace context from `.md` files. It powers the mc-board web UI's chat panel.
+
+## Installation
+
+```bash
+cd ~/.openclaw/miniclaw/plugins/mc-web-chat
+npm install
+npm run build
+```
+
+### Prerequisites
+
+- Claude CLI binary (default: `~/.local/bin/claude`)
+- Node.js `ws` library (included in dependencies)
+
+## CLI Usage
+
+```bash
+# Check server status
+openclaw mc-web-chat status
+```
+
+### Command Reference
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `status` | Check server status and active session count | `openclaw mc-web-chat status` |
+
+## Tool API
+
+No agent tools. mc-web-chat is a server-side plugin that handles WebSocket connections.
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `port` | `number` | `4221` | WebSocket server port |
+| `claudeBin` | `string` | `~/.local/bin/claude` | Path to claude CLI binary |
+| `workspaceDir` | `string` | — | Path to workspace `.md` files for context injection |
+
+## Examples
+
+### Example 1 — Check if the chat server is running
+
+```bash
+openclaw mc-web-chat status
+# Returns: { status: "running", sessions: 2 }
+```
+
+### Example 2 — Connect from the board UI
+
+Open the mc-board web interface and click the chat panel — it connects to `ws://localhost:4221` automatically.
+
+## Architecture
+
+- `index.ts` — Plugin entry point, starts WebSocket server, registers status CLI command
+- `server.ts` — WebSocket server implementation (spawns claude process, manages sessions, streams responses)
+- `com.miniclaw.web-chat.plist` — macOS launchd service configuration
+- `run.ts` — Service runner script
+
+### Session Lifecycle
+
+1. Browser connects via WebSocket to port 4221
+2. Server spawns a `claude` process for the session
+3. Messages are piped between WebSocket and claude stdin/stdout
+4. Workspace `.md` files are injected as context (if configured)
+5. Session ends when WebSocket disconnects
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Port already in use | Change `port` in config or stop the conflicting process |
+| Claude binary not found | Set `claudeBin` to the correct path |
+| No response from chat | Check that claude CLI is working: `claude --version` |
+| Context not injected | Set `workspaceDir` to the directory containing `.md` files |

--- a/docs/mc-x.md
+++ b/docs/mc-x.md
@@ -1,0 +1,96 @@
+# mc-x
+
+> X/Twitter API v2 client — post tweets, read timelines, and reply to tweets.
+
+## Overview
+
+mc-x provides X/Twitter integration via the API v2. The agent can post tweets, read user
+timelines, and reply to tweets. Authentication uses a Bearer token stored in mc-vault.
+
+## Installation
+
+```bash
+cd ~/.openclaw/miniclaw/plugins/mc-x
+npm install
+npm run build
+```
+
+### Prerequisites
+
+- X developer account with API v2 access
+- Bearer token stored in mc-vault: `openclaw mc-x auth --token <bearer>`
+
+## CLI Usage
+
+```bash
+# Store Bearer token
+openclaw mc-x auth --token BEARER_TOKEN
+
+# Post a tweet
+openclaw mc-x post "Hello from MiniClaw!"
+
+# Read a user's timeline
+openclaw mc-x timeline --user-id USER_ID [--count N]
+
+# Reply to a tweet
+openclaw mc-x reply TWEET_ID "Reply text"
+```
+
+### Command Reference
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `auth` | Store X/Twitter Bearer token in vault | `openclaw mc-x auth --token abc123` |
+| `post` | Post a new tweet | `openclaw mc-x post "Shipping new features today"` |
+| `timeline` | Read recent tweets from a user | `openclaw mc-x timeline --user-id 12345 --count 20` |
+| `reply` | Reply to a tweet | `openclaw mc-x reply 789456 "Great thread!"` |
+
+## Tool API
+
+| Tool | Description | Required Params | Optional Params |
+|------|-------------|-----------------|-----------------|
+| `x_post` | Post a new tweet (max 280 chars) | `text` | — |
+| `x_timeline` | Read recent tweets from a user | `user_id` | `count` (5–100, default 10) |
+| `x_reply` | Reply to a tweet (max 280 chars) | `tweet_id`, `text` | — |
+
+### Example tool call (agent perspective)
+
+```
+Use the x_post tool to tweet about the latest MiniClaw release.
+```
+
+## Configuration
+
+Bearer token is managed via mc-vault (set with `openclaw mc-x auth`). No additional config schema keys.
+
+## Examples
+
+### Example 1 — Post a tweet
+
+```bash
+openclaw mc-x post "Just shipped mc-x plugin for MiniClaw — tweet from the terminal 🚀"
+```
+
+### Example 2 — Read and reply to a timeline
+
+```bash
+openclaw mc-x timeline --user-id 12345 --count 5
+openclaw mc-x reply 789456123 "Interesting point about agent architectures"
+```
+
+## Architecture
+
+- `index.ts` — Plugin entry point, checks for Bearer token, registers CLI and tools
+- `cli/commands.ts` — CLI command registrations (auth, post, timeline, reply)
+- `tools/definitions.ts` — Agent tool definitions (x_post, x_timeline, x_reply)
+- `src/client.ts` — XClient class for X API v2 interactions
+- `src/vault.ts` — Bearer token vault management
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| "Bearer token not found" | Run `openclaw mc-x auth --token <token>` to store credentials |
+| 401 Unauthorized | Token may be expired — generate a new one from the X developer portal |
+| Rate limited | X API has rate limits — wait and retry, or reduce `count` on timeline reads |
+| Tweet too long | Tweets are limited to 280 characters |


### PR DESCRIPTION
## Summary
- Adds documentation for all 17 previously undocumented plugins: mc-calendar, mc-devlog, mc-fan, mc-github, mc-guardian, mc-memory, mc-moltbook, mc-oauth-guard, mc-research, mc-social, mc-tailscale, mc-update, mc-vending-bench, mc-voice, mc-vpn, mc-web-chat, mc-x
- Each doc follows the `_template.md` structure: Overview, Installation, CLI Usage, Tool API, Configuration, Examples, Architecture, Troubleshooting
- All CLI commands, agent tools, and config keys extracted from actual plugin source code — no placeholder text

Closes #315

## Test plan
- [x] All 17 .md files created in `docs/`
- [x] Each doc follows the _template.md structure
- [x] Commands, tools, and config extracted from real plugin source