### PR TITLE
feat(mc-realty): real estate workflow orchestration plugin

### DIFF
--- a/plugins/mc-realty/cli/commands.ts
+++ b/plugins/mc-realty/cli/commands.ts
@@ -1,0 +1,525 @@
+import type { Command } from "commander";
+import type { Logger } from "openclaw/plugin-sdk";
+import type { RealtyConfig } from "../src/config.js";
+import { searchComps, getPropertyDetails } from "../src/attom.js";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+interface Ctx {
+  program: Command;
+  cfg: RealtyConfig;
+  logger: Logger;
+}
+
+/* ── helpers ────────────────────────────────────────────────────────── */
+
+function ocBin(): string {
+  return process.env.OPENCLAW_BIN ?? "openclaw";
+}
+
+function run(bin: string, args: string[], opts?: { input?: string }): string {
+  try {
+    return execFileSync(bin, args, {
+      encoding: "utf-8",
+      timeout: 30_000,
+      input: opts?.input,
+    }).trim();
+  } catch (e: unknown) {
+    return `[exec error] ${(e as Error).message}`;
+  }
+}
+
+/** Run an openclaw plugin CLI command */
+function oc(...args: string[]): string {
+  return run(ocBin(), args);
+}
+
+function ensureDir(dir: string): void {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+}
+
+function fmtUsd(n: number): string {
+  return "$" + n.toLocaleString("en-US", { maximumFractionDigits: 0 });
+}
+
+function propertyId(address: string): string {
+  return address
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "")
+    .slice(0, 60);
+}
+
+/* ── register ───────────────────────────────────────────────────────── */
+
+export function registerRealtyCommands(ctx: Ctx): void {
+  const { program, cfg, logger } = ctx;
+
+  const sub = program
+    .command("mc-realty")
+    .description("Real estate workflow orchestration — listings, comps, showings, transactions, reports");
+
+  /* ── list-property ────────────────────────────────────────────────── */
+
+  sub
+    .command("list-property")
+    .description("Create a property listing — board card + KB entry + description via mc-docs")
+    .requiredOption("--address <addr>", "Street address")
+    .requiredOption("--city <city>", "City")
+    .requiredOption("--state <st>", "State abbreviation")
+    .option("--zip <zip>", "ZIP code")
+    .option("--price <price>", "Asking price")
+    .option("--beds <n>", "Bedrooms")
+    .option("--baths <n>", "Bathrooms")
+    .option("--sqft <n>", "Square footage")
+    .option("--description <text>", "Property highlights")
+    .action(async (opts: Record<string, string>) => {
+      const pid = propertyId(opts.address);
+      logger.info(`Listing property: ${opts.address}, ${opts.city}, ${opts.state}`);
+
+      // 1. Store property data in mc-kb
+      const kbData = JSON.stringify({
+        address: opts.address,
+        city: opts.city,
+        state: opts.state,
+        zip: opts.zip || "",
+        askingPrice: opts.price || "",
+        beds: opts.beds || "",
+        baths: opts.baths || "",
+        sqft: opts.sqft || "",
+        description: opts.description || "",
+        status: "listed",
+        listedDate: new Date().toISOString().split("T")[0],
+      });
+      oc("mc-kb", "add", `realty-property-${pid}`, "--content", kbData, "--tags", "realty,property,listing");
+      console.log(`  KB entry created: realty-property-${pid}`);
+
+      // 2. Create mc-board card for tracking
+      const title = `Property: ${opts.address}, ${opts.city} ${opts.state}`;
+      const cardNotes = [
+        `Address: ${opts.address}, ${opts.city}, ${opts.state} ${opts.zip || ""}`,
+        opts.price ? `Asking: ${opts.price}` : "",
+        opts.beds ? `Beds: ${opts.beds}` : "",
+        opts.baths ? `Baths: ${opts.baths}` : "",
+        opts.sqft ? `Sqft: ${opts.sqft}` : "",
+        `KB: realty-property-${pid}`,
+      ]
+        .filter(Boolean)
+        .join("\n");
+
+      oc("mc-board", "create", title, "--tags", "realty,property", "--notes", cardNotes);
+      console.log(`  Board card created: ${title}`);
+
+      // 3. Add to mc-rolodex as a property contact if notification email set
+      if (cfg.notificationEmail) {
+        oc("mc-rolodex", "add", pid, "--email", cfg.notificationEmail, "--tags", "realty,seller", "--notes", `Property: ${opts.address}`);
+        console.log(`  Rolodex entry created for seller`);
+      }
+
+      // 4. Generate listing description via mc-docs
+      const prompt = `Write a compelling real estate listing description for: ${opts.address}, ${opts.city}, ${opts.state}. ${opts.beds || "?"} beds, ${opts.baths || "?"} baths, ${opts.sqft || "?"} sqft. ${opts.description || ""}. Write in a professional MLS style.`;
+      const desc = oc("mc-docs", "generate", "--prompt", prompt);
+      if (desc && !desc.startsWith("[exec error]")) {
+        console.log(`\n--- Generated Listing Description ---\n${desc}\n`);
+      }
+
+      // 5. Save listing data locally
+      ensureDir(cfg.dataDir);
+      const listingFile = path.join(cfg.dataDir, `${pid}.json`);
+      fs.writeFileSync(listingFile, JSON.stringify({ ...JSON.parse(kbData), generatedDescription: desc }, null, 2));
+      console.log(`  Listing data saved: ${listingFile}`);
+      console.log(`\nProperty listed successfully. Use 'mc-realty comp-analysis' to get pricing data.`);
+    });
+
+  /* ── comp-analysis ────────────────────────────────────────────────── */
+
+  sub
+    .command("comp-analysis")
+    .description("Pull comps from ATTOM API and generate CMA report")
+    .requiredOption("--address <addr>", "Subject property street address")
+    .requiredOption("--city <city>", "City")
+    .requiredOption("--state <st>", "State abbreviation")
+    .option("--zip <zip>", "ZIP code")
+    .option("--radius <miles>", "Search radius in miles")
+    .option("--months <n>", "Lookback period in months")
+    .option("--max <n>", "Maximum number of comps to return")
+    .action(async (opts: Record<string, string>) => {
+      const pid = propertyId(opts.address);
+      logger.info(`Running comp analysis for ${opts.address}`);
+
+      console.log(`Searching for comps within ${opts.radius || cfg.compRadiusMiles}mi, last ${opts.months || cfg.compLookbackMonths} months...`);
+
+      try {
+        // 1. Fetch comps from ATTOM
+        const comps = await searchComps(cfg, {
+          address: opts.address,
+          city: opts.city,
+          state: opts.state,
+          zip: opts.zip,
+          radiusMiles: opts.radius ? parseFloat(opts.radius) : undefined,
+          lookbackMonths: opts.months ? parseInt(opts.months, 10) : undefined,
+          maxResults: opts.max ? parseInt(opts.max, 10) : undefined,
+        });
+
+        if (!comps.length) {
+          console.log("No comparable sales found. Try increasing radius or lookback period.");
+          return;
+        }
+
+        // 2. Calculate statistics
+        const prices = comps.map((c) => c.salePrice).filter((p) => p > 0);
+        const priceSqft = comps.map((c) => (c.sqft > 0 ? c.salePrice / c.sqft : 0)).filter((p) => p > 0);
+        const median = (arr: number[]) => {
+          const sorted = [...arr].sort((a, b) => a - b);
+          const mid = Math.floor(sorted.length / 2);
+          return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+        };
+        const avg = (arr: number[]) => arr.reduce((a, b) => a + b, 0) / arr.length;
+
+        // 3. Get subject property details
+        let subject = null;
+        try {
+          subject = await getPropertyDetails(cfg, {
+            address: opts.address,
+            city: opts.city,
+            state: opts.state,
+            zip: opts.zip,
+          });
+        } catch {
+          logger.info("Could not fetch subject property details — continuing with comps only");
+        }
+
+        // 4. Print CMA report
+        console.log(`\n${"=".repeat(60)}`);
+        console.log(`  COMPARATIVE MARKET ANALYSIS (CMA)`);
+        console.log(`  Subject: ${opts.address}, ${opts.city}, ${opts.state}`);
+        console.log(`${"=".repeat(60)}\n`);
+
+        if (subject) {
+          console.log(`Subject Property:`);
+          console.log(`  ${subject.bedrooms} bed / ${subject.bathrooms} bath / ${subject.sqft} sqft / Built ${subject.yearBuilt}`);
+          if (subject.avm) console.log(`  AVM (Automated Valuation): ${fmtUsd(subject.avm)}`);
+          if (subject.assessedValue) console.log(`  Assessed Value: ${fmtUsd(subject.assessedValue)}`);
+          if (subject.lastSalePrice) console.log(`  Last Sale: ${fmtUsd(subject.lastSalePrice)} (${subject.lastSaleDate})`);
+          console.log();
+        }
+
+        console.log(`Comparable Sales (${comps.length} found):\n`);
+        for (const c of comps) {
+          const pricePerSqft = c.sqft > 0 ? Math.round(c.salePrice / c.sqft) : 0;
+          console.log(`  ${c.address}, ${c.city} ${c.state} ${c.zip}`);
+          console.log(`    ${fmtUsd(c.salePrice)} | ${c.bedrooms}bd/${c.bathrooms}ba | ${c.sqft}sqft | $${pricePerSqft}/sqft | ${c.saleDate} | ${c.distanceMiles.toFixed(1)}mi`);
+        }
+
+        console.log(`\nMarket Summary:`);
+        console.log(`  Median Sale Price:   ${fmtUsd(median(prices))}`);
+        console.log(`  Average Sale Price:  ${fmtUsd(Math.round(avg(prices)))}`);
+        console.log(`  Price Range:         ${fmtUsd(Math.min(...prices))} – ${fmtUsd(Math.max(...prices))}`);
+        if (priceSqft.length) {
+          console.log(`  Median $/sqft:       $${Math.round(median(priceSqft))}`);
+          console.log(`  Average $/sqft:      $${Math.round(avg(priceSqft))}`);
+        }
+        console.log();
+
+        // 5. Store results in mc-kb
+        const cmaData = {
+          subject: opts.address,
+          date: new Date().toISOString().split("T")[0],
+          comps: comps.length,
+          medianPrice: median(prices),
+          avgPrice: Math.round(avg(prices)),
+          medianPriceSqft: priceSqft.length ? Math.round(median(priceSqft)) : null,
+          avm: subject?.avm ?? null,
+          compDetails: comps,
+        };
+        oc("mc-kb", "add", `realty-cma-${pid}`, "--content", JSON.stringify(cmaData), "--tags", "realty,cma,comps");
+        console.log(`CMA stored in KB: realty-cma-${pid}`);
+
+        // 6. Run supplementary research via mc-research
+        const researchQuery = `Real estate market trends ${opts.city} ${opts.state} ${new Date().getFullYear()} median home prices inventory`;
+        oc("mc-research", "search", researchQuery);
+        console.log(`Market research initiated via mc-research`);
+      } catch (e: unknown) {
+        console.error(`Comp analysis failed: ${(e as Error).message}`);
+        console.error(`Ensure ATTOM API key is set: openclaw mc-vault set attom_api_key <your-key>`);
+        process.exit(1);
+      }
+    });
+
+  /* ── schedule-showing ─────────────────────────────────────────────── */
+
+  sub
+    .command("schedule-showing")
+    .description("Create showing slots for a property via mc-booking + mc-calendar")
+    .requiredOption("--address <addr>", "Property address")
+    .requiredOption("--date <date>", "Showing date (YYYY-MM-DD)")
+    .option("--times <times>", "Comma-separated times (HH:MM), e.g. 10:00,11:00,14:00")
+    .option("--duration <min>", "Duration in minutes")
+    .option("--notify-buyers", "Email buyer contacts from mc-rolodex")
+    .action(async (opts: Record<string, string | boolean>) => {
+      const duration = (opts.duration as string) || String(cfg.bookingDurationMinutes);
+      const times = ((opts.times as string) || "10:00,11:00,14:00,15:00").split(",").map((t) => t.trim());
+      const address = opts.address as string;
+      const date = opts.date as string;
+
+      logger.info(`Scheduling showings for ${address} on ${date}`);
+      console.log(`Creating ${times.length} showing slots for ${address} on ${date}...`);
+
+      for (const time of times) {
+        const isoTime = `${date}T${time}:00`;
+        // Create booking slot via mc-booking
+        oc(
+          "mc-booking",
+          "slots",
+          "--create",
+          "--time",
+          isoTime,
+          "--duration",
+          duration,
+          "--label",
+          `Showing: ${address}`,
+        );
+        console.log(`  Slot created: ${date} ${time} (${duration}min)`);
+
+        // Sync to mc-calendar
+        oc(
+          "mc-calendar",
+          "add",
+          "--title",
+          `Showing: ${address}`,
+          "--start",
+          isoTime,
+          "--duration",
+          duration,
+          "--notes",
+          `Property showing at ${address}`,
+        );
+      }
+
+      console.log(`\n${times.length} showing slots created and synced to calendar.`);
+
+      // Optionally notify buyers from rolodex
+      if (opts["notify-buyers"]) {
+        const buyers = oc("mc-rolodex", "search", "--tags", "buyer,realty");
+        if (buyers && !buyers.startsWith("[exec error]")) {
+          const subject = `Open House: ${address} — ${date}`;
+          const body = `Showing times available at ${address} on ${date}: ${times.join(", ")}. Reply to schedule your visit or book online.`;
+          oc("mc-email", "send", "--to-tag", "buyer", "--subject", subject, "--body", body);
+          console.log(`Buyer notification emails sent via mc-email`);
+        }
+      }
+
+      console.log(`\nUse 'openclaw mc-booking pending' to manage showing requests.`);
+    });
+
+  /* ── generate-listing ─────────────────────────────────────────────── */
+
+  sub
+    .command("generate-listing")
+    .description("Generate listing graphics (mc-designer) + blog post (mc-blog) + syndicate (mc-social)")
+    .requiredOption("--address <addr>", "Property address")
+    .option("--city <city>", "City")
+    .option("--state <st>", "State")
+    .option("--price <price>", "Asking price")
+    .option("--beds <n>", "Bedrooms")
+    .option("--baths <n>", "Bathrooms")
+    .option("--sqft <n>", "Square footage")
+    .option("--description <text>", "Property description or highlights")
+    .option("--no-syndicate", "Skip social media syndication")
+    .action(async (opts: Record<string, string | boolean>) => {
+      const address = opts.address as string;
+      const pid = propertyId(address);
+      logger.info(`Generating listing for ${address}`);
+
+      // 1. Generate listing graphic via mc-designer
+      console.log(`Generating listing graphics via mc-designer...`);
+      const designPrompt = `Professional real estate listing graphic for ${address}${opts.city ? `, ${opts.city}` : ""}. ${opts.beds || "?"}bed/${opts.baths || "?"}bath, ${opts.sqft || "?"}sqft. ${opts.price ? "Asking " + opts.price : ""}. Clean modern design with property details overlay. MLS-style.`;
+      oc("mc-designer", "gen", designPrompt, "-c", `realty-listing-${pid}`, "--role", "background");
+      ensureDir(path.join(cfg.dataDir, "listings"));
+      const graphicPath = path.join(cfg.dataDir, "listings", `${pid}-graphic.png`);
+      oc("mc-designer", "composite", "-c", `realty-listing-${pid}`, "-o", graphicPath);
+      console.log(`  Listing graphic: ${graphicPath}`);
+
+      // 2. Generate blog listing page via mc-blog
+      console.log(`Creating listing blog post via mc-blog...`);
+      const blogTitle = `${address}${opts.city ? `, ${opts.city}` : ""} — ${opts.beds || "?"}BD/${opts.baths || "?"}BA${opts.price ? " | " + opts.price : ""}`;
+      const blogBody = [
+        opts.description || `Beautiful property at ${address}.`,
+        "",
+        `**Details:**`,
+        opts.beds ? `- Bedrooms: ${opts.beds}` : "",
+        opts.baths ? `- Bathrooms: ${opts.baths}` : "",
+        opts.sqft ? `- Square Feet: ${opts.sqft}` : "",
+        opts.price ? `- Asking Price: ${opts.price}` : "",
+        "",
+        `Contact us to schedule a showing.`,
+      ]
+        .filter((l) => l !== "")
+        .join("\n");
+
+      oc("mc-blog", "create", "--title", blogTitle, "--body", blogBody, "--tags", "realty,listing", "--publish");
+      console.log(`  Blog listing published`);
+
+      // 3. Syndicate to social platforms
+      const shouldSyndicate = opts.syndicate !== false && cfg.autoSyndicate;
+      if (shouldSyndicate) {
+        console.log(`Syndicating to ${cfg.syndicatePlatforms.join(", ")} via mc-social...`);
+        const socialText = `New Listing: ${address}${opts.city ? `, ${opts.city}` : ""}. ${opts.beds || "?"}bd/${opts.baths || "?"}ba, ${opts.sqft || "?"}sqft. ${opts.price || "Contact for price"}. DM for details or to schedule a showing!`;
+        for (const platform of cfg.syndicatePlatforms) {
+          oc("mc-social", "post", "--platform", platform, "--text", socialText, "--image", graphicPath);
+          console.log(`  Posted to ${platform}`);
+        }
+      }
+
+      console.log(`\nListing generated successfully.`);
+    });
+
+  /* ── track-transaction ────────────────────────────────────────────── */
+
+  sub
+    .command("track-transaction")
+    .description("Create an mc-board pipeline to track a real estate transaction through stages")
+    .requiredOption("--address <addr>", "Property address")
+    .option("--buyer <name>", "Buyer name")
+    .option("--buyer-email <email>", "Buyer email")
+    .option("--price <price>", "Offer/contract price")
+    .option("--stage <stage>", "Initial stage (default: listed)")
+    .action(async (opts: Record<string, string>) => {
+      const address = opts.address;
+      const pid = propertyId(address);
+      const initialStage = opts.stage || cfg.transactionStages[0];
+      logger.info(`Creating transaction pipeline for ${address}`);
+
+      // 1. Create board card for the transaction
+      const title = `Transaction: ${address}`;
+      const stageList = cfg.transactionStages
+        .map((s) => (s === initialStage ? `**[${s}]**` : s))
+        .join(" → ");
+
+      const notes = [
+        `Property: ${address}`,
+        opts.buyer ? `Buyer: ${opts.buyer}` : "",
+        opts["buyer-email"] ? `Buyer Email: ${opts["buyer-email"]}` : "",
+        opts.price ? `Price: ${opts.price}` : "",
+        `\nPipeline: ${stageList}`,
+        `Current Stage: ${initialStage}`,
+      ]
+        .filter(Boolean)
+        .join("\n");
+
+      const criteria = cfg.transactionStages
+        .map((s) => `- [ ] ${s}`)
+        .join("\n");
+
+      oc("mc-board", "create", title, "--tags", `realty,transaction,${initialStage}`, "--notes", notes, "--criteria", criteria);
+      console.log(`Transaction card created: ${title}`);
+      console.log(`Pipeline: ${cfg.transactionStages.join(" → ")}`);
+      console.log(`Current stage: ${initialStage}`);
+
+      // 2. Add buyer to rolodex if provided
+      if (opts.buyer) {
+        oc(
+          "mc-rolodex",
+          "add",
+          opts.buyer.toLowerCase().replace(/\s+/g, "-"),
+          "--name",
+          opts.buyer,
+          "--email",
+          opts["buyer-email"] || "",
+          "--tags",
+          "realty,buyer",
+          "--notes",
+          `Buyer for ${address}`,
+        );
+        console.log(`Buyer added to rolodex: ${opts.buyer}`);
+      }
+
+      // 3. Store transaction in mc-kb
+      const txData = {
+        property: address,
+        buyer: opts.buyer || "",
+        buyerEmail: opts["buyer-email"] || "",
+        price: opts.price || "",
+        stage: initialStage,
+        stages: cfg.transactionStages,
+        created: new Date().toISOString(),
+        history: [{ stage: initialStage, date: new Date().toISOString() }],
+      };
+      oc("mc-kb", "add", `realty-tx-${pid}`, "--content", JSON.stringify(txData), "--tags", "realty,transaction");
+      console.log(`Transaction data stored in KB: realty-tx-${pid}`);
+
+      // 4. Send notification if configured
+      if (cfg.notificationEmail) {
+        oc(
+          "mc-email",
+          "send",
+          "--to",
+          cfg.notificationEmail,
+          "--subject",
+          `Transaction Started: ${address}`,
+          "--body",
+          `Transaction tracking initiated for ${address}.\nStage: ${initialStage}\n${opts.buyer ? "Buyer: " + opts.buyer : ""}\n${opts.price ? "Price: " + opts.price : ""}`,
+        );
+        console.log(`Notification sent to ${cfg.notificationEmail}`);
+      }
+
+      console.log(`\nUse 'openclaw mc-board update <card-id> --add-tags <next-stage>' to advance stages.`);
+    });
+
+  /* ── market-report ────────────────────────────────────────────────── */
+
+  sub
+    .command("market-report")
+    .description("Generate market report via mc-research and email to client")
+    .requiredOption("--market <area>", "Market area (e.g. 'Miami-Fort Lauderdale' or ZIP)")
+    .option("--email <addr>", "Recipient email (defaults to notification_email)")
+    .action(async (opts: Record<string, string>) => {
+      const market = opts.market || cfg.defaultMarket;
+      const email = opts.email || cfg.notificationEmail;
+      logger.info(`Generating market report for ${market}`);
+
+      // 1. Research market trends via mc-research
+      console.log(`Researching market trends for ${market}...`);
+      const query = `${market} real estate market report ${new Date().getFullYear()} median home price inventory days on market trends`;
+      const research = oc("mc-research", "search", query);
+      console.log(`  Research gathered`);
+
+      // 2. Generate formatted report
+      const reportPrompt = `Generate a professional real estate market report for ${market}. Include: median home price, price trends, inventory levels, days on market, market conditions (buyer's/seller's). Based on: ${research}`;
+      const report = oc("mc-docs", "generate", "--prompt", reportPrompt);
+
+      const reportDate = new Date().toISOString().split("T")[0];
+      const reportId = `market-${market.toLowerCase().replace(/[^a-z0-9]+/g, "-")}-${reportDate}`;
+
+      // 3. Store in mc-kb
+      oc("mc-kb", "add", `realty-${reportId}`, "--content", report || query, "--tags", "realty,market-report");
+      console.log(`  Report stored in KB: realty-${reportId}`);
+
+      // 4. Print report
+      if (report && !report.startsWith("[exec error]")) {
+        console.log(`\n${"=".repeat(60)}`);
+        console.log(`  MARKET REPORT: ${market}`);
+        console.log(`  Date: ${reportDate}`);
+        console.log(`${"=".repeat(60)}\n`);
+        console.log(report);
+      }
+
+      // 5. Email report if recipient configured
+      if (email) {
+        oc(
+          "mc-email",
+          "send",
+          "--to",
+          email,
+          "--subject",
+          `Market Report: ${market} — ${reportDate}`,
+          "--body",
+          report || `Market report for ${market} generated on ${reportDate}. See KB entry: realty-${reportId}`,
+        );
+        console.log(`\nReport emailed to ${email}`);
+      } else {
+        console.log(`\nNo email recipient configured. Set notification_email in config or pass --email.`);
+      }
+    });
+}

