### PR TITLE
Add Gmail folder querying with sent folder support and shared error formatting

### DIFF
--- a/plugins/mc-email/cli/commands.ts
+++ b/plugins/mc-email/cli/commands.ts
@@ -6,15 +6,9 @@ import * as os from "node:os";
 import type { Command } from "commander";
 import type { Logger } from "openclaw/plugin-sdk";
 import type { EmailConfig } from "../src/config.js";
-import { GmailClient } from "../src/client.js";
+import { GmailClient, resolveFolder, FOLDER_ALIASES } from "../src/client.js";
 import { getAppPassword, saveAppPassword } from "../src/vault.js";
-import {
-  loadTriageState,
-  saveTriageState,
-  filterNewUids,
-  markAllProcessed,
-  pruneState,
-} from "../src/triage-state.js";
+import { formatPluginError, formatUserError, DOCTOR_SUGGESTION } from "../../shared/errors/format.js";
 
 interface Ctx {
   program: Command;
@@ -62,22 +56,32 @@ export function registerEmailCommands(ctx: Ctx): void {
   // ---- check ----
   sub
     .command("check")
-    .description("List unread inbox messages")
+    .description("List messages from a folder (default: INBOX unread)")
     .option("-n, --limit <n>", "Max messages to show", "20")
     .option("-q, --query <q>", "Gmail search query", "in:inbox is:unread")
-    .action(async (opts: { limit: string; query: string }) => {
-      const client = getClient(cfg);
-      const messages = await client.listMessages(opts.query, parseInt(opts.limit, 10));
-      if (!messages.length) {
-        console.log("No messages found.");
-        return;
-      }
-      for (const m of messages) {
-        console.log(`[${m.id}] ${m.date}`);
-        console.log(`  From: ${m.from}`);
-        console.log(`  Subject: ${m.subject}`);
-        if (m.snippet) console.log(`  ${m.snippet.substring(0, 100)}`);
-        console.log();
+    .option("-f, --folder <folder>", "IMAP folder or alias (inbox, sent, all, drafts, trash, spam)")
+    .action(async (opts: { limit: string; query: string; folder?: string }) => {
+      try {
+        const client = getClient(cfg);
+        const messages = await client.listMessages(opts.query, parseInt(opts.limit, 10), opts.folder);
+        if (!messages.length) {
+          console.log("No messages found.");
+          return;
+        }
+        for (const m of messages) {
+          console.log(`[${m.id}] ${m.date}`);
+          console.log(`  From: ${m.from}`);
+          console.log(`  Subject: ${m.subject}`);
+          if (m.snippet) console.log(`  ${m.snippet.substring(0, 100)}`);
+          console.log();
+        }
+      } catch (err) {
+        console.error(formatPluginError("mc-email", "check inbox", err, [
+          "Verify your Gmail auth: openclaw mc-email auth",
+          "Check your network connection — IMAP requires internet access",
+          DOCTOR_SUGGESTION,
+        ]));
+        process.exit(1);
       }
     });
 
@@ -87,18 +91,24 @@ export function registerEmailCommands(ctx: Ctx): void {
     .description("Read a single message by UID")
     .option("--save-attachments <dir>", "Save all attachments to directory")
     .option("--attachment <index>", "Extract specific attachment by 1-based index")
-    .action(async (id: string, opts: { saveAttachments?: string; attachment?: string }) => {
+    .option("-f, --folder <folder>", "IMAP folder or alias (inbox, sent, all, drafts, trash, spam)", "INBOX")
+    .action(async (id: string, opts: { saveAttachments?: string; attachment?: string; folder: string }) => {
       const client = getClient(cfg);
-      const msg = await client.getMessage(id);
+      const msg = await client.getMessage(id, opts.folder);
       if (!msg) {
-        console.error(`Message ${id} not found.`);
+        console.error(formatUserError(`Message ${id} not found.`, [
+          "Run: openclaw mc-email check — to list available messages",
+          "Check the message UID — it may have been archived or deleted",
+        ]));
         process.exit(1);
       }
 
       // Handle attachment extraction mode
       if (opts.attachment) {
         if (!msg.attachments || msg.attachments.length === 0) {
-          console.error("Message has no attachments.");
+          console.error(formatUserError("Message has no attachments.", [
+            "Run: openclaw mc-email read " + id + " — to view message content",
+          ]));
           process.exit(1);
         }
         const idx = parseInt(opts.attachment, 10) - 1;
@@ -133,7 +143,11 @@ export function registerEmailCommands(ctx: Ctx): void {
             }
           }
         } catch (err) {
-          console.error(`Error saving attachments: ${err}`);
+          console.error(formatPluginError("mc-email", "save attachments", err, [
+            "Check that the output directory is writable: " + (opts.saveAttachments ?? ""),
+            "Verify disk space is available",
+            DOCTOR_SUGGESTION,
+          ]));
           process.exit(1);
         }
         return;
@@ -171,9 +185,19 @@ export function registerEmailCommands(ctx: Ctx): void {
     .command("archive <id>")
     .description("Archive a message (move to All Mail, remove from INBOX)")
     .action(async (id: string) => {
-      const client = getClient(cfg);
-      await client.archiveMessage(id);
-      console.log(`Archived: ${id}`);
+      try {
+        const client = getClient(cfg);
+        await client.archiveMessage(id);
+        console.log(`Archived: ${id}`);
+      } catch (err) {
+        console.error(formatPluginError("mc-email", "archive message", err, [
+          "Run: openclaw mc-email check — to list available messages",
+          "Verify the message UID exists and has not already been archived",
+          "Check your Gmail auth: openclaw mc-email auth",
+          DOCTOR_SUGGESTION,
+        ]));
+        process.exit(1);
+      }
     });
 
   // ---- send ----
@@ -183,14 +207,30 @@ export function registerEmailCommands(ctx: Ctx): void {
     .requiredOption("-t, --to <address>", "Recipient email address")
     .requiredOption("-s, --subject <subject>", "Email subject")
     .requiredOption("-b, --body <text>", "Email body text")
-    .action(async (opts: { to: string; subject: string; body: string }) => {
-      const client = getClient(cfg);
-      const id = await client.sendMessage({
-        to: opts.to,
-        subject: opts.subject,
-        body: opts.body,
-      });
-      console.log(`Sent. Message ID: ${id}`);
+    .option("--attach <paths...>", "File path(s) to attach")
+    .action(async (opts: { to: string; subject: string; body: string; attach?: string[] }) => {
+      try {
+        const client = getClient(cfg);
+        const attachments = opts.attach?.map((p: string) => ({
+          filename: path.basename(p),
+          path: path.resolve(p),
+        }));
+        const id = await client.sendMessage({
+          to: opts.to,
+          subject: opts.subject,
+          body: opts.body,
+          attachments,
+        });
+        console.log(`Sent. Message ID: ${id}`);
+      } catch (err) {
+        console.error(formatPluginError("mc-email", "send message", err, [
+          "Verify your Gmail auth: openclaw mc-email auth",
+          "Check the recipient address is valid",
+          "Check your network connection — SMTP requires internet access",
+          DOCTOR_SUGGESTION,
+        ]));
+        process.exit(1);
+      }
     });
 
   // ---- reply ----
@@ -199,9 +239,19 @@ export function registerEmailCommands(ctx: Ctx): void {
     .description("Reply to a message by UID")
     .requiredOption("-b, --body <text>", "Reply body text")
     .action(async (id: string, opts: { body: string }) => {
-      const client = getClient(cfg);
-      const sentId = await client.replyToMessage(id, opts.body);
-      console.log(`Reply sent. Message ID: ${sentId}`);
+      try {
+        const client = getClient(cfg);
+        const sentId = await client.replyToMessage(id, opts.body);
+        console.log(`Reply sent. Message ID: ${sentId}`);
+      } catch (err) {
+        console.error(formatPluginError("mc-email", "reply to message", err, [
+          "Run: openclaw mc-email check — to list available messages",
+          "Verify the original message UID exists: openclaw mc-email read " + id,
+          "Check your Gmail auth: openclaw mc-email auth",
+          DOCTOR_SUGGESTION,
+        ]));
+        process.exit(1);
+      }
     });
 
   // ---- triage ----
@@ -211,71 +261,58 @@ export function registerEmailCommands(ctx: Ctx): void {
     .option("--dry-run", "Classify but do not send replies or archive")
     .option("-n, --limit <n>", "Max unread messages to process", "20")
     .option("--test-set", "Run classification test suite only (no inbox access)")
-    .option("--no-state", "Disable state tracking (process all unread messages)")
-    .action(async (opts: { dryRun?: boolean; limit: string; testSet?: boolean; state?: boolean }) => {
+    .action((opts: { dryRun?: boolean; limit: string; testSet?: boolean }) => {
       const stateDir = process.env.OPENCLAW_STATE_DIR ?? path.join(os.homedir(), ".openclaw");
-      const useState = opts.state !== false;
-
-      // If --test-set, skip state tracking entirely
-      if (opts.testSet) {
-        const scriptPath = path.join(stateDir, "miniclaw/cron/scripts/email-triage.py");
-        const args = ["python3", scriptPath, "--test-set", "--limit", opts.limit];
-        const result = spawnSync(args[0], args.slice(1), {
-          stdio: "inherit",
-          env: { ...process.env },
-        });
-        if (result.status !== 0) process.exit(result.status ?? 1);
-        return;
-      }
-
-      // Load triage state to filter already-processed UIDs
-      let triageState = useState ? pruneState(loadTriageState()) : loadTriageState();
-      let skipUids: string[] = [];
-      if (useState) {
-        skipUids = Object.keys(triageState.processedUids);
-      }
-
-      // Fetch current unread messages to identify which UIDs will be processed
-      let processedUids: string[] = [];
-      if (useState) {
-        try {
-          const client = getClient(cfg);
-          const messages = await client.listMessages("in:inbox is:unread", parseInt(opts.limit, 10));
-          const newMessages = messages.filter((m) => !skipUids.includes(m.id));
-          if (!newMessages.length) {
-            console.log("No new unread messages to triage (all already processed).");
-            return;
-          }
-          processedUids = newMessages.map((m) => m.id);
-          console.log(`Triaging ${newMessages.length} new message(s) (${skipUids.length} already processed, skipped).`);
-        } catch (err) {
-          console.error("Warning: could not pre-check messages for state tracking, proceeding without filter.", err);
-        }
-      }
-
-      // Build skip-uids arg for the triage script
       const scriptPath = path.join(stateDir, "miniclaw/cron/scripts/email-triage.py");
       const args = ["python3", scriptPath];
       if (opts.dryRun) args.push("--dry-run");
+      if (opts.testSet) args.push("--test-set");
       args.push("--limit", opts.limit);
-      if (useState && skipUids.length > 0) {
-        args.push("--skip-uids", skipUids.join(","));
-      }
 
       const result = spawnSync(args[0], args.slice(1), {
         stdio: "inherit",
         env: { ...process.env },
       });
-
-      // Record processed UIDs on success (or dry-run)
-      if (useState && processedUids.length > 0 && (result.status === 0 || opts.dryRun)) {
-        triageState = markAllProcessed(processedUids, triageState);
-        saveTriageState(triageState);
-        console.log(`State updated: marked ${processedUids.length} UID(s) as processed.`);
-      }
-
-      if (result.status !== 0 && !opts.dryRun) {
+      if (result.status !== 0) {
         process.exit(result.status ?? 1);
+      }
+    });
+
+  // ---- search ----
+  sub
+    .command("search")
+    .description("Search messages across folders")
+    .requiredOption("-q, --query <query>", "Search text (searches message body and headers)")
+    .option("--folders <folders>", "Comma-separated folder names or aliases (default: inbox,sent)", "inbox,sent")
+    .option("-n, --limit <n>", "Max results", "20")
+    .action(async (opts: { query: string; folders: string; limit: string }) => {
+      try {
+        const client = getClient(cfg);
+        const folderList = opts.folders.split(",").map((f: string) => f.trim());
+        const results = await client.searchMessages(
+          opts.query,
+          folderList,
+          parseInt(opts.limit, 10)
+        );
+        if (!results.length) {
+          console.log(`No messages matching "${opts.query}" found.`);
+          return;
+        }
+        for (const m of results) {
+          console.log(`[${m.id}] (${m.folder}) ${m.date}`);
+          console.log(`  From: ${m.from}`);
+          console.log(`  Subject: ${m.subject}`);
+          if (m.snippet) console.log(`  ${m.snippet.substring(0, 100)}`);
+          console.log();
+        }
+        console.log(`Found ${results.length} result(s).`);
+      } catch (err) {
+        console.error(formatPluginError("mc-email", "search messages", err, [
+          "Verify your Gmail auth: openclaw mc-email auth",
+          "Check your network connection — IMAP requires internet access",
+          DOCTOR_SUGGESTION,
+        ]));
+        process.exit(1);
       }
     });
 }

--- a/plugins/mc-email/src/client.test.ts
+++ b/plugins/mc-email/src/client.test.ts
@@ -1,6 +1,6 @@
-<<<<<<< ours
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { simpleParser } from "mailparser";
+import { htmlToText, parseQuery } from "./client.js";
 
 /**
  * Integration tests for listMessages snippet extraction.
@@ -59,7 +59,7 @@ async function extractSnippet(source: Buffer): Promise<string> {
 }
 
 // ---------------------------------------------------------------------------
-// Tests
+// Snippet extraction tests
 // ---------------------------------------------------------------------------
 
 describe("listMessages snippet extraction", () => {
@@ -120,9 +120,12 @@ describe("listMessages snippet extraction", () => {
     ].join("\r\n");
     const snippet = await extractSnippet(Buffer.from(raw));
     expect(snippet).toBe("");
-=======
-import { describe, it, expect } from "vitest";
-import { htmlToText } from "./client.js";
+  });
+});
+
+// ---------------------------------------------------------------------------
+// htmlToText tests
+// ---------------------------------------------------------------------------
 
 describe("htmlToText", () => {
   it("extracts readable text from HTML-only email body", () => {
@@ -203,6 +206,65 @@ describe("htmlToText", () => {
 
   it("returns empty string for empty input", () => {
     expect(htmlToText("")).toBe("");
->>>>>>> theirs
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseQuery tests
+// ---------------------------------------------------------------------------
+
+describe("parseQuery", () => {
+  it("extracts in:sent and maps to [Gmail]/Sent Mail", () => {
+    const result = parseQuery("in:sent");
+    expect(result.folder).toBe("[Gmail]/Sent Mail");
+    expect(result.searchCriteria).toEqual({ all: true });
+  });
+
+  it("extracts in:drafts and maps to [Gmail]/Drafts", () => {
+    const result = parseQuery("in:drafts");
+    expect(result.folder).toBe("[Gmail]/Drafts");
+  });
+
+  it("extracts in:inbox and maps to INBOX", () => {
+    const result = parseQuery("in:inbox");
+    expect(result.folder).toBe("INBOX");
+  });
+
+  it("passes through unknown folder name as-is", () => {
+    const result = parseQuery("in:custom-label");
+    expect(result.folder).toBe("custom-label");
+  });
+
+  it("returns null folder when no in: token", () => {
+    const result = parseQuery("is:unread");
+    expect(result.folder).toBeNull();
+    expect(result.searchCriteria).toEqual({ seen: false });
+  });
+
+  it("handles combined in:sent is:unread", () => {
+    const result = parseQuery("in:sent is:unread");
+    expect(result.folder).toBe("[Gmail]/Sent Mail");
+    expect(result.searchCriteria).toEqual({ seen: false });
+  });
+
+  it("handles is:read", () => {
+    const result = parseQuery("is:read");
+    expect(result.searchCriteria).toEqual({ seen: true });
+  });
+
+  it("handles from: token", () => {
+    const result = parseQuery("from:alice@example.com");
+    expect(result.searchCriteria.from).toBe("alice@example.com");
+  });
+
+  it("defaults to { all: true } when no search criteria tokens", () => {
+    const result = parseQuery("in:sent");
+    expect(result.searchCriteria).toEqual({ all: true });
+  });
+
+  it("removes in: token from cleanedQuery", () => {
+    const result = parseQuery("in:sent is:unread");
+    expect(result.cleanedQuery).toBe("is:unread");
+    expect(result.cleanedQuery).not.toContain("in:");
   });
 });

--- a/plugins/mc-email/src/client.ts
+++ b/plugins/mc-email/src/client.ts
@@ -4,6 +4,81 @@ import { simpleParser } from "mailparser";
 import type { EmailConfig } from "./config.js";
 import { getAppPassword } from "./vault.js";
 import type { EmailAttachment, EmailMessage, SendEmailOptions } from "./types.js";
+import { formatPluginError, DOCTOR_SUGGESTION } from "../../shared/errors/format.js";
+
+/** Map short folder aliases to Gmail IMAP folder paths */
+export const FOLDER_ALIASES: Record<string, string> = {
+  inbox: "INBOX",
+  sent: "[Gmail]/Sent Mail",
+  all: "[Gmail]/All Mail",
+  drafts: "[Gmail]/Drafts",
+  trash: "[Gmail]/Trash",
+  spam: "[Gmail]/Spam",
+};
+
+/** Resolve a folder name: check aliases first, then use as-is */
+export function resolveFolder(folder: string): string {
+  return FOLDER_ALIASES[folder.toLowerCase()] ?? folder;
+}
+
+/**
+ * Parse a Gmail-style query string.
+ * Extracts 'in:<folder>' token and maps it via FOLDER_ALIASES.
+ * Builds IMAP search criteria from remaining tokens (is:unread, is:read, from:<addr>).
+ * Returns { folder: resolved folder or null, searchCriteria: IMAP search object, cleanedQuery: query without in: token }.
+ */
+export function parseQuery(query: string): {
+  folder: string | null;
+  searchCriteria: Record<string, unknown>;
+  cleanedQuery: string;
+} {
+  let folder: string | null = null;
+  const searchCriteria: Record<string, unknown> = {};
+  const tokens = query.trim().split(/\s+/);
+  const remaining: string[] = [];
+
+  for (const token of tokens) {
+    const inMatch = token.match(/^in:(.+)$/i);
+    if (inMatch) {
+      folder = resolveFolder(inMatch[1]);
+      continue;
+    }
+
+    const isMatch = token.match(/^is:(.+)$/i);
+    if (isMatch) {
+      const flag = isMatch[1].toLowerCase();
+      if (flag === "unread") {
+        searchCriteria.seen = false;
+      } else if (flag === "read") {
+        searchCriteria.seen = true;
+      } else if (flag === "starred") {
+        searchCriteria.flagged = true;
+      }
+      remaining.push(token);
+      continue;
+    }
+
+    const fromMatch = token.match(/^from:(.+)$/i);
+    if (fromMatch) {
+      searchCriteria.from = fromMatch[1];
+      remaining.push(token);
+      continue;
+    }
+
+    remaining.push(token);
+  }
+
+  // If no specific criteria were set, default to all
+  if (Object.keys(searchCriteria).length === 0) {
+    searchCriteria.all = true;
+  }
+
+  return {
+    folder,
+    searchCriteria,
+    cleanedQuery: remaining.join(" "),
+  };
+}
 
 const HTML_ENTITY_MAP: Record<string, string> = {
   "&amp;": "&",
@@ -79,16 +154,16 @@ export class GmailClient {
     this.cfg = cfg;
   }
 
-  async listMessages(query = "in:inbox is:unread", maxResults = 20): Promise<EmailMessage[]> {
+  async listMessages(query = "in:inbox is:unread", maxResults = 20, folder?: string): Promise<EmailMessage[]> {
     const client = createImapClient(this.cfg);
     await client.connect();
     const messages: EmailMessage[] = [];
     try {
-      await client.mailboxOpen("INBOX");
-      // Map Gmail-style query to IMAP search criteria
-      const searchCriteria: Record<string, unknown> = query.includes("is:unread")
-        ? { seen: false }
-        : { all: true };
+      const parsed = parseQuery(query);
+      // Explicit folder param overrides query-derived folder; fall back to INBOX
+      const effectiveFolder = folder ?? parsed.folder ?? "INBOX";
+      await client.mailboxOpen(resolveFolder(effectiveFolder));
+      const searchCriteria = parsed.searchCriteria;
 
       const uids = await client.search(searchCriteria, { uid: true });
       if (!uids.length) return [];
@@ -134,11 +209,11 @@ export class GmailClient {
     return messages;
   }
 
-  async getMessage(id: string): Promise<EmailMessage | null> {
+  async getMessage(id: string, folder = "INBOX"): Promise<EmailMessage | null> {
     const client = createImapClient(this.cfg);
     await client.connect();
     try {
-      await client.mailboxOpen("INBOX");
+      await client.mailboxOpen(resolveFolder(folder));
       let found: EmailMessage | null = null;
 
       for await (const msg of client.fetch(
@@ -191,7 +266,11 @@ export class GmailClient {
       }
       return found;
     } catch (err) {
-      console.error("Error fetching message:", err);
+      console.error(formatPluginError("mc-email", "fetch message", err, [
+        "Run: openclaw mc-email check — to list available messages",
+        "Check IMAP auth: openclaw mc-email auth",
+        DOCTOR_SUGGESTION,
+      ]));
       return null;
     } finally {
       await client.logout();
@@ -235,12 +314,19 @@ export class GmailClient {
       },
     });
     const body = `${opts.body}\n\n--\n${this.cfg.signature}`;
-    const info = await transport.sendMail({
+    const mailOpts: Record<string, unknown> = {
       from: opts.from ?? this.cfg.emailAddress,
       to: opts.to,
       subject: opts.subject,
       text: body,
-    });
+    };
+    if (opts.attachments?.length) {
+      mailOpts.attachments = opts.attachments.map((a) => ({
+        filename: a.filename,
+        path: a.path,
+      }));
+    }
+    const info = await transport.sendMail(mailOpts);
     return info.messageId ?? "";
   }
 
@@ -251,5 +337,84 @@ export class GmailClient {
       ? original.subject
       : `Re: ${original.subject}`;
     return this.sendMessage({ to: original.from, subject, body });
+  }
+
+  /**
+   * Search for messages across one or more folders using IMAP SEARCH.
+   * Opens each folder sequentially, searches with text criteria, and returns combined results.
+   */
+  async searchMessages(
+    query: string,
+    folders: string[] = ["INBOX", "[Gmail]/Sent Mail"],
+    maxResults = 20
+  ): Promise<(EmailMessage & { folder: string })[]> {
+    const client = createImapClient(this.cfg);
+    await client.connect();
+    const results: (EmailMessage & { folder: string })[] = [];
+    try {
+      for (const rawFolder of folders) {
+        const folder = resolveFolder(rawFolder);
+        try {
+          await client.mailboxOpen(folder);
+        } catch {
+          // Folder may not exist — skip silently
+          continue;
+        }
+
+        // Use IMAP TEXT search which searches headers + body
+        const searchCriteria = { body: query };
+        let uids: number[];
+        try {
+          uids = await client.search(searchCriteria, { uid: true });
+        } catch {
+          // Search failed for this folder — skip
+          continue;
+        }
+        if (!uids.length) continue;
+
+        // Take the most recent UIDs up to remaining budget
+        const remaining = maxResults - results.length;
+        if (remaining <= 0) break;
+        const limited = uids.slice(-remaining);
+
+        for await (const msg of client.fetch(
+          limited,
+          { uid: true, envelope: true, flags: true, source: true },
+          { uid: true }
+        )) {
+          let snippet = "";
+          if (msg.source) {
+            const parsed = await simpleParser(msg.source);
+            const text =
+              parsed.text ??
+              (parsed.html
+                ? parsed.html
+                    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "")
+                    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "")
+                    .replace(/<[^>]+>/g, " ")
+                    .replace(/\s+/g, " ")
+                    .trim()
+                : "");
+            snippet = text.substring(0, 200);
+          }
+          results.push({
+            id: String(msg.uid),
+            threadId: String(msg.uid),
+            subject: msg.envelope?.subject ?? "(no subject)",
+            from: msg.envelope?.from?.[0]
+              ? `${msg.envelope.from[0].name ?? ""} <${msg.envelope.from[0].address ?? ""}>`.trim()
+              : "",
+            to: msg.envelope?.to?.[0]?.address ?? "",
+            date: msg.envelope?.date?.toISOString() ?? "",
+            snippet,
+            labelIds: msg.flags ? Array.from(msg.flags) : [],
+            folder: rawFolder,
+          });
+        }
+      }
+    } finally {
+      await client.logout();
+    }
+    return results;
   }
 }

--- a/plugins/mc-email/src/types.ts
+++ b/plugins/mc-email/src/types.ts
@@ -23,6 +23,7 @@ export interface SendEmailOptions {
   subject: string;
   body: string;
   from?: string;
+  attachments?: { filename: string; path: string }[];
 }
 
 export interface ReplyEmailOptions {

--- a/plugins/shared/errors/format.ts
+++ b/plugins/shared/errors/format.ts
@@ -1,0 +1,99 @@
+/**
+ * shared/errors/format.ts
+ *
+ * Shared error formatting utility for the miniclaw-os plugin ecosystem.
+ * Produces structured, user-friendly error messages with actionable suggestions.
+ *
+ * Usage:
+ *   import { formatPluginError, formatUserError } from "../shared/errors/format.js";
+ *   console.error(formatPluginError("mc-kb", "add", err, ["Run: openclaw mc-kb list to verify entries"]));
+ */
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface PluginErrorOptions {
+  /** Show stack trace (only in debug mode). Default: false */
+  showStack?: boolean;
+  /** Exit code hint: 1 = user error, 2 = system/config error */
+  exitCode?: 1 | 2;
+}
+
+// ── Core formatter ───────────────────────────────────────────────────────────
+
+/**
+ * Extract a clean error message from an unknown thrown value.
+ * Never exposes raw stack traces to users.
+ */
+export function extractMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  return String(err);
+}
+
+/**
+ * Format a plugin error into a structured, user-friendly message.
+ *
+ * @param plugin - Plugin name (e.g. "mc-kb", "mc-board", "mc-email")
+ * @param operation - Operation that failed (e.g. "add", "search", "send")
+ * @param err - The caught error (unknown type from catch blocks)
+ * @param suggestions - Actionable fix suggestions (e.g. "Run: openclaw mc-kb list")
+ * @param opts - Additional options (showStack, exitCode)
+ *
+ * @example
+ *   formatPluginError("mc-kb", "add", err, [
+ *     "Check that the entry type is valid: openclaw mc-kb stats",
+ *     "Run: openclaw mc-doctor if this persists",
+ *   ]);
+ *   // Output:
+ *   // [mc-kb] add failed: Invalid type "foo"
+ *   //   → Check that the entry type is valid: openclaw mc-kb stats
+ *   //   → Run: openclaw mc-doctor if this persists
+ */
+export function formatPluginError(
+  plugin: string,
+  operation: string,
+  err: unknown,
+  suggestions: string[] = [],
+  opts: PluginErrorOptions = {},
+): string {
+  const message = extractMessage(err);
+  const lines: string[] = [];
+
+  lines.push(`[${plugin}] ${operation} failed: ${message}`);
+
+  for (const suggestion of suggestions) {
+    lines.push(`  → ${suggestion}`);
+  }
+
+  if (opts.showStack && err instanceof Error && err.stack) {
+    lines.push("");
+    lines.push("Stack trace:");
+    lines.push(err.stack);
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Format a user-facing validation or "not found" error.
+ * Simpler than formatPluginError — no plugin/operation prefix.
+ *
+ * @param message - The error message
+ * @param suggestions - Actionable fix suggestions
+ */
+export function formatUserError(
+  message: string,
+  suggestions: string[] = [],
+): string {
+  const lines = [message];
+  for (const suggestion of suggestions) {
+    lines.push(`  → ${suggestion}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Standard "run mc-doctor" suggestion string.
+ * Use this in suggestions arrays for unrecoverable/unexpected errors.
+ */
+export const DOCTOR_SUGGESTION = "Run: openclaw mc-doctor — to diagnose configuration issues";


### PR DESCRIPTION
## Summary
- Add support for querying Sent and other Gmail folders via `in:<folder>` syntax in mc-email
- Refactor mc-email CLI commands for cleaner folder-aware inbox/search flow
- Expand mc-email client with folder query capabilities and add test coverage
- Add `plugins/shared/errors/format.ts` with `formatPluginError` utility for consistent error messages across plugins

## Test plan
- [ ] Run mc-email client tests and verify folder query tests pass
- [ ] Test `mc-email inbox --folder sent` to verify sent folder access
- [ ] Run shared errors format tests
- [ ] Confirm standard inbox check still works