### PR TITLE
feat(shared): add git-guardrails utility for PR-enforced shipping

### DIFF
--- a/plugins/shared/git-guardrails/guardrails.test.ts
+++ b/plugins/shared/git-guardrails/guardrails.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Integration tests for git guardrails.
+ *
+ * These tests create temporary git repos to verify:
+ * - Direct push to main/master is blocked
+ * - Branch push + PR creation flow works (PR creation is mocked)
+ * - Pre-push hook installation works
+ * - Protected branch detection works
+ *
+ * Run: npx vitest run shared/git-guardrails/guardrails.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import {
+  isProtectedBranch,
+  getCurrentBranch,
+  guardedPush,
+  guardedPushAndPR,
+  installPrePushHook,
+  PRE_PUSH_HOOK_CONTENT,
+} from "./index.js";
+
+const noopLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+function run(cmd: string, args: string[], cwd?: string): string {
+  return execFileSync(cmd, args, { encoding: "utf-8", cwd, timeout: 10_000 }).trim();
+}
+
+let tmpDir: string;
+let remoteDir: string;
+
+/**
+ * Set up a local git repo with a bare remote for push testing.
+ */
+function setupTestRepos(): { local: string; remote: string } {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "mc-guardrails-test-"));
+
+  // Create bare remote
+  const remote = path.join(base, "remote.git");
+  fs.mkdirSync(remote);
+  run("git", ["init", "--bare"], remote);
+
+  // Create local repo
+  const local = path.join(base, "local");
+  fs.mkdirSync(local);
+  run("git", ["init"], local);
+  run("git", ["config", "user.email", "test@test.com"], local);
+  run("git", ["config", "user.name", "Test"], local);
+  run("git", ["remote", "add", "origin", remote], local);
+
+  // Initial commit on main
+  fs.writeFileSync(path.join(local, "README.md"), "# Test\n");
+  run("git", ["add", "README.md"], local);
+  run("git", ["commit", "-m", "init"], local);
+  run("git", ["push", "-u", "origin", "main"], local);
+
+  return { local, remote };
+}
+
+function cleanupTestRepos(base: string): void {
+  try {
+    fs.rmSync(base, { recursive: true, force: true });
+  } catch {}
+}
+
+// ─── isProtectedBranch ──────────────────────────────────────────────────
+
+describe("isProtectedBranch", () => {
+  it("returns true for 'main'", () => {
+    expect(isProtectedBranch("main")).toBe(true);
+  });
+
+  it("returns true for 'master'", () => {
+    expect(isProtectedBranch("master")).toBe(true);
+  });
+
+  it("returns false for feature branches", () => {
+    expect(isProtectedBranch("feat/my-feature")).toBe(false);
+    expect(isProtectedBranch("contrib/mc-weather")).toBe(false);
+    expect(isProtectedBranch("fix/bug-123")).toBe(false);
+  });
+
+  it("returns false for branches containing 'main'", () => {
+    expect(isProtectedBranch("main-backup")).toBe(false);
+    expect(isProtectedBranch("not-main")).toBe(false);
+  });
+});
+
+// ─── guardedPush — blocks main ──────────────────────────────────────────
+
+describe("guardedPush", () => {
+  let repos: { local: string; remote: string };
+
+  beforeEach(() => {
+    repos = setupTestRepos();
+  });
+
+  afterEach(() => {
+    cleanupTestRepos(path.dirname(repos.local));
+  });
+
+  it("blocks direct push to main", () => {
+    const result = guardedPush(repos.local, "origin", "main", noopLogger);
+    expect(result.pushed).toBe(false);
+    expect(result.error).toContain("protected branch");
+    expect(result.error).toContain("main");
+  });
+
+  it("blocks direct push to master", () => {
+    const result = guardedPush(repos.local, "origin", "master", noopLogger);
+    expect(result.pushed).toBe(false);
+    expect(result.error).toContain("protected branch");
+  });
+
+  it("allows push to a feature branch", () => {
+    // Create a feature branch
+    run("git", ["checkout", "-b", "feat/test-feature"], repos.local);
+    fs.writeFileSync(path.join(repos.local, "feature.txt"), "new feature\n");
+    run("git", ["add", "feature.txt"], repos.local);
+    run("git", ["commit", "-m", "add feature"], repos.local);
+
+    const result = guardedPush(repos.local, "origin", undefined, noopLogger);
+    expect(result.pushed).toBe(true);
+    expect(result.branch).toBe("feat/test-feature");
+    expect(result.error).toBeUndefined();
+  });
+});
+
+// ─── guardedPushAndPR — blocks main, allows branches ────────────────────
+
+describe("guardedPushAndPR", () => {
+  let repos: { local: string; remote: string };
+
+  beforeEach(() => {
+    repos = setupTestRepos();
+  });
+
+  afterEach(() => {
+    cleanupTestRepos(path.dirname(repos.local));
+  });
+
+  it("blocks push+PR to main", () => {
+    const result = guardedPushAndPR(
+      repos.local,
+      "origin",
+      "test/repo",
+      { branch: "main", title: "Test PR", body: "Test body" },
+      noopLogger,
+    );
+    expect(result.pushed).toBe(false);
+    expect(result.prCreated).toBe(false);
+    expect(result.error).toContain("protected branch");
+  });
+
+  it("pushes branch successfully (PR creation will fail without gh auth, but push succeeds)", () => {
+    run("git", ["checkout", "-b", "feat/pr-test"], repos.local);
+    fs.writeFileSync(path.join(repos.local, "pr-feature.txt"), "pr content\n");
+    run("git", ["add", "pr-feature.txt"], repos.local);
+    run("git", ["commit", "-m", "add pr feature"], repos.local);
+
+    const result = guardedPushAndPR(
+      repos.local,
+      "origin",
+      "test/repo",
+      { title: "Test PR", body: "Test body" },
+      noopLogger,
+    );
+    // Push should succeed (local bare remote)
+    expect(result.pushed).toBe(true);
+    expect(result.branch).toBe("feat/pr-test");
+    // PR creation will fail (no gh auth to test/repo) but that's expected
+    // The important thing is the push succeeded and PR was attempted
+  });
+});
+
+// ─── Pre-push hook ──────────────────────────────────────────────────────
+
+describe("installPrePushHook", () => {
+  let repos: { local: string; remote: string };
+
+  beforeEach(() => {
+    repos = setupTestRepos();
+  });
+
+  afterEach(() => {
+    cleanupTestRepos(path.dirname(repos.local));
+  });
+
+  it("installs the pre-push hook successfully", () => {
+    const result = installPrePushHook(repos.local, noopLogger);
+    expect(result).toBe(true);
+
+    const hookPath = path.join(repos.local, ".git", "hooks", "pre-push");
+    expect(fs.existsSync(hookPath)).toBe(true);
+
+    const content = fs.readFileSync(hookPath, "utf-8");
+    expect(content).toContain("MiniClaw pre-push hook");
+    expect(content).toContain("PROTECTED_BRANCHES");
+  });
+
+  it("is idempotent (installing twice succeeds)", () => {
+    installPrePushHook(repos.local, noopLogger);
+    const result = installPrePushHook(repos.local, noopLogger);
+    expect(result).toBe(true);
+  });
+
+  it("backs up existing non-miniclaw hooks", () => {
+    const hooksDir = path.join(repos.local, ".git", "hooks");
+    fs.mkdirSync(hooksDir, { recursive: true });
+    const hookPath = path.join(hooksDir, "pre-push");
+    fs.writeFileSync(hookPath, "#!/bin/bash\necho 'existing hook'\n", { mode: 0o755 });
+
+    const result = installPrePushHook(repos.local, noopLogger);
+    expect(result).toBe(true);
+
+    // Original hook should be backed up
+    const backups = fs.readdirSync(hooksDir).filter(f => f.startsWith("pre-push.backup-"));
+    expect(backups.length).toBe(1);
+  });
+
+  it("hook content blocks push to main", () => {
+    // Verify the hook script contains the blocking logic
+    expect(PRE_PUSH_HOOK_CONTENT).toContain("BLOCKED");
+    expect(PRE_PUSH_HOOK_CONTENT).toContain("main master");
+    expect(PRE_PUSH_HOOK_CONTENT).toContain("exit 1");
+  });
+});