--- a/plugins/mc-realty/index.ts
+++ b/plugins/mc-realty/index.ts
@@ -1,0 +1,31 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { resolveConfig } from "./src/config.js";
+import { registerRealtyCommands } from "./cli/commands.js";
+import { createRealtyTools } from "./tools/definitions.js";
+
+export default function register(api: OpenClawPluginApi): void {
+  const cfg = resolveConfig((api.pluginConfig ?? {}) as Record<string, unknown>);
+
+  api.logger.info(`mc-realty loaded (market=${cfg.defaultMarket || "any"}, radius=${cfg.compRadiusMiles}mi)`);
+
+  if (typeof api.hook === "function") api.hook("before_prompt_build", (_ctx) => {
+    return {
+      prepend:
+        `## Real Estate Context\n` +
+        `You are a real estate assistant helping with FSBO (For Sale By Owner) and brokerage workflows.\n` +
+        `Available commands: list-property, comp-analysis, schedule-showing, generate-listing, track-transaction, market-report.\n` +
+        `For pricing, always use comp-analysis with real ATTOM Data API comps — never estimate prices from training data.\n` +
+        `Transaction stages: ${cfg.transactionStages.join(" → ")}.\n` +
+        `Default market: ${cfg.defaultMarket || "(not set — ask the user)"}.\n` +
+        `Syndication platforms: ${cfg.syndicatePlatforms.join(", ")}.\n`,
+    };
+  });
+
+  api.registerCli((ctx) => {
+    registerRealtyCommands({ program: ctx.program, cfg, logger: api.logger });
+  });
+
+  for (const tool of createRealtyTools(cfg)) {
+    api.registerTool(tool);
+  }
+}

