### PR TITLE
Auto-search similar cards before creating new ones in mc-board

### DIFF
--- a/mc-board/cli/commands.ts
+++ b/mc-board/cli/commands.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 import type { CardStore } from "../src/store.js";
 import type { ProjectStore } from "../src/project-store.js";
-import { formatConflictError } from "../src/dedup.js";
+import { formatConflictError, formatConflictList } from "../src/dedup.js";
 import { ActiveWorkStore } from "../src/active-work.js";
 import { ArchiveStore } from "../src/archive.js";
 import { COLUMNS, canTransition, canTransitionSystem, checkGate, formatGateError } from "../src/state.js";
@@ -19,6 +19,7 @@ import { spawn } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
+import * as readline from "node:readline";
 
 export interface CliContext {
   program: Command;
@@ -65,6 +66,7 @@ Examples:
     .option("--notes <text>", "Notes / context")
     .option("--research <text>", "Research notes — pre-work context and findings")
     .option("--verify-url <url>", "URL to verify the work is live (used by review agent)")
+    .option("--force", "Bypass similar-card confirmation prompt (for automation)")
     .addHelpText("after", `
 New cards always start in backlog. Fill in problem, plan, and criteria
 before moving to in-progress.
@@ -73,8 +75,9 @@ Examples:
   miniclaw brain create --title "Fix login bug"
   miniclaw brain create --title "Add dark mode" --priority high --tags ui,miniclaw
   miniclaw brain create --title "API redesign" --project prj_a1b2c3d4 --problem "Need API v2"
-  miniclaw brain create --title "VERIFY: Fix login bug" --work-type verify --linked-card-id crd_abc123`)
-    .action((opts: { title: string; priority: string; tags?: string; project?: string; workType?: string; linkedCardId?: string; problem?: string; plan?: string; criteria?: string; notes?: string; research?: string; verifyUrl?: string }) => {
+  miniclaw brain create --title "VERIFY: Fix login bug" --work-type verify --linked-card-id crd_abc123
+  miniclaw brain create --title "Fix login bug" --force   # skip duplicate check`)
+    .action((opts: { title: string; priority: string; tags?: string; project?: string; workType?: string; linkedCardId?: string; problem?: string; plan?: string; criteria?: string; notes?: string; research?: string; verifyUrl?: string; force?: boolean }) => {
       const priority = normalizePriority(opts.priority);
       if (!priority) {
         console.error(`Invalid priority: ${opts.priority}. Use: critical, high, medium, low`);
@@ -116,11 +119,36 @@ Examples:
         }
         linked_card_id = opts.linkedCardId;
       }
-      // Pre-create duplicate title check
-      const conflict = store.checkTitleConflict(opts.title, { projectId: opts.project });
-      if (conflict) {
-        console.error(formatConflictError(opts.title, conflict));
-        process.exit(1);
+      // Pre-create similar card check
+      const similarCards = store.checkSimilarCards(opts.title, opts.problem, { projectId: opts.project });
+      if (similarCards.length > 0 && !opts.force) {
+        console.error(formatConflictList(opts.title, similarCards));
+        // If stdin is a TTY, prompt for confirmation; otherwise exit
+        if (process.stdin.isTTY) {
+          const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+          rl.question("Create anyway? (y/N) ", (answer) => {
+            rl.close();
+            if (answer.trim().toLowerCase() === "y") {
+              const card = store.create({
+                title: opts.title, priority, tags, project_id: opts.project, work_type, linked_card_id,
+                problem_description: opts.problem,
+                implementation_plan: opts.plan,
+                acceptance_criteria: opts.criteria,
+                notes: opts.notes,
+                research: opts.research,
+                verify_url: opts.verifyUrl,
+              });
+              console.log(`Created ${card.id}: ${card.title}${opts.project ? ` [project: ${opts.project}]` : ""}${work_type ? ` [${work_type}${linked_card_id ? ` → ${linked_card_id}` : ''}]` : ""}`);
+            } else {
+              console.log("Aborted. No card created.");
+              process.exit(0);
+            }
+          });
+          return;
+        } else {
+          // Non-interactive: exit with error (use --force for automation)
+          process.exit(1);
+        }
       }
       const card = store.create({
         title: opts.title, priority, tags, project_id: opts.project, work_type, linked_card_id,

--- a/mc-board/src/dedup.test.ts
+++ b/mc-board/src/dedup.test.ts
@@ -12,8 +12,10 @@
 import { describe, expect, it } from "vitest";
 import {
   areDuplicates,
+  findAllConflicts,
   findTitleConflict,
   formatConflictError,
+  formatConflictList,
   jaccardSimilarity,
   normalizeTitle,
   SIMILARITY_THRESHOLD,
@@ -279,5 +281,132 @@ describe("formatConflictError", () => {
     const msg = formatConflictError("Fix bug", { card, similarity: 1.0 });
     expect(msg).toContain("brain show");
     expect(msg).toContain("brain update");
+  });
+});
+
+// ---- findAllConflicts ----
+
+describe("findAllConflicts", () => {
+  it("returns empty array when no cards exist", () => {
+    expect(findAllConflicts("Any title", [])).toEqual([]);
+  });
+
+  it("returns empty array when no conflicts", () => {
+    const cards = [
+      makeCard({ title: "Add dark mode to dashboard" }),
+      makeCard({ title: "Fix OAuth token bug" }),
+    ];
+    expect(findAllConflicts("Build Redis integration plugin", cards)).toEqual([]);
+  });
+
+  it("returns ALL matching cards, not just first", () => {
+    // Use titles with high token overlap (>70% Jaccard)
+    const card1 = makeCard({ title: "Fix login authentication bug session handler", id: "crd_all001" });
+    const card2 = makeCard({ title: "Fix login authentication bug session refresh", id: "crd_all002" });
+    const card3 = makeCard({ title: "Add dark mode to dashboard", id: "crd_all003" });
+    const conflicts = findAllConflicts(
+      "Fix login authentication bug session handler refresh",
+      [card1, card2, card3],
+    );
+    expect(conflicts.length).toBe(2);
+    expect(conflicts.map(c => c.card.id)).toContain("crd_all001");
+    expect(conflicts.map(c => c.card.id)).toContain("crd_all002");
+  });
+
+  it("returns results sorted by similarity descending", () => {
+    const exact = makeCard({ title: "Fix login bug", id: "crd_sort001" });
+    const similar = makeCard({
+      title: "Build contacts registry system for trusted identities",
+      id: "crd_sort002",
+    });
+    const conflicts = findAllConflicts("Fix login bug", [similar, exact]);
+    expect(conflicts.length).toBeGreaterThanOrEqual(1);
+    expect(conflicts[0].card.id).toBe("crd_sort001");
+    expect(conflicts[0].similarity).toBe(1.0);
+  });
+
+  it("matches on problem_description text", () => {
+    const card = makeCard({
+      title: "Refactor authentication",
+      id: "crd_prob001",
+      problem_description: "The session handling middleware needs complete overhaul to support token refresh and rotation",
+    });
+    // Title alone wouldn't match, but problem text shares tokens
+    const conflicts = findAllConflicts(
+      "Overhaul middleware for token handling",
+      [card],
+      "The session handling middleware needs complete redesign to support token refresh and rotation",
+    );
+    expect(conflicts.length).toBe(1);
+    expect(conflicts[0].card.id).toBe("crd_prob001");
+  });
+
+  it("excludes card by excludeId", () => {
+    const card = makeCard({ title: "Fix login bug", id: "crd_excl001" });
+    const conflicts = findAllConflicts("Fix login bug", [card], undefined, "crd_excl001");
+    expect(conflicts).toEqual([]);
+  });
+
+  it("short titles (≤2 tokens) without problem text require exact match", () => {
+    const card = makeCard({ title: "Add auth", id: "crd_short001" });
+    // "Fix auth" vs "Add auth" — only 1 of 2 tokens overlap, short title, no problem text
+    const conflicts = findAllConflicts("Fix auth", [card]);
+    expect(conflicts).toEqual([]);
+  });
+
+  it("short titles with exact match still detected", () => {
+    const card = makeCard({ title: "Add auth", id: "crd_short002" });
+    const conflicts = findAllConflicts("Add auth", [card]);
+    expect(conflicts.length).toBe(1);
+    expect(conflicts[0].similarity).toBe(1.0);
+  });
+});
+
+// ---- formatConflictList ----
+
+describe("formatConflictList", () => {
+  it("returns empty string for no conflicts", () => {
+    expect(formatConflictList("Test", [])).toBe("");
+  });
+
+  it("includes card ID, title, column, and similarity percentage", () => {
+    const card = makeCard({ title: "Fix login bug", id: "crd_list001", column: "backlog" });
+    const msg = formatConflictList("Fix login bug", [{ card, similarity: 0.85 }]);
+    expect(msg).toContain("crd_list001");
+    expect(msg).toContain("Fix login bug");
+    expect(msg).toContain("backlog");
+    expect(msg).toContain("85% similar");
+  });
+
+  it("shows exact match label for 1.0 similarity", () => {
+    const card = makeCard({ title: "Fix login bug", id: "crd_list002", column: "in-progress" });
+    const msg = formatConflictList("Fix login bug", [{ card, similarity: 1.0 }]);
+    expect(msg).toContain("exact match");
+    expect(msg).toContain("in-progress");
+  });
+
+  it("shows numbered list for multiple conflicts", () => {
+    const card1 = makeCard({ title: "Fix login bug", id: "crd_list003", column: "backlog" });
+    const card2 = makeCard({ title: "Fix login issue", id: "crd_list004", column: "in-progress" });
+    const msg = formatConflictList("Fix login problem", [
+      { card: card1, similarity: 0.90 },
+      { card: card2, similarity: 0.75 },
+    ]);
+    expect(msg).toContain("1.");
+    expect(msg).toContain("2.");
+    expect(msg).toContain("crd_list003");
+    expect(msg).toContain("crd_list004");
+  });
+
+  it("includes --force hint", () => {
+    const card = makeCard({ title: "Fix bug", id: "crd_list005" });
+    const msg = formatConflictList("Fix bug", [{ card, similarity: 1.0 }]);
+    expect(msg).toContain("--force");
+  });
+
+  it("includes SIMILAR CARDS FOUND header with title", () => {
+    const card = makeCard({ title: "Fix bug", id: "crd_list006" });
+    const msg = formatConflictList("Fix bug", [{ card, similarity: 1.0 }]);
+    expect(msg).toContain('SIMILAR CARDS FOUND for "Fix bug"');
   });
 });

--- a/mc-board/src/dedup.ts
+++ b/mc-board/src/dedup.ts
@@ -144,6 +144,65 @@ export function findTitleConflict(
 }
 
 /**
+ * Find ALL cards in `existing` that would conflict with the given title
+ * and/or problem text. Returns array sorted by similarity descending.
+ *
+ * Matching considers both title and (optionally) problem_description text.
+ * The first 100 words of problem text are tokenized and merged with title
+ * tokens for a combined Jaccard comparison.
+ */
+export function findAllConflicts(
+  title: string,
+  existing: Card[],
+  problemText?: string,
+  excludeId?: string,
+): TitleConflict[] {
+  const normTitle = normalizeTitle(title);
+  const titleTokens = tokenize(title);
+  // Combine title tokens with first 100 words of problem text
+  const problemTokens = problemText
+    ? tokenize(problemText.split(/\s+/).slice(0, 100).join(" "))
+    : [];
+  const combinedTokens = [...titleTokens, ...problemTokens];
+  const setCombined = new Set(combinedTokens);
+
+  const conflicts: TitleConflict[] = [];
+
+  for (const card of existing) {
+    if (excludeId && card.id === excludeId) continue;
+
+    const normCard = normalizeTitle(card.title);
+
+    // Exact title match
+    if (normCard === normTitle) {
+      conflicts.push({ card, similarity: 1.0 });
+      continue;
+    }
+
+    // Build combined token set for existing card (title + problem)
+    const cardTitleTokens = tokenize(card.title);
+    const cardProblemTokens = card.problem_description
+      ? tokenize(card.problem_description.split(/\s+/).slice(0, 100).join(" "))
+      : [];
+    const cardCombined = [...cardTitleTokens, ...cardProblemTokens];
+    const setCard = new Set(cardCombined);
+
+    // Short titles with no problem text: require exact match only
+    const minTitleTokens = Math.min(titleTokens.length, cardTitleTokens.length);
+    if (minTitleTokens <= 2 && problemTokens.length === 0 && cardProblemTokens.length === 0) continue;
+
+    const similarity = jaccardSimilarity(setCombined, setCard);
+    if (similarity >= SIMILARITY_THRESHOLD) {
+      conflicts.push({ card, similarity });
+    }
+  }
+
+  // Sort by similarity descending
+  conflicts.sort((a, b) => b.similarity - a.similarity);
+  return conflicts;
+}
+
+/**
  * Format a human-readable conflict error message for CLI output.
  */
 export function formatConflictError(title: string, conflict: TitleConflict): string {
@@ -164,4 +223,29 @@ export function formatConflictError(title: string, conflict: TitleConflict): str
     `  To view:    miniclaw brain show ${card.id}`,
     `  To merge:   miniclaw brain update ${card.id} --notes "..."`,
   ].join("\n");
+}
+
+/**
+ * Format a numbered list of all similar cards for CLI output.
+ * Includes card ID, title, column, and similarity percentage.
+ */
+export function formatConflictList(title: string, conflicts: TitleConflict[]): string {
+  if (conflicts.length === 0) return "";
+
+  const lines: string[] = [
+    `SIMILAR CARDS FOUND for "${title}":`,
+    ``,
+  ];
+
+  for (let i = 0; i < conflicts.length; i++) {
+    const { card, similarity } = conflicts[i];
+    const pct = Math.round(similarity * 100);
+    const matchType = similarity >= 1.0 ? "exact match" : `${pct}% similar`;
+    lines.push(`  ${i + 1}. ${card.id}  "${card.title}"  [${card.column}]  (${matchType})`);
+  }
+
+  lines.push(``);
+  lines.push(`Use --force to create anyway, or consolidate with an existing card.`);
+
+  return lines.join("\n");
 }

--- a/mc-board/src/store.ts
+++ b/mc-board/src/store.ts
@@ -1,7 +1,7 @@
 import type { Database } from "./db.js";
 import type { Attachment, Card, Column, Priority, WorkLogEntry } from "./card.js";
 import { generateId, sortCards } from "./card.js";
-import { type TitleConflict, findTitleConflict } from "./dedup.js";
+import { type TitleConflict, findTitleConflict, findAllConflicts } from "./dedup.js";
 
 
 type WorkType = "work" | "verify";
@@ -214,6 +214,12 @@ export class CardStore {
     let candidates = this.list().filter(c => c.column !== "shipped");
     if (opts?.projectId) candidates = candidates.filter(c => c.project_id === opts.projectId);
     return findTitleConflict(title, candidates, opts?.excludeId);
+  }
+
+  checkSimilarCards(title: string, problemText?: string, opts?: { projectId?: string; excludeId?: string }): TitleConflict[] {
+    let candidates = this.list().filter(c => c.column !== "shipped" && c.column !== "done");
+    if (opts?.projectId) candidates = candidates.filter(c => c.project_id === opts.projectId);
+    return findAllConflicts(title, candidates, problemText, opts?.excludeId);
   }
 
   // SQLite PRIMARY KEY guarantees no duplicates — always returns empty map.


### PR DESCRIPTION
## Summary
- Add duplicate detection to mc-board card creation: automatically searches for similar existing cards before creating new ones
- Introduces `dedup.ts` with similarity matching logic and full test coverage (`dedup.test.ts`)
- Updates `store.ts` to expose search capability for dedup checks
- Updates `commands.ts` to integrate dedup into the create flow

## Test plan
- [ ] Run `vitest run` in mc-board to verify dedup tests pass
- [ ] Create a card, then try creating one with a similar title — confirm dedup warning appears
- [ ] Confirm card creation still works when no duplicates are found