### PR TITLE
feat(mc-web-chat): reply-to-message in web chat

### DIFF
--- a/plugins/mc-board/web/src/app/globals.css
+++ b/plugins/mc-board/web/src/app/globals.css
@@ -10,6 +10,11 @@ body {
 }
 a { color: inherit; }
 
+/* ── Chat reply button hover ── */
+.chat-msg-wrapper:hover .chat-reply-btn {
+  opacity: 1 !important;
+}
+
 /* ── Markdown prose (FileViewModal) ── */
 .prose-modal {
   max-width: 72ch;


### PR DESCRIPTION
## Summary
- Add reply-to-message support in web chat UI
- Users can click a reply button on any message to quote-reply
- Reply context shown inline above the compose area

## Card
crd_0152bac8

## Test plan
- [ ] Send a message, click reply, verify quote appears
- [ ] Send reply, verify it shows linked to parent message
- [ ] Verify new chat clears reply state