--- a/plugins/mc-realty/openclaw.plugin.json
+++ b/plugins/mc-realty/openclaw.plugin.json
@@ -1,0 +1,54 @@
+{
+  "id": "mc-realty",
+  "name": "Miniclaw Realty",
+  "description": "Real estate workflow orchestration for FSBO sellers and small brokerages — pricing, listings, showings, transactions, and market reports.",
+  "version": "0.1.0",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "attom_api_key_vault": {
+        "type": "string",
+        "description": "mc-vault key name for ATTOM Data API key (default: attom_api_key)"
+      },
+      "default_market": {
+        "type": "string",
+        "description": "Default metro area for comp searches (e.g. 'Miami-Fort Lauderdale')"
+      },
+      "comp_radius_miles": {
+        "type": "number",
+        "description": "Radius in miles for comparable property search"
+      },
+      "comp_lookback_months": {
+        "type": "number",
+        "description": "How many months back to search for comps"
+      },
+      "comp_max_results": {
+        "type": "number",
+        "description": "Maximum number of comps to return"
+      },
+      "booking_duration_minutes": {
+        "type": "number",
+        "description": "Default showing duration in minutes"
+      },
+      "transaction_stages": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Pipeline stages for transaction tracking"
+      },
+      "syndicate_platforms": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Social platforms for listing syndication"
+      },
+      "auto_syndicate": {
+        "type": "boolean",
+        "description": "Auto-post listings to syndicate_platforms on generate-listing"
+      },
+      "notification_email": {
+        "type": "string",
+        "description": "Seller/agent email for status updates"
+      }
+    }
+  }
+}

