### PR TITLE
Clarify subscription pricing in multilingual READMEs

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -201,9 +201,21 @@ Eso es todo. El **asistente de configuración** te guía a través de la configu
 ### Requisitos
 
 - **Un Mac** — 2020 o más reciente (Intel o Apple Silicon)
-- **Claves API** — Claude, GPT-4 o tu LLM preferido (almacenado cifrado en `mc-vault`)
+- **Una suscripción a Claude** (obligatoria) — MiniClaw está diseñado para funcionar con una suscripción a Claude. Sin cobros por uso, sin cargos sorpresa.
 - **~20GB de disco** — para el entorno de ejecución y modelos locales
 - **Internet** — para la configuración e inferencia de LLM (solo SSL, sin telemetría)
+
+### Precios
+
+MiniClaw funciona con tu suscripción existente a Claude — **sin facturas sorpresa, sin tarifas por token**.
+
+| Plan | Costo mensual | Ideal para |
+|------|-------------|----------|
+| **Claude Pro** | $20/mes | Uso ligero — proyectos personales, tareas ocasionales |
+| **Claude Max (5x)** | $100/mes | Cargas de trabajo promedio — operación autónoma diaria |
+| **Claude Max (20x)** | $200/mes | Desarrolladores y alto volumen — uso autónomo intensivo, múltiples agentes |
+
+**¿Y las otras claves API?** Algunos plugins usan APIs de terceros opcionales (por ejemplo, Nano Banana 2 para generación de imágenes en mc-designer, Perplexity para mc-research). Estos son **complementos opcionales** — MiniClaw funciona sin ellos. Si los agregas, usan sus propios precios. Todas las claves se almacenan cifradas en `mc-vault`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -203,9 +203,21 @@ That's it. The **setup wizard** walks you through API key configuration, plugin 
 ### Requirements
 
 - **A Mac** — 2020 or newer (Intel or Apple Silicon)
-- **API keys** — Claude, GPT-4, or your preferred LLM (stored encrypted in `mc-vault`)
+- **A Claude subscription** (required) — MiniClaw is built to run on a Claude subscription. No usage-based billing, no surprise charges.
 - **~20GB disk** — for runtime and local models
 - **Internet** — for setup and LLM inference (SSL only, no telemetry)
+
+### Pricing
+
+MiniClaw runs on your existing Claude subscription — **no surprise bills, no pay-per-token fees**.
+
+| Plan | Monthly Cost | Best For |
+|------|-------------|----------|
+| **Claude Pro** | $20/month | Light use — personal projects, occasional tasks |
+| **Claude Max (5x)** | $100/month | Average workloads — daily autonomous operation |
+| **Claude Max (20x)** | $200/month | Developers and high-volume — heavy autonomous use, multiple agents |
+
+**What about other API keys?** Some plugins use optional third-party APIs (e.g., Nano Banana 2 for mc-designer image generation, Perplexity for mc-research). These are **optional add-ons** — MiniClaw works without them. If you add them, they use their own pricing. All keys are stored encrypted in `mc-vault`.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -201,9 +201,21 @@ curl -fsSL https://raw.githubusercontent.com/augmentedmike/miniclaw-os/main/boot
 ### 系统要求
 
 - **Mac** — 2020 年或更新款（Intel 或 Apple Silicon）
-- **API 密钥** — Claude、GPT-4 或你偏好的 LLM（加密存储于 `mc-vault`）
+- **Claude 订阅**（必需） — MiniClaw 专为 Claude 订阅设计运行。无按量计费，无意外账单。
 - **约 20GB 磁盘空间** — 用于运行时和本地模型
 - **网络连接** — 用于安装和 LLM 推理（仅 SSL，无遥测）
+
+### 价格
+
+MiniClaw 使用你现有的 Claude 订阅运行 — **无意外账单，无按 token 收费**。
+
+| 方案 | 月费 | 适用场景 |
+|------|-------------|----------|
+| **Claude Pro** | $20/月 | 轻度使用 — 个人项目、偶尔的任务 |
+| **Claude Max (5x)** | $100/月 | 中等负载 — 日常自主运行 |
+| **Claude Max (20x)** | $200/月 | 开发者和高负载 — 重度自主使用、多智能体 |
+
+**其他 API 密钥呢？** 部分插件使用可选的第三方 API（例如 Nano Banana 2 用于 mc-designer 图像生成，Perplexity 用于 mc-research）。这些是**可选附加组件** — MiniClaw 无需它们即可运行。如果你添加了它们，它们使用各自的定价。所有密钥均加密存储于 `mc-vault`。
 
 ---
 


### PR DESCRIPTION
## Summary
- Replaces vague "API keys" requirement with explicit Claude subscription requirement in all three READMEs (EN, ES, ZH-CN)
- Adds a Pricing section with the three Claude tiers: $20/mo (light), $100/mo (average), $200/mo (developers/high-volume)
- Clarifies that other API keys (Nano Banana 2, Perplexity, etc.) are optional add-ons, not required

## Test plan
- [ ] Verify README.md renders correctly on GitHub
- [ ] Verify README.es.md renders correctly on GitHub
- [ ] Verify README.zh-CN.md renders correctly on GitHub
- [ ] Confirm pricing table displays properly in all three languages

Closes #372