### PR TITLE
Add triage state tracking to mc-email to prevent re-surfacing

### DIFF
--- a/plugins/mc-email/cli/commands.ts
+++ b/plugins/mc-email/cli/commands.ts
@@ -145,19 +145,70 @@ export function registerEmailCommands(ctx: Ctx): void {
     .option("--dry-run", "Classify but do not send replies or archive")
     .option("-n, --limit <n>", "Max unread messages to process", "20")
     .option("--test-set", "Run classification test suite only (no inbox access)")
-    .action((opts: { dryRun?: boolean; limit: string; testSet?: boolean }) => {
+    .option("--no-state", "Disable state tracking (process all unread messages)")
+    .action(async (opts: { dryRun?: boolean; limit: string; testSet?: boolean; state?: boolean }) => {
       const stateDir = process.env.OPENCLAW_STATE_DIR ?? path.join(os.homedir(), ".openclaw");
+      const useState = opts.state !== false;
+
+      // If --test-set, skip state tracking entirely
+      if (opts.testSet) {
+        const scriptPath = path.join(stateDir, "cron/scripts/email-triage.py");
+        const args = ["python3", scriptPath, "--test-set", "--limit", opts.limit];
+        const result = spawnSync(args[0], args.slice(1), {
+          stdio: "inherit",
+          env: { ...process.env },
+        });
+        if (result.status !== 0) process.exit(result.status ?? 1);
+        return;
+      }
+
+      // Load triage state to filter already-processed UIDs
+      let triageState = useState ? pruneState(loadTriageState()) : loadTriageState();
+      let skipUids: string[] = [];
+      if (useState) {
+        skipUids = Object.keys(triageState.processedUids);
+      }
+
+      // Fetch current unread messages to identify which UIDs will be processed
+      let processedUids: string[] = [];
+      if (useState) {
+        try {
+          const client = getClient(cfg);
+          const messages = await client.listMessages("in:inbox is:unread", parseInt(opts.limit, 10));
+          const newMessages = messages.filter((m) => !skipUids.includes(m.id));
+          if (!newMessages.length) {
+            console.log("No new unread messages to triage (all already processed).");
+            return;
+          }
+          processedUids = newMessages.map((m) => m.id);
+          console.log(`Triaging ${newMessages.length} new message(s) (${skipUids.length} already processed, skipped).`);
+        } catch (err) {
+          console.error("Warning: could not pre-check messages for state tracking, proceeding without filter.", err);
+        }
+      }
+
+      // Build skip-uids arg for the triage script
       const scriptPath = path.join(stateDir, "cron/scripts/email-triage.py");
       const args = ["python3", scriptPath];
       if (opts.dryRun) args.push("--dry-run");
-      if (opts.testSet) args.push("--test-set");
       args.push("--limit", opts.limit);
+      if (useState && skipUids.length > 0) {
+        args.push("--skip-uids", skipUids.join(","));
+      }
 
       const result = spawnSync(args[0], args.slice(1), {
         stdio: "inherit",
         env: { ...process.env },
       });
-      if (result.status !== 0) {
+
+      // Record processed UIDs on success (or dry-run)
+      if (useState && processedUids.length > 0 && (result.status === 0 || opts.dryRun)) {
+        triageState = markAllProcessed(processedUids, triageState);
+        saveTriageState(triageState);
+        console.log(`State updated: marked ${processedUids.length} UID(s) as processed.`);
+      }
+
+      if (result.status !== 0 && !opts.dryRun) {
         process.exit(result.status ?? 1);
       }
     });

--- a/plugins/mc-email/src/triage-state.test.ts
+++ b/plugins/mc-email/src/triage-state.test.ts
@@ -1,0 +1,113 @@
+import { test, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import {
+  loadTriageState,
+  saveTriageState,
+  isAlreadyProcessed,
+  markProcessed,
+  filterNewUids,
+  markAllProcessed,
+  pruneState,
+} from "./triage-state.ts";
+
+let tmpDir: string;
+let statePath: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "triage-state-test-"));
+  statePath = path.join(tmpDir, "email-triage-state.json");
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("loadTriageState returns default when file does not exist", () => {
+  const state = loadTriageState(statePath);
+  expect(state).toEqual({ processedUids: {} });
+});
+
+test("saveTriageState and loadTriageState roundtrip", () => {
+  const state = {
+    processedUids: {
+      "123": { timestamp: "2026-01-01T00:00:00.000Z" },
+      "456": { timestamp: "2026-01-02T00:00:00.000Z" },
+    },
+  };
+  saveTriageState(state, statePath);
+  const loaded = loadTriageState(statePath);
+  expect(loaded).toEqual(state);
+});
+
+test("loadTriageState handles corrupted file", () => {
+  fs.writeFileSync(statePath, "not json!!!");
+  const state = loadTriageState(statePath);
+  expect(state).toEqual({ processedUids: {} });
+});
+
+test("isAlreadyProcessed returns true for known UIDs", () => {
+  const state = {
+    processedUids: {
+      "100": { timestamp: "2026-01-01T00:00:00.000Z" },
+    },
+  };
+  expect(isAlreadyProcessed("100", state)).toBe(true);
+  expect(isAlreadyProcessed("200", state)).toBe(false);
+});
+
+test("markProcessed adds a UID with timestamp", () => {
+  const state = { processedUids: {} };
+  const updated = markProcessed("999", state);
+  expect(updated.processedUids["999"]).toBeDefined();
+  expect(updated.processedUids["999"].timestamp).toBeTruthy();
+  // Original state is not mutated
+  expect(state.processedUids).toEqual({});
+});
+
+test("filterNewUids removes already-processed UIDs", () => {
+  const state = {
+    processedUids: {
+      "1": { timestamp: "2026-01-01T00:00:00.000Z" },
+      "3": { timestamp: "2026-01-01T00:00:00.000Z" },
+    },
+  };
+  const result = filterNewUids(["1", "2", "3", "4"], state);
+  expect(result).toEqual(["2", "4"]);
+});
+
+test("markAllProcessed marks multiple UIDs at once", () => {
+  const state = { processedUids: {} };
+  const updated = markAllProcessed(["10", "20", "30"], state);
+  expect(Object.keys(updated.processedUids)).toEqual(["10", "20", "30"]);
+  for (const entry of Object.values(updated.processedUids)) {
+    expect(entry.timestamp).toBeTruthy();
+  }
+});
+
+test("pruneState removes entries older than maxAgeDays", () => {
+  const old = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000).toISOString();
+  const recent = new Date().toISOString();
+  const state = {
+    processedUids: {
+      "old-uid": { timestamp: old },
+      "new-uid": { timestamp: recent },
+    },
+  };
+  const pruned = pruneState(state, 90);
+  expect(pruned.processedUids["old-uid"]).toBeUndefined();
+  expect(pruned.processedUids["new-uid"]).toBeDefined();
+});
+
+test("pruneState keeps all entries within window", () => {
+  const recent = new Date().toISOString();
+  const state = {
+    processedUids: {
+      "a": { timestamp: recent },
+      "b": { timestamp: recent },
+    },
+  };
+  const pruned = pruneState(state, 90);
+  expect(Object.keys(pruned.processedUids)).toHaveLength(2);
+});


### PR DESCRIPTION
## Summary
- Adds triage state persistence to mc-email so previously triaged emails are not re-surfaced
- Includes 113 lines of tests in `triage-state.test.ts`
- Extends CLI commands with triage state read/write logic

## Test plan
- [ ] Run triage state tests (`mc-email/src/triage-state.test.ts`)
- [ ] Triage an email, then run triage again and confirm it does not reappear