--- a/plugins/mc-realty/package.json
+++ b/plugins/mc-realty/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "mc-realty",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "index.ts",
+  "description": "Real estate workflow orchestration — comp analysis, listings, showings, transactions, market reports",
+  "dependencies": {},
+  "devDependencies": {
+    "openclaw": "file:../../../openclaw"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/plugins/mc-realty/smoke.test.ts
+++ b/plugins/mc-realty/smoke.test.ts
@@ -1,0 +1,415 @@
+import { test, expect, vi, beforeEach } from "vitest";
+import { existsSync } from "node:fs";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveConfig } from "./src/config.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/* ── Structure tests ──────────────────────────────────────────────── */
+
+test("index.ts exists", () => {
+  expect(existsSync(__dirname + "/index.ts")).toBe(true);
+});
+
+test("openclaw.plugin.json exists and has required fields", async () => {
+  const pluginJson = await import("./openclaw.plugin.json", { with: { type: "json" } });
+  const cfg = pluginJson.default;
+  expect(cfg.id).toBe("mc-realty");
+  expect(cfg.name).toBeDefined();
+  expect(cfg.description).toBeDefined();
+  expect(cfg.configSchema).toBeDefined();
+  expect(cfg.configSchema.properties.attom_api_key_vault).toBeDefined();
+  expect(cfg.configSchema.properties.comp_radius_miles).toBeDefined();
+  expect(cfg.configSchema.properties.comp_lookback_months).toBeDefined();
+});
+
+test("plugin files all exist", () => {
+  const files = [
+    "index.ts",
+    "cli/commands.ts",
+    "tools/definitions.ts",
+    "src/attom.ts",
+    "src/config.ts",
+    "openclaw.plugin.json",
+    "package.json",
+  ];
+  for (const f of files) {
+    expect(existsSync(`${__dirname}/${f}`), `${f} should exist`).toBe(true);
+  }
+});
+
+/* ── Config tests ─────────────────────────────────────────────────── */
+
+test("resolveConfig returns defaults", () => {
+  const cfg = resolveConfig({});
+  expect(cfg).toBeDefined();
+  expect(cfg.compRadiusMiles).toBe(1.5);
+  expect(cfg.compLookbackMonths).toBe(6);
+  expect(cfg.compMaxResults).toBe(10);
+  expect(cfg.bookingDurationMinutes).toBe(30);
+  expect(cfg.autoSyndicate).toBe(true);
+  expect(cfg.transactionStages).toEqual([
+    "listed", "showings", "offers", "under-contract",
+    "inspection", "appraisal", "closing", "sold",
+  ]);
+  expect(cfg.syndicatePlatforms).toEqual(["instagram", "facebook", "twitter"]);
+  expect(cfg.attomApiKeyVault).toBe("attom_api_key");
+  expect(typeof cfg.dataDir).toBe("string");
+  expect(typeof cfg.vaultBin).toBe("string");
+});
+
+test("resolveConfig accepts overrides", () => {
+  const cfg = resolveConfig({
+    default_market: "Miami-Fort Lauderdale",
+    comp_radius_miles: 3,
+    comp_lookback_months: 12,
+    comp_max_results: 20,
+    booking_duration_minutes: 45,
+    auto_syndicate: false,
+    notification_email: "test@example.com",
+    transaction_stages: ["listed", "sold"],
+    syndicate_platforms: ["instagram"],
+  });
+  expect(cfg.defaultMarket).toBe("Miami-Fort Lauderdale");
+  expect(cfg.compRadiusMiles).toBe(3);
+  expect(cfg.compLookbackMonths).toBe(12);
+  expect(cfg.compMaxResults).toBe(20);
+  expect(cfg.bookingDurationMinutes).toBe(45);
+  expect(cfg.autoSyndicate).toBe(false);
+  expect(cfg.notificationEmail).toBe("test@example.com");
+  expect(cfg.transactionStages).toEqual(["listed", "sold"]);
+  expect(cfg.syndicatePlatforms).toEqual(["instagram"]);
+});
+
+/* ── ATTOM client tests (mocked fetch) ────────────────────────────── */
+
+const MOCK_SALE_RESPONSE = {
+  property: [
+    {
+      address: { line1: "100 Oak Ave", locality: "Miami", countrySubd: "FL", postal1: "33101" },
+      building: {
+        rooms: { beds: 3, bathstotal: 2 },
+        size: { livingsize: 1800 },
+        summary: { yearbuilt: 2005 },
+      },
+      lot: { lotsize1: 5000 },
+      sale: {
+        amount: { saleamt: 425000 },
+        saleTransDate: "2025-11-15",
+      },
+      distance: 0.8,
+    },
+    {
+      address: { line1: "200 Pine St", locality: "Miami", countrySubd: "FL", postal1: "33101" },
+      building: {
+        rooms: { beds: 4, bathstotal: 3 },
+        size: { livingsize: 2200 },
+        summary: { yearbuilt: 2010 },
+      },
+      lot: { lotsize1: 6000 },
+      sale: {
+        amount: { saleamt: 550000 },
+        saleTransDate: "2025-10-22",
+      },
+      distance: 1.2,
+    },
+    {
+      address: { line1: "300 Elm Dr", locality: "Miami", countrySubd: "FL", postal1: "33102" },
+      building: {
+        rooms: { beds: 3, bathstotal: 2 },
+        size: { livingsize: 1650 },
+        summary: { yearbuilt: 2000 },
+      },
+      lot: { lotsize1: 4500 },
+      sale: {
+        amount: { saleamt: 390000 },
+        saleTransDate: "2025-09-05",
+      },
+      distance: 1.4,
+    },
+  ],
+};
+
+const MOCK_PROPERTY_RESPONSE = {
+  property: [
+    {
+      address: { line1: "123 Main St", locality: "Miami", countrySubd: "FL", postal1: "33101", countrySecSubd: "Miami-Dade" },
+      building: {
+        rooms: { beds: 3, bathstotal: 2 },
+        size: { livingsize: 1900 },
+        summary: { yearbuilt: 2008, proptype: "SFR" },
+      },
+      lot: { lotsize1: 5500 },
+      assessment: {
+        assessed: { assdttlvalue: 320000 },
+        tax: { taxamt: 4800 },
+      },
+      avm: { amount: { value: 475000 } },
+      sale: {
+        amount: { saleamt: 350000 },
+        saleTransDate: "2020-03-15",
+      },
+    },
+  ],
+};
+
+// Mock getAttomApiKey to avoid vault dependency
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(() => "mock-attom-api-key-12345"),
+  execSync: vi.fn(() => "mock-value"),
+}));
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  // Re-mock execFileSync after restore
+  const cp = require("node:child_process");
+  cp.execFileSync = vi.fn(() => "mock-attom-api-key-12345");
+});
+
+test("searchComps parses ATTOM sale/snapshot response correctly", async () => {
+  const mockFetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(MOCK_SALE_RESPONSE),
+    text: () => Promise.resolve(""),
+  });
+  vi.stubGlobal("fetch", mockFetch);
+
+  const { searchComps } = await import("./src/attom.ts");
+  const cfg = resolveConfig({});
+
+  const comps = await searchComps(cfg, {
+    address: "123 Main St",
+    city: "Miami",
+    state: "FL",
+  });
+
+  expect(comps).toHaveLength(3);
+
+  // First comp
+  expect(comps[0].address).toBe("100 Oak Ave");
+  expect(comps[0].city).toBe("Miami");
+  expect(comps[0].state).toBe("FL");
+  expect(comps[0].zip).toBe("33101");
+  expect(comps[0].bedrooms).toBe(3);
+  expect(comps[0].bathrooms).toBe(2);
+  expect(comps[0].sqft).toBe(1800);
+  expect(comps[0].salePrice).toBe(425000);
+  expect(comps[0].saleDate).toBe("2025-11-15");
+  expect(comps[0].distanceMiles).toBe(0.8);
+
+  // Second comp
+  expect(comps[1].address).toBe("200 Pine St");
+  expect(comps[1].salePrice).toBe(550000);
+  expect(comps[1].bedrooms).toBe(4);
+  expect(comps[1].bathrooms).toBe(3);
+
+  // Third comp
+  expect(comps[2].address).toBe("300 Elm Dr");
+  expect(comps[2].salePrice).toBe(390000);
+
+  // Verify fetch was called with correct URL structure
+  expect(mockFetch).toHaveBeenCalledTimes(1);
+  const callUrl = mockFetch.mock.calls[0][0];
+  expect(callUrl).toContain("sale/snapshot");
+  expect(callUrl).toContain("address1=123+Main+St");
+  expect(callUrl).toContain("searchType=radius");
+
+  // Verify API key header
+  const callOpts = mockFetch.mock.calls[0][1];
+  expect(callOpts.headers.apikey).toBe("mock-attom-api-key-12345");
+
+  vi.unstubAllGlobals();
+});
+
+test("getPropertyDetails parses ATTOM expandedprofile response correctly", async () => {
+  const mockFetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(MOCK_PROPERTY_RESPONSE),
+    text: () => Promise.resolve(""),
+  });
+  vi.stubGlobal("fetch", mockFetch);
+
+  const { getPropertyDetails } = await import("./src/attom.ts");
+  const cfg = resolveConfig({});
+
+  const details = await getPropertyDetails(cfg, {
+    address: "123 Main St",
+    city: "Miami",
+    state: "FL",
+  });
+
+  expect(details.address).toBe("123 Main St");
+  expect(details.city).toBe("Miami");
+  expect(details.state).toBe("FL");
+  expect(details.county).toBe("Miami-Dade");
+  expect(details.bedrooms).toBe(3);
+  expect(details.bathrooms).toBe(2);
+  expect(details.sqft).toBe(1900);
+  expect(details.yearBuilt).toBe(2008);
+  expect(details.propertyType).toBe("SFR");
+  expect(details.avm).toBe(475000);
+  expect(details.assessedValue).toBe(320000);
+  expect(details.taxAmount).toBe(4800);
+  expect(details.lastSalePrice).toBe(350000);
+  expect(details.lastSaleDate).toBe("2020-03-15");
+
+  // Verify fetch called expandedprofile endpoint
+  const callUrl = mockFetch.mock.calls[0][0];
+  expect(callUrl).toContain("property/expandedprofile");
+
+  vi.unstubAllGlobals();
+});
+
+test("searchComps returns empty array when no properties", async () => {
+  const mockFetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ property: [] }),
+    text: () => Promise.resolve(""),
+  });
+  vi.stubGlobal("fetch", mockFetch);
+
+  const { searchComps } = await import("./src/attom.ts");
+  const cfg = resolveConfig({});
+
+  const comps = await searchComps(cfg, {
+    address: "999 Nowhere Rd",
+    city: "Nowhere",
+    state: "ZZ",
+  });
+
+  expect(comps).toHaveLength(0);
+  vi.unstubAllGlobals();
+});
+
+test("searchComps throws on ATTOM API error", async () => {
+  const mockFetch = vi.fn().mockResolvedValue({
+    ok: false,
+    status: 401,
+    statusText: "Unauthorized",
+    text: () => Promise.resolve("Invalid API key"),
+  });
+  vi.stubGlobal("fetch", mockFetch);
+
+  const { searchComps } = await import("./src/attom.ts");
+  const cfg = resolveConfig({});
+
+  await expect(
+    searchComps(cfg, { address: "123 Main St", city: "Miami", state: "FL" }),
+  ).rejects.toThrow("ATTOM API 401");
+
+  vi.unstubAllGlobals();
+});
+
+test("searchComps uses config defaults for radius and lookback", async () => {
+  const mockFetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ property: [] }),
+    text: () => Promise.resolve(""),
+  });
+  vi.stubGlobal("fetch", mockFetch);
+
+  const { searchComps } = await import("./src/attom.ts");
+  const cfg = resolveConfig({ comp_radius_miles: 2.5, comp_lookback_months: 3, comp_max_results: 5 });
+
+  await searchComps(cfg, { address: "123 Main St", city: "Miami", state: "FL" });
+
+  const callUrl = mockFetch.mock.calls[0][0];
+  expect(callUrl).toContain("radius=2.5");
+  expect(callUrl).toContain("pagesize=5");
+
+  vi.unstubAllGlobals();
+});
+
+test("searchComps overrides config with explicit params", async () => {
+  const mockFetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ property: [] }),
+    text: () => Promise.resolve(""),
+  });
+  vi.stubGlobal("fetch", mockFetch);
+
+  const { searchComps } = await import("./src/attom.ts");
+  const cfg = resolveConfig({});
+
+  await searchComps(cfg, {
+    address: "123 Main St",
+    city: "Miami",
+    state: "FL",
+    radiusMiles: 5,
+    lookbackMonths: 12,
+    maxResults: 25,
+  });
+
+  const callUrl = mockFetch.mock.calls[0][0];
+  expect(callUrl).toContain("radius=5");
+  expect(callUrl).toContain("pagesize=25");
+
+  vi.unstubAllGlobals();
+});
+
+/* ── CMA statistics ───────────────────────────────────────────────── */
+
+test("CMA statistics calculated correctly from mock comps", () => {
+  const prices = [425000, 550000, 390000];
+  const sorted = [...prices].sort((a, b) => a - b); // [390000, 425000, 550000]
+  const median = sorted[Math.floor(sorted.length / 2)]; // 425000
+  const avg = Math.round(prices.reduce((a, b) => a + b, 0) / prices.length); // 455000
+
+  expect(median).toBe(425000);
+  expect(avg).toBe(455000);
+  expect(Math.min(...prices)).toBe(390000);
+  expect(Math.max(...prices)).toBe(550000);
+
+  // Price per sqft
+  const sqfts = [1800, 2200, 1650];
+  const ppsf = prices.map((p, i) => Math.round(p / sqfts[i])); // [236, 250, 236]
+  expect(ppsf[0]).toBe(236);
+  expect(ppsf[1]).toBe(250);
+  expect(ppsf[2]).toBe(236);
+});
+
+/* ── Tools definitions ────────────────────────────────────────────── */
+
+test("createRealtyTools returns all expected tools", async () => {
+  const { createRealtyTools } = await import("./tools/definitions.ts");
+  const cfg = resolveConfig({});
+  const tools = createRealtyTools(cfg);
+
+  const toolNames = tools.map((t) => t.name);
+  expect(toolNames).toContain("realty_comp_analysis");
+  expect(toolNames).toContain("realty_list_property");
+  expect(toolNames).toContain("realty_schedule_showing");
+  expect(toolNames).toContain("realty_generate_listing");
+  expect(toolNames).toContain("realty_track_transaction");
+  expect(toolNames).toContain("realty_market_report");
+  expect(tools.length).toBe(6);
+
+  // Each tool has required fields
+  for (const tool of tools) {
+    expect(tool.name).toBeDefined();
+    expect(tool.label).toBeDefined();
+    expect(tool.description).toBeDefined();
+    expect(tool.parameters).toBeDefined();
+    expect(typeof tool.execute).toBe("function");
+  }
+});
+
+test("realty_comp_analysis tool has correct parameter schema", async () => {
+  const { createRealtyTools } = await import("./tools/definitions.ts");
+  const cfg = resolveConfig({});
+  const tools = createRealtyTools(cfg);
+
+  const compTool = tools.find((t) => t.name === "realty_comp_analysis");
+  expect(compTool).toBeDefined();
+  const params = compTool!.parameters as { properties: Record<string, unknown>; required: string[] };
+  expect(params.properties).toHaveProperty("address");
+  expect(params.properties).toHaveProperty("city");
+  expect(params.properties).toHaveProperty("state");
+  expect(params.properties).toHaveProperty("zip");
+  expect(params.properties).toHaveProperty("radius_miles");
+  expect(params.properties).toHaveProperty("lookback_months");
+  expect(params.required).toContain("address");
+  expect(params.required).toContain("city");
+  expect(params.required).toContain("state");
+});

