### PR TITLE
Add pilot program document (PILOTS.md)

### DIFF
--- a/PILOTS.md
+++ b/PILOTS.md
@@ -1,0 +1,160 @@
+# MiniClaw Pilot Program
+
+> **We're looking for professionals who want to push what AI agents can actually do.**
+>
+> MiniClaw OS is a cognitive architecture — memory, planning, continuity, self-repair — running locally on your Mac. We're building it in the open and we need real-world operators to help us make it great.
+>
+> **As a pilot, you get:**
+> - Direct access to the MiniClaw team and founder
+> - Hands-on onboarding and setup support
+> - Your feedback shapes the product — plugins, workflows, and priorities
+> - Early access to new capabilities before public release
+>
+> **What we ask:**
+> - Use MiniClaw on real work, not toy examples
+> - Tell us what breaks, what's missing, and what surprises you
+> - Be willing to iterate with us
+>
+> **Interested?** [Apply here](https://miniclaw.bot/#pilots) or email **michael@claimhawk.app** with what you do and what you'd want your agent to handle.
+
+---
+
+## Use Cases
+
+MiniClaw OS isn't limited to software development. The plugin architecture, persistent memory, and autonomous task execution make it useful across any domain where you need an AI that actually remembers what it's doing.
+
+### Sales
+
+- **Lead research and qualification** — Agent researches prospects, enriches contact data via `mc-rolodex`, and drafts personalized outreach
+- **Pipeline management** — Track deals on `mc-board`, automate follow-ups via `mc-email`, and surface stale opportunities
+- **Competitive intelligence** — `mc-research` monitors competitors, summarizes changes, and flags relevant shifts
+- **Meeting prep** — Pull context from memory, CRM notes, and prior correspondence before every call
+- **Quote and proposal generation** — `mc-docs` drafts proposals with versioning; `mc-stripe` or `mc-square` handles payments
+
+### Marketing
+
+- **Content calendar execution** — Plan campaigns on `mc-board`, write and schedule posts via `mc-substack`, `mc-reddit`, `mc-x`
+- **SEO management** — `mc-seo` runs audits, tracks rankings, and submits sitemaps
+- **Social media operations** — Monitor mentions, draft replies, manage publishing across platforms
+- **Email campaigns** — Segment contacts in `mc-rolodex`, draft sequences, send and track via `mc-email`
+- **Visual asset creation** — `mc-designer` generates and composites images for social, blog, and ads
+- **Blog and newsletter publishing** — `mc-blog` and `mc-substack` handle end-to-end content production
+
+### CRM & Customer Success
+
+- **Contact management** — `mc-rolodex` with fuzzy search, tagging, trust tracking, and relationship history
+- **Inbox triage** — `mc-email` classifies, routes, and auto-responds to incoming messages
+- **Customer onboarding** — Automated welcome sequences, documentation delivery, and check-in scheduling via `mc-calendar`
+- **Support ticket tracking** — Log issues on `mc-board`, research solutions via `mc-kb`, draft responses
+- **Retention monitoring** — Track engagement patterns, flag at-risk accounts, draft re-engagement outreach
+
+### Software Development
+
+- **Autonomous coding** — Agent picks tasks from `mc-board`, writes code, runs tests, submits PRs via `mc-github`
+- **Bug triage and self-repair** — `mc-contribute` files issues with full context; agent patches its own bugs
+- **Code review** — `mc-github` reviews PRs, checks for patterns, suggests improvements
+- **Documentation** — `mc-docs` generates and maintains technical docs alongside code changes
+- **Release management** — Automated changelog generation, version bumping, and release notes via `mc-devlog`
+
+### Copywriting & Content
+
+- **Long-form writing** — Research, outline, draft, and revise articles with persistent context across sessions
+- **Brand voice consistency** — `mc-soul` maintains tone, style, and vocabulary preferences across all output
+- **Multi-format adaptation** — Repurpose a single piece into blog posts, social threads, newsletters, and email sequences
+- **Editing and revision** — Agent remembers editorial feedback and applies it to future drafts without re-prompting
+- **Client work management** — Track assignments on `mc-board`, manage deadlines via `mc-calendar`
+
+### Underwriting & Risk Assessment
+
+- **Document analysis** — Ingest policies, applications, and supporting documents; extract key data points
+- **Risk research** — `mc-research` pulls industry data, loss histories, and regulatory updates
+- **Report generation** — `mc-docs` produces structured assessment reports with version tracking
+- **Compliance monitoring** — Flag policy changes, regulatory shifts, and documentation gaps
+- **Portfolio tracking** — Monitor exposure across accounts using `mc-board` and `mc-kb` for historical context
+
+### Novel Writing & Creative Work
+
+- **World-building** — `mc-kb` stores characters, locations, timelines, and plot threads across sessions
+- **Drafting with continuity** — Agent remembers every chapter, character arc, and narrative decision
+- **Research integration** — `mc-research` gathers historical, cultural, and technical details for authenticity
+- **Revision management** — `mc-docs` tracks drafts with full version history and editorial notes
+- **Publishing pipeline** — From manuscript to formatted blog serialization via `mc-blog` and `mc-substack`
+
+### Finance & Accounting
+
+- **Invoice processing** — Parse incoming invoices from `mc-email`, log to board, trigger payments via `mc-stripe`
+- **Financial reporting** — Aggregate data, generate summaries, and track key metrics over time in `mc-kb`
+- **Expense tracking** — Categorize transactions, flag anomalies, and produce periodic reports
+- **Client billing** — `mc-booking` manages appointments; `mc-stripe` and `mc-square` handle collection
+- **Audit preparation** — `mc-docs` maintains documentation trails with version history
+
+### Legal & Compliance
+
+- **Contract review** — Ingest documents, flag non-standard clauses, and track revision history
+- **Compliance monitoring** — `mc-research` watches regulatory feeds; `mc-board` tracks action items
+- **Case management** — Organize matters on `mc-board` with deadlines, notes, and document links
+- **Legal research** — Cross-reference case law, statutes, and internal precedents via `mc-kb`
+- **Document assembly** — `mc-docs` generates templated agreements with versioning
+
+### Real Estate
+
+- **Listing management** — Track properties on `mc-board`, draft descriptions, schedule showings via `mc-calendar`
+- **Client communication** — Automated updates, showing confirmations, and follow-ups via `mc-email`
+- **Market research** — `mc-research` monitors comparable sales, market trends, and neighborhood data
+- **Transaction coordination** — Track milestones, deadlines, and document requirements across deals
+- **Marketing materials** — `mc-designer` creates property graphics; `mc-social` distributes across platforms
+
+### Education & Research
+
+- **Literature review** — `mc-research` gathers sources; `mc-kb` stores and cross-references findings
+- **Writing assistance** — Draft, revise, and cite with persistent context across sessions
+- **Course management** — Track syllabi, assignments, and deadlines on `mc-board`
+- **Student communication** — Batch and personalized outreach via `mc-email`
+- **Knowledge management** — Build a searchable knowledge base that grows with every research session
+
+### Personal Productivity
+
+- **Life management** — Calendar, email, contacts, and task tracking unified under one agent
+- **Health tracking** — Medication reminders, appointment scheduling, and habit monitoring
+- **Travel planning** — Research destinations, compare options, and build itineraries with persistent memory
+- **Daily briefings** — Morning summaries pulling from email, calendar, board, and news
+- **Home automation** — Integrate with smart devices, schedule routines, and respond to voice commands
+
+---
+
+## How the Pilot Works
+
+1. **Apply** — Tell us your domain, your team size, and what you'd want MiniClaw to handle
+2. **Onboard** — We set up your instance, configure plugins for your workflow, and walk you through everything
+3. **Use it** — Run MiniClaw on your real work for 30 days
+4. **Feedback loop** — Weekly check-ins with the team. Your input directly shapes what we build next
+5. **Stay or go** — No lock-in. If it works, keep using it. If not, you helped us get better
+
+---
+
+## Requirements
+
+- A Mac (2020 or newer)
+- A Claude subscription ([Pro $20/mo](https://claude.ai) or [Max $100–200/mo](https://claude.ai))
+- Real work to throw at it — we're not looking for tire-kickers
+
+---
+
+## Apply
+
+**Email:** michael@claimhawk.app
+**Subject:** MiniClaw Pilot — [Your Domain]
+
+Tell us:
+- What you do
+- What tasks you'd want your agent to handle
+- Your team size (solo is fine)
+- Any tools or workflows you'd need integrated
+
+Or visit [miniclaw.bot/#pilots](https://miniclaw.bot/#pilots) to apply online.
+
+---
+
+<p align="center">
+  <strong>We're building the brain for AI agents. Help us make it work for your world.</strong>
+</p>


### PR DESCRIPTION
## Summary
- Adds `PILOTS.md` — a recruiting document for the MiniClaw pilot program
- Covers 12 use-case domains: Sales, Marketing, CRM, Software Dev, Copywriting, Underwriting, Novel Writing, Finance, Legal, Real Estate, Education, Personal Productivity
- Each domain maps real tasks to specific MiniClaw plugins
- Includes banner with clear value prop and apply instructions

**Board card:** `crd_324b9f53`

## Test plan
- [ ] Verify PILOTS.md renders correctly on GitHub
- [ ] Confirm all plugin references are accurate
- [ ] Check apply link points to correct URL