--- a/plugins/shared/git-guardrails/index.ts
+++ b/plugins/shared/git-guardrails/index.ts
@@ -1,0 +1,226 @@
+/**
+ * Shared git guardrails for the MiniClaw plugin ecosystem.
+ *
+ * Wraps git push to enforce branch+PR workflow:
+ * - Blocks direct pushes to main/master
+ * - Ensures a PR is created after pushing a branch
+ * - Provides a pre-push hook template for additional safety
+ */
+
+import { execFileSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+type Logger = { info(m: string): void; warn(m: string): void; error(m: string): void };
+
+const PROTECTED_BRANCHES = ["main", "master"];
+
+function run(cmd: string, args: string[], cwd?: string): string {
+  return execFileSync(cmd, args, { encoding: "utf-8", cwd, timeout: 30_000 }).trim();
+}
+
+function ghWithBodyFile(
+  subcmd: string[],
+  body: string,
+  extraArgs: string[],
+  cwd?: string
+): string {
+  const tmpFile = path.join(os.tmpdir(), `mc-guardrail-${Date.now()}-${Math.random().toString(36).slice(2)}.md`);
+  try {
+    fs.writeFileSync(tmpFile, body, "utf-8");
+    return run("gh", [...subcmd, "--body-file", tmpFile, ...extraArgs], cwd);
+  } finally {
+    try { fs.unlinkSync(tmpFile); } catch {}
+  }
+}
+
+export interface GuardedPushResult {
+  /** Whether the push succeeded */
+  pushed: boolean;
+  /** The branch that was pushed */
+  branch: string;
+  /** Error message if push was blocked or failed */
+  error?: string;
+}
+
+export interface GuardedPushAndPRResult extends GuardedPushResult {
+  /** URL of the created PR, if any */
+  prUrl?: string;
+  /** Whether a PR was created */
+  prCreated: boolean;
+}
+
+/**
+ * Check if a branch name is a protected branch (main, master).
+ */
+export function isProtectedBranch(branch: string): boolean {
+  return PROTECTED_BRANCHES.includes(branch.toLowerCase());
+}
+
+/**
+ * Get the current branch name in a git repo.
+ */
+export function getCurrentBranch(cwd: string): string {
+  return run("git", ["branch", "--show-current"], cwd);
+}
+
+/**
+ * Push a branch to a remote, blocking pushes to protected branches.
+ *
+ * @param cwd - The git repo working directory
+ * @param remote - Remote name (e.g. "origin", "fork")
+ * @param branch - Branch to push (if omitted, uses current branch)
+ * @param logger - Logger instance
+ * @returns GuardedPushResult with success/failure info
+ */
+export function guardedPush(
+  cwd: string,
+  remote: string,
+  branch: string | undefined,
+  logger: Logger,
+): GuardedPushResult {
+  const resolvedBranch = branch || getCurrentBranch(cwd);
+
+  if (!resolvedBranch) {
+    return { pushed: false, branch: "", error: "Could not determine current branch" };
+  }
+
+  if (isProtectedBranch(resolvedBranch)) {
+    const msg = `Blocked: direct push to protected branch '${resolvedBranch}' is not allowed. Create a feature branch and submit a PR instead.`;
+    logger.error(msg);
+    return { pushed: false, branch: resolvedBranch, error: msg };
+  }
+
+  try {
+    run("git", ["push", "-u", remote, resolvedBranch], cwd);
+    logger.info(`Pushed branch '${resolvedBranch}' to remote '${remote}'`);
+    return { pushed: true, branch: resolvedBranch };
+  } catch (err: unknown) {
+    const e = err as { stderr?: string };
+    const msg = `Failed to push branch '${resolvedBranch}' to '${remote}': ${e.stderr || "unknown error"}`;
+    logger.error(msg);
+    return { pushed: false, branch: resolvedBranch, error: msg };
+  }
+}
+
+/**
+ * Push a branch and create a PR in one step.
+ * Blocks pushes to protected branches and ensures a PR is always created.
+ *
+ * @param cwd - The git repo working directory
+ * @param remote - Remote name (e.g. "origin", "fork")
+ * @param repo - GitHub repo in "owner/name" format for the PR target
+ * @param options - PR creation options
+ * @param logger - Logger instance
+ * @returns GuardedPushAndPRResult with push and PR info
+ */
+export function guardedPushAndPR(
+  cwd: string,
+  remote: string,
+  repo: string,
+  options: {
+    branch?: string;
+    title: string;
+    body: string;
+    base?: string;
+    draft?: boolean;
+  },
+  logger: Logger,
+): GuardedPushAndPRResult {
+  const pushResult = guardedPush(cwd, remote, options.branch, logger);
+
+  if (!pushResult.pushed) {
+    return { ...pushResult, prCreated: false };
+  }
+
+  const base = options.base || "main";
+  const args = ["--repo", repo, "--title", options.title, "--base", base];
+  if (options.draft) args.push("--draft");
+
+  try {
+    const prUrl = ghWithBodyFile(["pr", "create"], options.body, args, cwd);
+    logger.info(`PR created: ${prUrl}`);
+    return { ...pushResult, prUrl, prCreated: true };
+  } catch (err: unknown) {
+    const e = err as { stderr?: string };
+    const msg = `Branch pushed but PR creation failed: ${e.stderr || "unknown error"}`;
+    logger.warn(msg);
+    return { ...pushResult, prCreated: false, error: msg };
+  }
+}
+
+/**
+ * Content for a pre-push git hook that blocks direct pushes to main/master.
+ * Install this in .git/hooks/pre-push to enforce the policy at the git level.
+ */
+export const PRE_PUSH_HOOK_CONTENT = `#!/bin/bash
+# MiniClaw pre-push hook — blocks direct pushes to protected branches.
+# Install: cp this file to .git/hooks/pre-push && chmod +x .git/hooks/pre-push
+# Or run: openclaw mc-contribute install-hook
+
+PROTECTED_BRANCHES="main master"
+
+while read local_ref local_oid remote_ref remote_oid; do
+  # Extract the branch name from the remote ref
+  remote_branch="\${remote_ref#refs/heads/}"
+
+  for protected in $PROTECTED_BRANCHES; do
+    if [ "$remote_branch" = "$protected" ]; then
+      echo ""
+      echo "🚫 BLOCKED: Direct push to '$protected' is not allowed."
+      echo ""
+      echo "MiniClaw enforces a branch + pull request workflow."
+      echo "Please:"
+      echo "  1. Create a feature branch:  git checkout -b my-feature"
+      echo "  2. Push the branch:          git push -u origin my-feature"
+      echo "  3. Create a PR:              openclaw mc-contribute pr -t 'My change' -s 'Description'"
+      echo ""
+      exit 1
+    fi
+  done
+done
+
+exit 0
+`;
+
+/**
+ * Install the pre-push hook in a git repository.
+ *
+ * @param repoPath - Path to the git repository
+ * @param logger - Logger instance
+ * @returns true if installed successfully, false otherwise
+ */
+export function installPrePushHook(repoPath: string, logger: Logger): boolean {
+  try {
+    const gitDir = run("git", ["rev-parse", "--git-dir"], repoPath);
+    const hooksDir = path.resolve(repoPath, gitDir, "hooks");
+    const hookPath = path.join(hooksDir, "pre-push");
+
+    // Create hooks directory if it doesn't exist
+    if (!fs.existsSync(hooksDir)) {
+      fs.mkdirSync(hooksDir, { recursive: true });
+    }
+
+    // Check if a pre-push hook already exists
+    if (fs.existsSync(hookPath)) {
+      const existing = fs.readFileSync(hookPath, "utf-8");
+      if (existing.includes("MiniClaw pre-push hook")) {
+        logger.info("MiniClaw pre-push hook already installed");
+        return true;
+      }
+      // Back up existing hook
+      const backupPath = `${hookPath}.backup-${Date.now()}`;
+      fs.copyFileSync(hookPath, backupPath);
+      logger.info(`Backed up existing pre-push hook to ${backupPath}`);
+    }
+
+    fs.writeFileSync(hookPath, PRE_PUSH_HOOK_CONTENT, { mode: 0o755 });
+    logger.info(`Installed MiniClaw pre-push hook at ${hookPath}`);
+    return true;
+  } catch (err: unknown) {
+    const e = err as { message?: string };
+    logger.error(`Failed to install pre-push hook: ${e.message || "unknown error"}`);
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- Add `shared/git-guardrails/` utility that wraps git push to block direct pushes to main/master
- Provides `guardedPush`, `guardedPushAndPR`, `isProtectedBranch`, `installPrePushHook` exports
- Includes pre-push git hook template for repo-level enforcement
- 13 integration tests covering all guardrail behaviors

## Context
Part of crd_f4f7cc9d — ensuring shipping code includes pull request handling.

Additional changes applied to live plugin directory (mc-github autoPush support, PLUGIN.md doc updates) will be committed when those plugins are added to the repo.

## Test plan
- [x] All 13 vitest tests pass
- [ ] Verify import works from mc-github tools/definitions.ts