--- a/plugins/mc-realty/src/attom.ts
+++ b/plugins/mc-realty/src/attom.ts
@@ -1,0 +1,208 @@
+import { execFileSync } from "node:child_process";
+import type { RealtyConfig } from "./config.js";
+
+const ATTOM_BASE = "https://api.gateway.attomdata.com/propertyapi/v1.0.0";
+
+/**
+ * Resolve the ATTOM API key from mc-vault at runtime.
+ * Never hardcode or cache the key — always read from vault.
+ */
+export function getAttomApiKey(cfg: RealtyConfig): string {
+  try {
+    const key = execFileSync(cfg.vaultBin, ["get", cfg.attomApiKeyVault], {
+      encoding: "utf-8",
+      timeout: 5000,
+    }).trim();
+    if (!key) throw new Error("Empty API key returned from mc-vault");
+    return key;
+  } catch (e: unknown) {
+    throw new Error(
+      `Failed to read ATTOM API key from mc-vault (key: ${cfg.attomApiKeyVault}): ${(e as Error).message}`,
+    );
+  }
+}
+
+interface AttomRequestOpts {
+  endpoint: string;
+  params: Record<string, string | number>;
+  apiKey: string;
+}
+
+async function attomRequest<T>(opts: AttomRequestOpts): Promise<T> {
+  const url = new URL(`${ATTOM_BASE}/${opts.endpoint}`);
+  for (const [k, v] of Object.entries(opts.params)) {
+    url.searchParams.set(k, String(v));
+  }
+
+  const resp = await fetch(url.toString(), {
+    headers: {
+      Accept: "application/json",
+      apikey: opts.apiKey,
+    },
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => "");
+    throw new Error(`ATTOM API ${resp.status}: ${resp.statusText} — ${body}`);
+  }
+
+  return resp.json() as Promise<T>;
+}
+
+export interface SalesComp {
+  address: string;
+  city: string;
+  state: string;
+  zip: string;
+  bedrooms: number;
+  bathrooms: number;
+  sqft: number;
+  lotSizeSqft: number;
+  yearBuilt: number;
+  salePrice: number;
+  saleDate: string;
+  distanceMiles: number;
+}
+
+export interface PropertyDetails {
+  address: string;
+  city: string;
+  state: string;
+  zip: string;
+  county: string;
+  bedrooms: number;
+  bathrooms: number;
+  sqft: number;
+  lotSizeSqft: number;
+  yearBuilt: number;
+  propertyType: string;
+  avm: number | null;
+  assessedValue: number | null;
+  taxAmount: number | null;
+  lastSalePrice: number | null;
+  lastSaleDate: string | null;
+}
+
+/**
+ * Search for comparable sales near an address.
+ */
+export async function searchComps(
+  cfg: RealtyConfig,
+  opts: {
+    address: string;
+    city: string;
+    state: string;
+    zip?: string;
+    radiusMiles?: number;
+    lookbackMonths?: number;
+    maxResults?: number;
+  },
+): Promise<SalesComp[]> {
+  const apiKey = getAttomApiKey(cfg);
+  const radius = opts.radiusMiles ?? cfg.compRadiusMiles;
+  const lookback = opts.lookbackMonths ?? cfg.compLookbackMonths;
+  const maxResults = opts.maxResults ?? cfg.compMaxResults;
+
+  const cutoffDate = new Date();
+  cutoffDate.setMonth(cutoffDate.getMonth() - lookback);
+  const minSaleDate = cutoffDate.toISOString().split("T")[0];
+
+  const params: Record<string, string | number> = {
+    address1: opts.address,
+    address2: `${opts.city}, ${opts.state}${opts.zip ? " " + opts.zip : ""}`,
+    searchType: "radius",
+    radius: radius,
+    minsalesdate: minSaleDate,
+    pagesize: maxResults,
+  };
+
+  const data = await attomRequest<Record<string, unknown>>({
+    endpoint: "sale/snapshot",
+    params,
+    apiKey,
+  });
+
+  const properties = ((data as Record<string, unknown>).property ?? []) as Record<string, unknown>[];
+
+  return properties.map((p: Record<string, unknown>) => {
+    const addr = (p.address ?? {}) as Record<string, unknown>;
+    const building = (p.building ?? {}) as Record<string, unknown>;
+    const rooms = (building.rooms ?? {}) as Record<string, unknown>;
+    const size = (building.size ?? {}) as Record<string, unknown>;
+    const summary = (building.summary ?? {}) as Record<string, unknown>;
+    const lot = (p.lot ?? {}) as Record<string, unknown>;
+    const sale = (p.sale ?? {}) as Record<string, unknown>;
+    const amount = (sale.amount ?? {}) as Record<string, unknown>;
+
+    return {
+      address: (addr.line1 as string) ?? "",
+      city: (addr.locality as string) ?? "",
+      state: (addr.countrySubd as string) ?? "",
+      zip: (addr.postal1 as string) ?? "",
+      bedrooms: (rooms.beds as number) ?? 0,
+      bathrooms: (rooms.bathstotal as number) ?? 0,
+      sqft: (size.livingsize as number) ?? 0,
+      lotSizeSqft: (lot.lotsize1 as number) ?? 0,
+      yearBuilt: (summary.yearbuilt as number) ?? 0,
+      salePrice: (amount.saleamt as number) ?? 0,
+      saleDate: (sale.saleTransDate as string) ?? "",
+      distanceMiles: (p.distance as number) ?? 0,
+    };
+  });
+}
+
+/**
+ * Get detailed property information by address.
+ */
+export async function getPropertyDetails(
+  cfg: RealtyConfig,
+  opts: { address: string; city: string; state: string; zip?: string },
+): Promise<PropertyDetails> {
+  const apiKey = getAttomApiKey(cfg);
+
+  const params: Record<string, string | number> = {
+    address1: opts.address,
+    address2: `${opts.city}, ${opts.state}${opts.zip ? " " + opts.zip : ""}`,
+  };
+
+  const data = await attomRequest<Record<string, unknown>>({
+    endpoint: "property/expandedprofile",
+    params,
+    apiKey,
+  });
+
+  const properties = ((data as Record<string, unknown>).property ?? []) as Record<string, unknown>[];
+  const p = properties[0] ?? {};
+  const addr = (p.address ?? {}) as Record<string, unknown>;
+  const building = (p.building ?? {}) as Record<string, unknown>;
+  const rooms = (building.rooms ?? {}) as Record<string, unknown>;
+  const size = (building.size ?? {}) as Record<string, unknown>;
+  const summary = (building.summary ?? {}) as Record<string, unknown>;
+  const lot = (p.lot ?? {}) as Record<string, unknown>;
+  const assessment = (p.assessment ?? {}) as Record<string, unknown>;
+  const assessed = (assessment.assessed ?? {}) as Record<string, unknown>;
+  const tax = (assessment.tax ?? {}) as Record<string, unknown>;
+  const avm = (p.avm ?? {}) as Record<string, unknown>;
+  const avmAmount = (avm.amount ?? {}) as Record<string, unknown>;
+  const sale = (p.sale ?? {}) as Record<string, unknown>;
+  const saleAmount = (sale.amount ?? {}) as Record<string, unknown>;
+
+  return {
+    address: (addr.line1 as string) ?? "",
+    city: (addr.locality as string) ?? "",
+    state: (addr.countrySubd as string) ?? "",
+    zip: (addr.postal1 as string) ?? "",
+    county: (addr.countrySecSubd as string) ?? "",
+    bedrooms: (rooms.beds as number) ?? 0,
+    bathrooms: (rooms.bathstotal as number) ?? 0,
+    sqft: (size.livingsize as number) ?? 0,
+    lotSizeSqft: (lot.lotsize1 as number) ?? 0,
+    yearBuilt: (summary.yearbuilt as number) ?? 0,
+    propertyType: (summary.proptype as string) ?? "",
+    avm: (avmAmount.value as number) ?? null,
+    assessedValue: (assessed.assdttlvalue as number) ?? null,
+    taxAmount: (tax.taxamt as number) ?? null,
+    lastSalePrice: (saleAmount.saleamt as number) ?? null,
+    lastSaleDate: (sale.saleTransDate as string) ?? null,
+  };
+}

