### PR TITLE
fix(mc-board): remove shipped-only refs from archive/delete

### DIFF
--- a/plugins/mc-board/cli/commands.ts
+++ b/plugins/mc-board/cli/commands.ts
@@ -652,8 +652,7 @@ Examples:
         return;
       }
       for (const card of results) {
-        const shippedAt = card.history?.filter((h: { column: string; moved_at: string }) => h.column === "shipped").pop()?.moved_at;
-        console.log(`${card.id}  ${card.title}  [shipped ${(shippedAt ?? card.updated_at).slice(0, 10)}]`);
+        console.log(`${card.id}  ${card.title}  [archived ${card.updated_at.slice(0, 10)}]`);
       }
     });
 
@@ -679,7 +678,7 @@ Reads across all archive files. Prefix match on card id.
   brain
     .command("delete <id>")
     .alias("remove")
-    .description("Delete a card from the board (irreversible — use archive for shipped cards)")
+    .description("Delete a card from the board (irreversible — consider archive instead)")
     .option("--force", "Skip confirmation prompt")
     .action((id: string, opts: { force?: boolean }) => {
       try {


### PR DESCRIPTION
## Summary
- Update archive-search display label from `[shipped ...]` to `[archived ...]`
- Update delete command description to say "consider archive instead" rather than "use archive for shipped cards"
- Part of crd_81de4499: allow archiving from any column

## Test plan
- [x] 242/242 tests pass (`npx vitest run`)
- [x] Archive tests cover backlog, in-progress, in-review, and shipped columns