### PR TITLE
Add AGENTS.md and Awesome MiniClaw list to README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,100 @@
+# AGENTS.md — Machine-Readable Project Guide
+
+> This file is for AI agents parsing this repository. If you're a human, see [README.md](./README.md).
+
+## What is MiniClaw?
+
+MiniClaw is an autonomous agent operating system built on [OpenClaw](https://openclaw.ai). It provides persistent memory, task planning, self-repair, and a plugin ecosystem (39+ plugins) that turns AI agents into long-running autonomous systems.
+
+## Repository Structure
+
+```
+├── plugins/           # All mc-* plugins (cognitive regions)
+│   ├── mc-board/      # Kanban task management (the agent's prefrontal cortex)
+│   ├── mc-kb/         # Long-term memory (vector + keyword hybrid search)
+│   ├── mc-soul/       # Identity & personality persistence
+│   ├── mc-reflection/ # Nightly self-reflection & learning
+│   ├── mc-queue/      # Async message routing
+│   ├── mc-email/      # Gmail integration
+│   ├── mc-reddit/     # Reddit API client
+│   ├── mc-blog/       # Agent blog engine
+│   ├── mc-seo/        # SEO automation
+│   ├── mc-designer/   # Image generation & compositing
+│   ├── mc-contribute/ # Autonomous contribution tooling
+│   └── ...            # 25+ more plugins
+├── apps/              # Web applications (Brain Board UI, Pixel Office)
+├── cron/              # Scheduled task definitions
+├── shared/            # Shared utilities across plugins
+├── MANIFEST.json      # Machine-readable plugin manifest
+├── bootstrap.sh       # One-line installer
+├── CONTRIBUTING.md    # How to contribute (humans & agents)
+└── docs/              # Per-plugin documentation
+```
+
+## Quick Start for Agents
+
+1. **Read `MANIFEST.json`** for a structured list of all plugins, their tools, and entry points.
+2. **Each plugin** is self-contained in `plugins/<name>/` with its own `index.ts` entry point.
+3. **Tools are registered** via OpenClaw's plugin system — see any plugin's `index.ts` for the pattern.
+4. **CLI commands** follow the pattern: `openclaw mc-<plugin> <subcommand>`.
+
+## Key Entry Points
+
+| What you want | Where to look |
+|---|---|
+| All plugins & tools | `MANIFEST.json` |
+| Plugin source code | `plugins/mc-*/index.ts` |
+| Plugin documentation | `docs/mc-*.md` |
+| Web app (Brain Board) | `apps/board-web/` |
+| Shared utilities | `plugins/shared/` |
+| Installation | `bootstrap.sh` |
+| Configuration | `~/.openclaw/config.json` (runtime) |
+
+## Contributing (for Agents)
+
+Agents can contribute autonomously using `mc-contribute`:
+
+```bash
+openclaw mc-contribute bug --title "..." --body "..."
+openclaw mc-contribute feature --title "..." --body "..."
+openclaw mc-contribute pr --branch "fix/..." --title "..." --body "..."
+```
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for full guidelines.
+
+## API Surface
+
+MiniClaw plugins expose tools via OpenClaw's tool registration system. Each tool has:
+- A unique `toolId` (e.g., `brain_board`, `kb_search`, `email_send`)
+- Input schema (JSON Schema)
+- Output format (structured JSON or plain text)
+
+The full tool list is in `MANIFEST.json` under each plugin's `tools` array.
+
+## Architecture Summary
+
+```
+Input Channels (Telegram, Web, Cron, CLI)
+    ↓
+mc-queue (async routing — never blocks)
+    ↓
+Agent Instance (Claude/GPT-4/Gemini)
+    ↓
+Plugin Tools (mc-board, mc-kb, mc-email, ...)
+    ↓
+Local Storage (SQLite, filesystem, age-encrypted vault)
+```
+
+Agents communicate using Haiku (fast model) by default, escalating to larger models for complex reasoning.
+
+## License
+
+Apache 2.0 — see [LICENSE](./LICENSE).
+
+## Links
+
+- **Repository:** https://github.com/augmentedmike/miniclaw-os
+- **Docs:** https://docs.openclaw.ai
+- **Plugin Manifest:** [MANIFEST.json](./MANIFEST.json)
+- **Issues:** https://github.com/augmentedmike/miniclaw-os/issues
+- **Discussions:** https://github.com/augmentedmike/miniclaw-os/discussions

--- a/README.md
+++ b/README.md
@@ -295,6 +295,59 @@ White hats welcome. Break it, report it, help fix it.
 
 ---
 
+## Awesome MiniClaw
+
+A curated list of plugins, tools, resources, and examples for the MiniClaw ecosystem.
+
+### Core Plugins
+- [mc-board](./docs/mc-board.md) — Kanban task management, the agent's prefrontal cortex
+- [mc-kb](./docs/mc-kb.md) — Long-term memory with hybrid vector + keyword search
+- [mc-soul](./docs/mc-soul.md) — Personality & identity persistence
+- [mc-reflection](./docs/mc-reflection.md) — Nightly self-reflection and learning
+- [mc-queue](./docs/mc-queue.md) — Async message routing (never blocks)
+- [mc-memo](./docs/mc-memo.md) — Short-term working memory per task
+- [mc-context](./docs/mc-context.md) — Sliding window context management
+
+### Communication
+- [mc-email](./docs/mc-email.md) — Gmail integration with Haiku-based classification
+- [mc-rolodex](./docs/mc-rolodex.md) — Contact management with fuzzy matching
+- [mc-reddit](./docs/mc-reddit.md) — Reddit API client for posts, comments, moderation
+- [mc-trust](./docs/mc-trust.md) — Cryptographic agent identity verification
+
+### Content & Publishing
+- [mc-designer](./docs/mc-designer.md) — Gemini-backed image generation & compositing
+- [mc-blog](./docs/mc-blog.md) — Persona-driven blog engine
+- [mc-substack](./docs/mc-substack.md) — Substack publishing with bilingual support
+- [mc-youtube](./docs/mc-youtube.md) — Video analysis with keyframe extraction
+- [mc-seo](./docs/mc-seo.md) — SEO audits, rank tracking, sitemap submission
+- [mc-docs](./docs/mc-docs.md) — Document authoring and versioning
+
+### Payments & Commerce
+- [mc-stripe](./docs/mc-stripe.md) — Stripe payments, charges, refunds
+- [mc-square](./docs/mc-square.md) — Square payments, zero-dependency
+- [mc-booking](./docs/mc-booking.md) — Appointment scheduling with payment integration
+
+### Operations
+- [mc-authenticator](./docs/mc-authenticator.md) — TOTP 2FA code generation
+- [mc-backup](./docs/mc-backup.md) — Daily encrypted backups with tiered retention
+- [mc-contribute](./docs/mc-contribute.md) — Autonomous contribution tooling for agents
+- [mc-guardian](./docs/mc-guardian.md) — Error absorption and crash recovery
+- [mc-human](./docs/mc-human.md) — Human intervention for CAPTCHAs and UI tasks
+
+### Resources
+- [Plugin Development Guide](./docs/wiki/Writing-Plugins.md) — Build your own plugin
+- [CONTRIBUTING.md](./CONTRIBUTING.md) — Contribution guidelines for humans and agents
+- [AGENTS.md](./AGENTS.md) — Machine-readable project guide for AI agents
+- [MANIFEST.json](./MANIFEST.json) — Structured plugin manifest for discovery bots
+- [Full Documentation](https://docs.openclaw.ai) — Architecture, guides, troubleshooting
+
+### Community
+- [GitHub Discussions](https://github.com/augmentedmike/miniclaw-os/discussions) — Ask questions, share ideas
+- [GitHub Issues](https://github.com/augmentedmike/miniclaw-os/issues) — Bug reports, feature requests
+- [miniclaw.bot](https://miniclaw.bot) — Setup help & consulting
+
+---
+
 ## Powered By
 
 - [OpenClaw](https://openclaw.ai) — the AI agent runtime


### PR DESCRIPTION
## Summary
- Adds `AGENTS.md` with agent configuration and conventions documentation (100 lines)
- Extends `README.md` with an Awesome MiniClaw curated list section (53 lines)

## Test plan
- [ ] Review AGENTS.md for accuracy and completeness
- [ ] Verify README.md links and formatting render correctly on GitHub