--- a/plugins/mc-realty/src/config.ts
+++ b/plugins/mc-realty/src/config.ts
@@ -1,0 +1,45 @@
+import * as path from "node:path";
+import * as os from "node:os";
+
+const STATE_DIR = process.env.OPENCLAW_STATE_DIR ?? path.join(os.homedir(), ".openclaw");
+
+export interface RealtyConfig {
+  vaultBin: string;
+  attomApiKeyVault: string;
+  defaultMarket: string;
+  compRadiusMiles: number;
+  compLookbackMonths: number;
+  compMaxResults: number;
+  bookingDurationMinutes: number;
+  transactionStages: string[];
+  syndicatePlatforms: string[];
+  autoSyndicate: boolean;
+  notificationEmail: string;
+  dataDir: string;
+}
+
+export function resolveConfig(raw: Record<string, unknown>): RealtyConfig {
+  return {
+    vaultBin: (raw.vaultBin as string) || path.join(STATE_DIR, "miniclaw", "SYSTEM", "bin", "mc-vault"),
+    attomApiKeyVault: (raw.attom_api_key_vault as string) || "attom_api_key",
+    defaultMarket: (raw.default_market as string) || "",
+    compRadiusMiles: (raw.comp_radius_miles as number) || 1.5,
+    compLookbackMonths: (raw.comp_lookback_months as number) || 6,
+    compMaxResults: (raw.comp_max_results as number) || 10,
+    bookingDurationMinutes: (raw.booking_duration_minutes as number) || 30,
+    transactionStages: (raw.transaction_stages as string[]) || [
+      "listed",
+      "showings",
+      "offers",
+      "under-contract",
+      "inspection",
+      "appraisal",
+      "closing",
+      "sold",
+    ],
+    syndicatePlatforms: (raw.syndicate_platforms as string[]) || ["instagram", "facebook", "twitter"],
+    autoSyndicate: raw.auto_syndicate !== undefined ? (raw.auto_syndicate as boolean) : true,
+    notificationEmail: (raw.notification_email as string) || "",
+    dataDir: path.join(STATE_DIR, "USER", "realty"),
+  };
+}

