### PR TITLE
feat(mc-board): derive shipped_at from card_history for CLI archive-search

### DIFF
--- a/plugins/mc-board/cli/commands.ts
+++ b/plugins/mc-board/cli/commands.ts
@@ -598,7 +598,8 @@ Examples:
         return;
       }
       for (const card of results) {
-        console.log(`${card.id}  ${card.title}  [shipped ${card.updated_at.slice(0, 10)}]`);
+        const shippedAt = card.history?.filter((h: { column: string; moved_at: string }) => h.column === "shipped").pop()?.moved_at;
+        console.log(`${card.id}  ${card.title}  [shipped ${(shippedAt ?? card.updated_at).slice(0, 10)}]`);
       }
     });
 

--- a/plugins/mc-board/web/src/lib/accent-context.tsx
+++ b/plugins/mc-board/web/src/lib/accent-context.tsx
@@ -1,0 +1,19 @@
+"use client";
+import { createContext, useContext } from "react";
+
+const DEFAULT_ACCENT = "#00E5CC";
+
+export const AccentContext = createContext<string>(DEFAULT_ACCENT);
+
+export function useAccent(): string {
+  return useContext(AccentContext);
+}
+
+/** Convert hex to RGB components for use in rgba() */
+export function hexToRgb(hex: string): string {
+  const h = hex.replace("#", "");
+  const r = parseInt(h.substring(0, 2), 16);
+  const g = parseInt(h.substring(2, 4), 16);
+  const b = parseInt(h.substring(4, 6), 16);
+  return `${r}, ${g}, ${b}`;
+}


### PR DESCRIPTION
## Summary
- CLI `archive-search` now shows the actual shipped date (derived from `card_history`) instead of `updated_at` for shipped cards
- Adds `accent-context.tsx` for web UI accent color theming

## Test plan
- [x] `shipped_at` field exists in web `BoardCard` type (`types.ts`)
- [x] SQL query in `data.ts` derives `shipped_at` via subquery from `card_history`
- [x] Web UI `card-item.tsx` displays shipped date when present
- [x] Web UI `column.tsx` sorts shipped column by `shipped_at`
- [x] CLI archive-search derives `shipped_at` from card history
- [x] Working plugin synced with upstream changes