### PR TITLE
Fix triage: CARD_ID interpolation + tool access

### DIFF
--- a/plugins/mc-board/cli/commands.ts
+++ b/plugins/mc-board/cli/commands.ts
@@ -995,7 +995,7 @@ Rules:
 - "research" replaces the existing research field — be comprehensive
 - "move_to": set to "in-progress" ONLY if the card has ALL of: (1) clear problem_description, (2) acceptance_criteria, (3) implementation_plan, AND the work appears well-scoped and actionable. If any are missing or vague, omit "move_to" entirely.`;
 
-      const fullPrompt = promptTemplate.replace("{{CARD}}", cardLines) + APPLY_INSTRUCTION;
+      const fullPrompt = promptTemplate.replace("{{CARD}}", cardLines).replace(/\{\{CARD_ID\}\}/g, cardId) + APPLY_INSTRUCTION;
 
       // Setup run dir
       const runDir = path.join(ctx.stateDir, "tmp", `${ts0}-${cardId}`);
@@ -1004,8 +1004,8 @@ Rules:
         `# Triage: ${card.title}`,
         "",
         `Card: ${cardId} (backlog)`,
-        "This is a sandboxed non-interactive session. Do not use tools.",
-        "Respond only with your analysis and the APPLY block.",
+        "You have full tool access. Use bash to read code, run CLI commands, and verify your work.",
+        "Respond with your analysis and the APPLY block.",
       ].join("\n"));
 
       const CLAUDE_BIN = process.env.CLAUDE_BIN ?? "claude";

--- a/plugins/mc-board/web/src/app/api/triage-prompt/[column]/test/route.ts
+++ b/plugins/mc-board/web/src/app/api/triage-prompt/[column]/test/route.ts
@@ -70,7 +70,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ col
   }
 
   const cardsSummary = colCards.map(cardToTriageSummary).join("\n\n");
-  const fullPrompt = prompt.replace("{{CARDS}}", cardsSummary) + APPLY_INSTRUCTION;
+  const fullPrompt = prompt.replace("{{CARDS}}", cardsSummary).replace(/\{\{CARD_ID\}\}/g, "") + APPLY_INSTRUCTION;
 
   const logDir = path.join(STATE_DIR, "logs", `${column}-triage`);
   fs.mkdirSync(logDir, { recursive: true });
@@ -125,8 +125,8 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ col
     `# ${column} Triage`,
     "",
     `You are a triage processor for the ${column} column of the Brain board.`,
-    "This is a sandboxed non-interactive session. Do not use tools.",
-    "Respond only with your analysis and the APPLY block.",
+    "You have full tool access. Use bash to read code, run CLI commands, and verify your work.",
+    "Respond with your analysis and the APPLY block.",
   ].join("\n"));
 
   const debugFile = path.join(logDir, `${ts0}.debug.log`);


### PR DESCRIPTION
## Summary
- Interpolate `{{CARD_ID}}` placeholder in CLI triage prompt (commands.ts:998)
- Interpolate `{{CARD_ID}}` in web triage route (test/route.ts:73)
- Fix conflicting CLAUDE.md: was "sandboxed, do not use tools" while prompt templates require CLI tool usage — now says "full tool access"

Closes board card `crd_e5e6e132`.

## Test plan
- [ ] Run `openclaw mc-board triage <backlog-card-id>` and verify card ID appears in CLI commands (not literal `{{CARD_ID}}`)
- [ ] Verify triage logs show tool-aware CLAUDE.md
- [ ] Check web triage route handles batch mode (empty card ID replacement)