--- a/plugins/mc-realty/tools/definitions.ts
+++ b/plugins/mc-realty/tools/definitions.ts
@@ -1,0 +1,382 @@
+import type { AnyAgentTool } from "openclaw/plugin-sdk";
+import type { RealtyConfig } from "../src/config.js";
+import { searchComps, getPropertyDetails } from "../src/attom.js";
+import { execFileSync } from "node:child_process";
+
+function schema(props: Record<string, unknown>, required?: string[]): unknown {
+  return { type: "object", properties: props, required: required ?? [], additionalProperties: false };
+}
+
+function str(d: string): unknown { return { type: "string", description: d }; }
+function optStr(d: string): unknown { return { type: "string", description: d }; }
+function optNum(d: string): unknown { return { type: "number", description: d }; }
+function optBool(d: string): unknown { return { type: "boolean", description: d }; }
+
+function ok(text: string) { return { content: [{ type: "text" as const, text: text.trim() }], details: {} }; }
+function err(text: string) { return { content: [{ type: "text" as const, text: text.trim() }], isError: true, details: {} }; }
+
+function oc(cfg: RealtyConfig, ...args: string[]): string {
+  const bin = process.env.OPENCLAW_BIN ?? "openclaw";
+  try {
+    return execFileSync(bin, args, { encoding: "utf-8", timeout: 30_000 }).trim();
+  } catch (e: unknown) {
+    return `[error] ${(e as Error).message}`;
+  }
+}
+
+function fmtUsd(n: number): string {
+  return "$" + n.toLocaleString("en-US", { maximumFractionDigits: 0 });
+}
+
+export function createRealtyTools(cfg: RealtyConfig): AnyAgentTool[] {
+  return [
+    /* ── list_property ──────────────────────────────────────────────── */
+    {
+      name: "realty_list_property",
+      label: "List Property",
+      description:
+        "Create a new property listing. Creates a board card, stores in KB, and generates a listing description. " +
+        "Use this when the human wants to list a property for sale.",
+      parameters: schema(
+        {
+          address: str("Street address"),
+          city: str("City"),
+          state: str("State abbreviation (e.g. FL)"),
+          zip: optStr("ZIP code"),
+          price: optStr("Asking price (e.g. '$450,000')"),
+          beds: optNum("Number of bedrooms"),
+          baths: optNum("Number of bathrooms"),
+          sqft: optNum("Square footage"),
+          description: optStr("Property highlights or features"),
+        },
+        ["address", "city", "state"],
+      ) as never,
+      async execute(_id: string, _input: unknown) {
+        const p = _input as Record<string, unknown>;
+        try {
+          const addr = `${p.address}, ${p.city}, ${p.state}${p.zip ? " " + p.zip : ""}`;
+
+          // Store in KB
+          const pid = (p.address as string).toLowerCase().replace(/[^a-z0-9]+/g, "-").slice(0, 60);
+          const kbData = JSON.stringify({
+            address: p.address, city: p.city, state: p.state, zip: p.zip || "",
+            askingPrice: p.price || "", beds: p.beds || "", baths: p.baths || "",
+            sqft: p.sqft || "", description: p.description || "",
+            status: "listed", listedDate: new Date().toISOString().split("T")[0],
+          });
+          oc(cfg, "mc-kb", "add", `realty-property-${pid}`, "--content", kbData, "--tags", "realty,property");
+
+          // Create board card
+          oc(cfg, "mc-board", "create", `Property: ${addr}`, "--tags", "realty,property");
+
+          // Generate description
+          const desc = oc(cfg, "mc-docs", "generate", "--prompt",
+            `Write a professional MLS-style listing for ${addr}. ${p.beds || "?"}bd/${p.baths || "?"}ba, ${p.sqft || "?"}sqft. ${p.description || ""}`);
+
+          return ok(
+            `Property listed: ${addr}\n` +
+            `KB entry: realty-property-${pid}\n` +
+            `Board card created.\n\n` +
+            `Generated Description:\n${desc}\n\n` +
+            `Next: run comp-analysis for pricing data, or generate-listing for marketing materials.`,
+          );
+        } catch (e: unknown) {
+          return err(`Failed to list property: ${(e as Error).message}`);
+        }
+      },
+    },
+
+    /* ── comp_analysis ──────────────────────────────────────────────── */
+    {
+      name: "realty_comp_analysis",
+      label: "Comp Analysis",
+      description:
+        "Run a comparative market analysis (CMA) for a property using ATTOM Data API. " +
+        "Returns nearby comparable sales with pricing statistics. Use for pricing guidance.",
+      parameters: schema(
+        {
+          address: str("Subject property street address"),
+          city: str("City"),
+          state: str("State abbreviation"),
+          zip: optStr("ZIP code"),
+          radius_miles: optNum("Search radius (default: from config)"),
+          lookback_months: optNum("Months to look back (default: from config)"),
+        },
+        ["address", "city", "state"],
+      ) as never,
+      async execute(_id: string, _input: unknown) {
+        const p = _input as Record<string, unknown>;
+        try {
+          const comps = await searchComps(cfg, {
+            address: p.address as string,
+            city: p.city as string,
+            state: p.state as string,
+            zip: p.zip as string | undefined,
+            radiusMiles: p.radius_miles as number | undefined,
+            lookbackMonths: p.lookback_months as number | undefined,
+          });
+
+          if (!comps.length) return ok("No comparable sales found. Try increasing radius or lookback period.");
+
+          const prices = comps.map((c) => c.salePrice).filter((p) => p > 0);
+          const median = (arr: number[]) => {
+            const s = [...arr].sort((a, b) => a - b);
+            const m = Math.floor(s.length / 2);
+            return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+          };
+
+          let subject = null;
+          try {
+            subject = await getPropertyDetails(cfg, {
+              address: p.address as string, city: p.city as string,
+              state: p.state as string, zip: p.zip as string | undefined,
+            });
+          } catch { /* continue without subject details */ }
+
+          const lines = [
+            `## CMA: ${p.address}, ${p.city}, ${p.state}`,
+            "",
+          ];
+
+          if (subject) {
+            lines.push(`**Subject:** ${subject.bedrooms}bd/${subject.bathrooms}ba, ${subject.sqft}sqft, built ${subject.yearBuilt}`);
+            if (subject.avm) lines.push(`**AVM:** ${fmtUsd(subject.avm)}`);
+            lines.push("");
+          }
+
+          lines.push(`**${comps.length} Comparable Sales:**`);
+          for (const c of comps) {
+            const ppsf = c.sqft > 0 ? `$${Math.round(c.salePrice / c.sqft)}/sqft` : "";
+            lines.push(`- ${c.address}: ${fmtUsd(c.salePrice)} | ${c.bedrooms}bd/${c.bathrooms}ba | ${c.sqft}sqft | ${ppsf} | ${c.saleDate} | ${c.distanceMiles.toFixed(1)}mi`);
+          }
+
+          lines.push("");
+          lines.push(`**Summary:** Median ${fmtUsd(median(prices))}, Range ${fmtUsd(Math.min(...prices))}–${fmtUsd(Math.max(...prices))}`);
+
+          // Store in KB
+          const pid = (p.address as string).toLowerCase().replace(/[^a-z0-9]+/g, "-").slice(0, 60);
+          oc(cfg, "mc-kb", "add", `realty-cma-${pid}`, "--content", JSON.stringify({ comps, median: median(prices) }), "--tags", "realty,cma");
+
+          return ok(lines.join("\n"));
+        } catch (e: unknown) {
+          return err(`Comp analysis failed: ${(e as Error).message}\nEnsure ATTOM API key is set via: openclaw mc-vault set attom_api_key <key>`);
+        }
+      },
+    },
+
+    /* ── schedule_showing ───────────────────────────────────────────── */
+    {
+      name: "realty_schedule_showing",
+      label: "Schedule Showing",
+      description:
+        "Schedule property showing slots via mc-booking and sync to mc-calendar. " +
+        "Creates time slots for buyers to book. Optionally notifies buyer contacts.",
+      parameters: schema(
+        {
+          address: str("Property address"),
+          date: str("Showing date (YYYY-MM-DD)"),
+          times: optStr("Comma-separated times (HH:MM), default: 10:00,11:00,14:00,15:00"),
+          duration_minutes: optNum("Duration per showing (default: from config)"),
+          notify_buyers: optBool("Email buyer contacts from rolodex"),
+        },
+        ["address", "date"],
+      ) as never,
+      async execute(_id: string, _input: unknown) {
+        const p = _input as Record<string, unknown>;
+        try {
+          const times = ((p.times as string) || "10:00,11:00,14:00,15:00").split(",").map((t) => t.trim());
+          const dur = String((p.duration_minutes as number) || cfg.bookingDurationMinutes);
+
+          for (const time of times) {
+            const iso = `${p.date}T${time}:00`;
+            oc(cfg, "mc-booking", "slots", "--create", "--time", iso, "--duration", dur, "--label", `Showing: ${p.address}`);
+            oc(cfg, "mc-calendar", "add", "--title", `Showing: ${p.address}`, "--start", iso, "--duration", dur);
+          }
+
+          if (p.notify_buyers) {
+            oc(cfg, "mc-email", "send", "--to-tag", "buyer",
+              "--subject", `Open House: ${p.address} — ${p.date}`,
+              "--body", `Showing times at ${p.address} on ${p.date}: ${times.join(", ")}. Reply to schedule.`);
+          }
+
+          return ok(
+            `${times.length} showing slots created for ${p.address} on ${p.date}:\n` +
+            times.map((t) => `  ${t} (${dur}min)`).join("\n") +
+            `\nSlots synced to calendar.` +
+            (p.notify_buyers ? `\nBuyer notifications sent.` : "") +
+            `\nUse 'mc-booking pending' to manage requests.`,
+          );
+        } catch (e: unknown) {
+          return err(`Failed to schedule showing: ${(e as Error).message}`);
+        }
+      },
+    },
+
+    /* ── generate_listing ───────────────────────────────────────────── */
+    {
+      name: "realty_generate_listing",
+      label: "Generate Listing",
+      description:
+        "Generate full listing package: graphics (mc-designer), blog post (mc-blog), and social media posts (mc-social). " +
+        "Creates marketing materials for a property.",
+      parameters: schema(
+        {
+          address: str("Property address"),
+          city: optStr("City"),
+          state: optStr("State"),
+          price: optStr("Asking price"),
+          beds: optNum("Bedrooms"),
+          baths: optNum("Bathrooms"),
+          sqft: optNum("Square footage"),
+          description: optStr("Property description"),
+          syndicate: optBool("Post to social media (default: auto_syndicate config)"),
+        },
+        ["address"],
+      ) as never,
+      async execute(_id: string, _input: unknown) {
+        const p = _input as Record<string, unknown>;
+        try {
+          const pid = (p.address as string).toLowerCase().replace(/[^a-z0-9]+/g, "-").slice(0, 60);
+
+          // Designer
+          oc(cfg, "mc-designer", "gen",
+            `Professional real estate listing graphic for ${p.address}. ${p.beds || "?"}bd/${p.baths || "?"}ba, ${p.sqft || "?"}sqft. Clean MLS style.`,
+            "-c", `realty-listing-${pid}`, "--role", "background");
+          const graphicPath = `${cfg.dataDir}/listings/${pid}-graphic.png`;
+          oc(cfg, "mc-designer", "composite", "-c", `realty-listing-${pid}`, "-o", graphicPath);
+
+          // Blog
+          const blogTitle = `${p.address}${p.city ? ", " + p.city : ""} — ${p.beds || "?"}BD/${p.baths || "?"}BA${p.price ? " | " + p.price : ""}`;
+          oc(cfg, "mc-blog", "create", "--title", blogTitle, "--body", (p.description as string) || `Property at ${p.address}`, "--tags", "realty,listing", "--publish");
+
+          // Social
+          const shouldSyndicate = p.syndicate !== false && cfg.autoSyndicate;
+          if (shouldSyndicate) {
+            const text = `New Listing: ${p.address}. ${p.beds || "?"}bd/${p.baths || "?"}ba, ${p.sqft || "?"}sqft. ${p.price || "Contact for price"}. DM for details!`;
+            for (const platform of cfg.syndicatePlatforms) {
+              oc(cfg, "mc-social", "post", "--platform", platform, "--text", text, "--image", graphicPath);
+            }
+          }
+
+          return ok(
+            `Listing package generated for ${p.address}:\n` +
+            `- Graphic: ${graphicPath}\n` +
+            `- Blog post published\n` +
+            (shouldSyndicate ? `- Posted to: ${cfg.syndicatePlatforms.join(", ")}\n` : "") +
+            `\nNext: schedule showings or run comp analysis.`,
+          );
+        } catch (e: unknown) {
+          return err(`Failed to generate listing: ${(e as Error).message}`);
+        }
+      },
+    },
+
+    /* ── track_transaction ──────────────────────────────────────────── */
+    {
+      name: "realty_track_transaction",
+      label: "Track Transaction",
+      description:
+        "Create a transaction tracking pipeline on mc-board with configurable stages " +
+        "(listed → showings → offers → under-contract → inspection → appraisal → closing → sold). " +
+        "Tracks buyer info, price, and sends status notifications.",
+      parameters: schema(
+        {
+          address: str("Property address"),
+          buyer: optStr("Buyer name"),
+          buyer_email: optStr("Buyer email"),
+          price: optStr("Offer/contract price"),
+          stage: optStr("Initial stage (default: first configured stage)"),
+        },
+        ["address"],
+      ) as never,
+      async execute(_id: string, _input: unknown) {
+        const p = _input as Record<string, unknown>;
+        try {
+          const stage = (p.stage as string) || cfg.transactionStages[0];
+          const pipeline = cfg.transactionStages.map((s) => (s === stage ? `[${s}]` : s)).join(" → ");
+
+          const criteria = cfg.transactionStages.map((s) => `- [ ] ${s}`).join("\n");
+          oc(cfg, "mc-board", "create", `Transaction: ${p.address}`,
+            "--tags", `realty,transaction,${stage}`,
+            "--notes", `Buyer: ${p.buyer || "TBD"}\nPrice: ${p.price || "TBD"}\nPipeline: ${pipeline}`,
+            "--criteria", criteria);
+
+          if (p.buyer) {
+            oc(cfg, "mc-rolodex", "add", (p.buyer as string).toLowerCase().replace(/\s+/g, "-"),
+              "--name", p.buyer as string, "--email", (p.buyer_email as string) || "",
+              "--tags", "realty,buyer", "--notes", `Buyer for ${p.address}`);
+          }
+
+          oc(cfg, "mc-kb", "add", `realty-tx-${(p.address as string).toLowerCase().replace(/[^a-z0-9]+/g, "-").slice(0, 60)}`,
+            "--content", JSON.stringify({ property: p.address, buyer: p.buyer, price: p.price, stage, created: new Date().toISOString() }),
+            "--tags", "realty,transaction");
+
+          if (cfg.notificationEmail) {
+            oc(cfg, "mc-email", "send", "--to", cfg.notificationEmail,
+              "--subject", `Transaction Started: ${p.address}`,
+              "--body", `Transaction tracking for ${p.address}. Stage: ${stage}. Buyer: ${p.buyer || "TBD"}. Price: ${p.price || "TBD"}.`);
+          }
+
+          return ok(
+            `Transaction pipeline created for ${p.address}\n` +
+            `Stage: ${stage}\n` +
+            `Pipeline: ${pipeline}\n` +
+            (p.buyer ? `Buyer: ${p.buyer}\n` : "") +
+            (p.price ? `Price: ${p.price}\n` : "") +
+            `\nUse mc-board to advance stages.`,
+          );
+        } catch (e: unknown) {
+          return err(`Failed to create transaction: ${(e as Error).message}`);
+        }
+      },
+    },
+
+    /* ── market_report ──────────────────────────────────────────────── */
+    {
+      name: "realty_market_report",
+      label: "Market Report",
+      description:
+        "Generate a market report for a given area using mc-research and mc-docs. " +
+        "Emails the report to the client if configured.",
+      parameters: schema(
+        {
+          market: str("Market area (e.g. 'Miami-Fort Lauderdale' or ZIP code)"),
+          email: optStr("Recipient email (default: notification_email from config)"),
+        },
+        ["market"],
+      ) as never,
+      async execute(_id: string, _input: unknown) {
+        const p = _input as Record<string, unknown>;
+        try {
+          const market = p.market as string;
+          const email = (p.email as string) || cfg.notificationEmail;
+
+          const research = oc(cfg, "mc-research", "search",
+            `${market} real estate market ${new Date().getFullYear()} median price inventory days on market`);
+
+          const report = oc(cfg, "mc-docs", "generate", "--prompt",
+            `Professional real estate market report for ${market}. Include median price, trends, inventory, days on market. Data: ${research}`);
+
+          const reportDate = new Date().toISOString().split("T")[0];
+          oc(cfg, "mc-kb", "add", `realty-market-${market.toLowerCase().replace(/[^a-z0-9]+/g, "-")}-${reportDate}`,
+            "--content", report || research, "--tags", "realty,market-report");
+
+          if (email) {
+            oc(cfg, "mc-email", "send", "--to", email,
+              "--subject", `Market Report: ${market} — ${reportDate}`,
+              "--body", report || `Market data for ${market} on ${reportDate}`);
+          }
+
+          return ok(
+            `## Market Report: ${market}\n` +
+            `Date: ${reportDate}\n\n` +
+            (report || research || "Report generated — see KB for details.") +
+            (email ? `\n\nReport emailed to ${email}.` : ""),
+          );
+        } catch (e: unknown) {
+          return err(`Failed to generate market report: ${(e as Error).message}`);
+        }
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- New mc-realty plugin: orchestrates 11 existing plugins into unified real estate workflows
- 6 CLI commands + 6 agent tools: list-property, comp-analysis, schedule-showing, generate-listing, track-transaction, market-report
- ATTOM Data API integration for real comp data (API key via mc-vault, never hardcoded)
- Configurable: comp radius/lookback, transaction stages, syndication platforms, auto-syndicate

## Test plan
- [x] All 14 smoke tests pass (structure, config, ATTOM parsing, tools)
- [x] Plugin follows mc-booking pattern (register, resolveConfig, hook, registerCli, registerTool)
- [x] Config schema validated in openclaw.plugin.json
- [x] ATTOM API key read from mc-vault at runtime

Card: crd_1deb6988