### PR TITLE
fix(mc-memory): preserve full episodic content instead of truncating

### DIFF
--- a/plugins/mc-memory/index.ts
+++ b/plugins/mc-memory/index.ts
@@ -122,7 +122,7 @@ export default function register(api: OpenClawPluginApi): void {
           case "memo":
             return `[memo/${r.cardId}] ${r.line}`;
           case "episodic":
-            return `[episodic/${r.date}] ${r.snippet?.slice(0, 150)}`;
+            return `[episodic/${r.date}] ${(r.content ?? r.snippet ?? "").slice(0, 2000)}`;
           default:
             return "";
         }

--- a/plugins/mc-memory/src/promote.ts
+++ b/plugins/mc-memory/src/promote.ts
@@ -65,7 +65,7 @@ export async function promote(
   // Generate embedding
   let vector: Float32Array | undefined;
   try {
-    const v = await embedder.embed(`${title}\n${input.content.slice(0, 512)}`);
+    const v = await embedder.embed(`${title}\n${input.content.slice(0, 1024)}`);
     vector = v ?? undefined;
   } catch {
     // Fall back to FTS-only
@@ -76,7 +76,7 @@ export async function promote(
       type: type as any,
       title,
       content: input.content,
-      summary: input.content.slice(0, 200).replace(/\n/g, " ").trim(),
+      summary: input.content.slice(0, 500).replace(/\n/g, " ").trim(),
       tags,
       source: `${input.source_type}:${input.source_ref}`,
     },

--- a/plugins/mc-memory/src/recall.ts
+++ b/plugins/mc-memory/src/recall.ts
@@ -167,6 +167,7 @@ function searchEpisodic(
         score,
         date,
         snippet: body.trim().slice(0, 300),
+        content: body.trim(),
       });
     }
   } catch {

--- a/plugins/mc-memory/src/types.ts
+++ b/plugins/mc-memory/src/types.ts
@@ -80,6 +80,7 @@ export interface RecallResult {
   // Episodic fields
   date?: string;
   snippet?: string;
+  content?: string;   // full episodic body text (for agent/context consumption)
 }
 
 export interface PromoteResult {

--- a/plugins/mc-memory/src/writer.ts
+++ b/plugins/mc-memory/src/writer.ts
@@ -86,7 +86,7 @@ async function writeKb(
   // Generate embedding
   let vector: Float32Array | undefined;
   try {
-    const v = await embedder.embed(`${title}\n${content.slice(0, 512)}`);
+    const v = await embedder.embed(`${title}\n${content.slice(0, 1024)}`);
     vector = v ?? undefined;
   } catch {
     // Fall back to FTS-only
@@ -100,7 +100,7 @@ async function writeKb(
       type: type as any,
       title,
       content,
-      summary: content.slice(0, 200).replace(/\n/g, " ").trim(),
+      summary: content.slice(0, 500).replace(/\n/g, " ").trim(),
       tags,
       source: context?.source ?? "memory_write",
     },

--- a/plugins/mc-memory/tools/definitions.ts
+++ b/plugins/mc-memory/tools/definitions.ts
@@ -169,7 +169,7 @@ export function createMemoryTools(
               case "memo":
                 return `[Memo/${r.cardId}] ${r.timestamp ?? ""}\n> ${r.line}`;
               case "episodic":
-                return `[Episodic/${r.date}]\n> ${r.snippet}`;
+                return `[Episodic/${r.date}]\n> ${r.content ?? r.snippet}`;
               default:
                 return `[${r.source}] (unknown format)`;
             }


### PR DESCRIPTION
## Summary
- Store full episodic body text in `RecallResult.content` field alongside the existing 300-char `snippet`
- Context injection (`before_prompt_build`) now uses full content capped at 2000 chars instead of 150-char snippet
- `memory_recall` tool output shows full episodic content instead of truncated snippet
- KB auto-summary increased from 200→500 chars; embedding input from 512→1024 chars
- CLI display truncation (120 chars) preserved for terminal preview

## Files changed
- `plugins/mc-memory/src/types.ts` — added optional `content` field to `RecallResult`
- `plugins/mc-memory/src/recall.ts` — populate `content` with full body
- `plugins/mc-memory/index.ts` — use full content in context injection (2000 cap)
- `plugins/mc-memory/tools/definitions.ts` — show full content in tool output
- `plugins/mc-memory/src/writer.ts` — increase summary (500) and embedding (1024) limits
- `plugins/mc-memory/src/promote.ts` — same limit increases

## Test plan
- [ ] `openclaw mc-memory recall --query "email triage"` returns full episodic content
- [ ] Memory context injection in agent prompts shows full memories (up to 2000 chars)
- [ ] CLI `mc-memory list` still shows 120-char previews
- [ ] No regressions in memory_write, memory_promote tools