### PR TITLE
feat(mc-board): click card ID to copy to clipboard

### DIFF
--- a/plugins/mc-board/web/src/app/globals.css
+++ b/plugins/mc-board/web/src/app/globals.css
@@ -291,6 +291,9 @@ a { color: inherit; }
 .card--held:hover { border-color: rgba(217,119,6,.5); }
 .card-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 4px; }
 .card-id { font-size: 11px; color: #52525b; font-family: monospace; }
+.card-id--clickable { cursor: pointer; user-select: none; transition: color 0.15s; }
+.card-id--clickable:hover { color: #a1a1aa; }
+.card-id--copied { color: #22c55e !important; }
 .priority-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; display: inline-block; }
 .card-worker {
   display: none;

--- a/plugins/mc-board/web/src/components/card-item.tsx
+++ b/plugins/mc-board/web/src/components/card-item.tsx
@@ -75,6 +75,7 @@ export const CardItem = memo(function CardItem({ card, projectName, isActive, wo
   const pct = total > 0 ? Math.round((checked / total) * 100) : -1;
   const focused = card.tags.includes("focus");
   const held = card.tags.includes("hold");
+  const [idCopied, setIdCopied] = useState(false);
 
   const handleContextMenu = (e: React.MouseEvent) => {
     if (!onInjectContext) return;
@@ -111,7 +112,17 @@ export const CardItem = memo(function CardItem({ card, projectName, isActive, wo
 
       {/* Header: id + focus badge + priority badge */}
       <div className="card-header">
-        <span className="card-id">{card.id}</span>
+        <span
+          className={`card-id card-id--clickable${idCopied ? " card-id--copied" : ""}`}
+          title="Click to copy card ID"
+          onClick={(e) => {
+            e.stopPropagation();
+            navigator.clipboard.writeText(card.id).then(() => {
+              setIdCopied(true);
+              setTimeout(() => setIdCopied(false), 1600);
+            });
+          }}
+        >{idCopied ? "copied!" : card.id}</span>
         <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
           <HoldBadge held={held} onToggle={onHoldToggle ? (e) => { e.stopPropagation(); onHoldToggle(card.id); } : undefined} />
           <FocusBadge focused={focused} onToggle={onFocusToggle ? (e) => { e.stopPropagation(); onFocusToggle(card.id, !focused); } : undefined} />

--- a/plugins/mc-board/web/src/components/card-modal.tsx
+++ b/plugins/mc-board/web/src/components/card-modal.tsx
@@ -560,6 +560,7 @@ export function CardModal({ cardId, projects, activeIds, onClose, onOpenLog, onT
   );
 
   const [fileModal, setFileModal] = useState<{ path: string; base?: string } | null>(null);
+  const [idCopied, setIdCopied] = useState(false);
 
   const projectMap = Object.fromEntries(projects.map(p => [p.id, p.name]));
   const isActive = cardId ? (activeIds?.has(cardId) ?? false) : false;
@@ -760,7 +761,17 @@ export function CardModal({ cardId, projects, activeIds, onClose, onOpenLog, onT
       {/* Footer */}
       {card && (
         <div className="border-t border-zinc-800 px-6 py-3 flex-shrink-0">
-          <div className="text-xs text-zinc-600 font-mono">{card.id}</div>
+          <div
+            className="text-xs font-mono card-id--clickable"
+            style={{ color: idCopied ? "#22c55e" : "#52525b", cursor: "pointer", userSelect: "none", display: "inline-block" }}
+            title="Click to copy card ID"
+            onClick={() => {
+              navigator.clipboard.writeText(card.id).then(() => {
+                setIdCopied(true);
+                setTimeout(() => setIdCopied(false), 1600);
+              });
+            }}
+          >{idCopied ? "copied!" : card.id}</div>
         </div>
       )}
     </Modal>


### PR DESCRIPTION
## Summary
- Add clipboard copy on click for card IDs in board card list and card modal footer
- Visual feedback shows "copied!" in green for 1.6 seconds
- Uses stopPropagation on board cards to prevent card open on ID click
- Follows existing clipboard pattern from file-view-modal.tsx

## Test plan
- [ ] Click card ID on board → copies to clipboard, shows "copied!" in green
- [ ] Click card ID in card modal footer → same behavior
- [ ] Clicking card ID does NOT open the card modal
- [ ] Hover over card ID shows pointer cursor and lighter color

Card: crd_76c47aa4