### PR TITLE
Release v0.1.9-prerelease

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -1,11 +1,11 @@
 {
   "name": "miniclaw-os",
-  "version": "0.1.8",
+  "version": "0.1.9-prerelease",
   "openclaw": {
     "npm": "@miniclaw_official/openclaw",
     "npmVersion": "2026.3.12",
     "repo": "augmentedmike/openclaw",
-    "tag": "v0.1.8"
+    "tag": "v0.1.9-prerelease"
   },
   "description": "AugmentedMike's AI operating system \u2014 plugins, tools, and infrastructure for OpenClaw",
   "dependencies": {

--- a/README.es.md
+++ b/README.es.md
@@ -14,7 +14,7 @@
   <a href="#install"><img src="https://img.shields.io/badge/Install_in_60s-FF6D00?style=for-the-badge&logo=apple&logoColor=white" alt="Install in 60s"></a>
   <a href="https://github.com/augmentedmike/miniclaw-os/stargazers"><img src="https://img.shields.io/github/stars/augmentedmike/miniclaw-os?style=for-the-badge&color=yellow" alt="GitHub Stars"></a>
   <a href="https://github.com/augmentedmike/miniclaw-os/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge" alt="Apache 2.0 License"></a>
-  <a href="https://github.com/augmentedmike/miniclaw-os/releases"><img src="https://img.shields.io/badge/version-v0.1.8-blue?style=for-the-badge" alt="v0.1.8"></a>
+  <a href="https://github.com/augmentedmike/miniclaw-os/releases"><img src="https://img.shields.io/badge/version-v0.1.9--prerelease-blue?style=for-the-badge" alt="v0.1.9-prerelease"></a>
   <a href="https://github.com/augmentedmike/miniclaw-os/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/augmentedmike/miniclaw-os/test.yml?branch=stable&style=for-the-badge&label=tests" alt="Tests"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="#install"><img src="https://img.shields.io/badge/Install_in_60s-FF6D00?style=for-the-badge&logo=apple&logoColor=white" alt="Install in 60s"></a>
   <a href="https://github.com/augmentedmike/miniclaw-os/stargazers"><img src="https://img.shields.io/github/stars/augmentedmike/miniclaw-os?style=for-the-badge&color=yellow" alt="GitHub Stars"></a>
   <a href="https://github.com/augmentedmike/miniclaw-os/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge" alt="Apache 2.0 License"></a>
-  <a href="https://github.com/augmentedmike/miniclaw-os/releases"><img src="https://img.shields.io/badge/version-v0.1.8-blue?style=for-the-badge" alt="v0.1.8"></a>
+  <a href="https://github.com/augmentedmike/miniclaw-os/releases"><img src="https://img.shields.io/badge/version-v0.1.9--prerelease-blue?style=for-the-badge" alt="v0.1.9-prerelease"></a>
   <a href="https://github.com/augmentedmike/miniclaw-os/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/augmentedmike/miniclaw-os/test.yml?branch=stable&style=for-the-badge&label=tests" alt="Tests"></a>
 </p>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@
   <a href="#install"><img src="https://img.shields.io/badge/Install_in_60s-FF6D00?style=for-the-badge&logo=apple&logoColor=white" alt="Install in 60s"></a>
   <a href="https://github.com/augmentedmike/miniclaw-os/stargazers"><img src="https://img.shields.io/github/stars/augmentedmike/miniclaw-os?style=for-the-badge&color=yellow" alt="GitHub Stars"></a>
   <a href="https://github.com/augmentedmike/miniclaw-os/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge" alt="Apache 2.0 License"></a>
-  <a href="https://github.com/augmentedmike/miniclaw-os/releases"><img src="https://img.shields.io/badge/version-v0.1.8-blue?style=for-the-badge" alt="v0.1.8"></a>
+  <a href="https://github.com/augmentedmike/miniclaw-os/releases"><img src="https://img.shields.io/badge/version-v0.1.9--prerelease-blue?style=for-the-badge" alt="v0.1.9-prerelease"></a>
   <a href="https://github.com/augmentedmike/miniclaw-os/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/augmentedmike/miniclaw-os/test.yml?branch=stable&style=for-the-badge&label=tests" alt="Tests"></a>
 </p>
 


### PR DESCRIPTION
## Summary

Version bump to 0.1.9-prerelease. This release includes all fixes and features since v0.1.8.

### Highlights

**New Features**
- WebMCP integration for miniclaw.bot and helloam.bot
- mc-vending-bench — VendingBench 2 benchmark plugin
- mc-email rewrite to wrap himalaya CLI (removed nodemailer/imapflow)
- mc-board: mobile responsive redesign with swipeable columns, tabbed memory, touch office
- mc-board: dynamic accent color system, hamburger menu, interrupt overlay for streaming chat
- mc-board: auto-search similar cards before creating new ones
- mc-board: FileViewModal for non-image attachments
- mc-board: shipped_at timestamp tracking
- mc-kb: hybrid search with vector + FTS, descriptive error formatting
- mc-memory: paginated list command
- Spanish and Chinese README translations with language switcher
- Shared error formatter adopted across mc-board, mc-backup, mc-rolodex

**Fixes**
- mc-board: speech-to-text race condition and resource leaks
- mc-board: separate setup wizard and settings routes
- mc-board: removed health dots from top bar
- mc-email: correct email-triage paths, support Sent folder queries
- mc-memory: preserve full episodic content (was truncating to 300 chars)
- mc-substack: convert markdown to ProseMirror before publishing
- mc-vpn: correct JSON field paths for Mullvad status parsing
- vending-bench: use MiniClaw agent loop + persistent Claude Code session

**Docs & Tests**
- Build Your First Plugin tutorial
- Documentation templates for 17 undocumented plugins
- mc-kb vitest coverage for store CRUD/FTS and hybridSearch

## Test plan
- [ ] `mc-smoke` passes
- [ ] Board web UI loads on port 4220
- [ ] Version shows 0.1.9-prerelease in MANIFEST.json