### PR TITLE
fix(mc-board): replace checkSimilarCards with checkTitleConflict in CLI

### DIFF
--- a/mc-board/cli/commands.ts
+++ b/mc-board/cli/commands.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 import type { CardStore } from "../src/store.js";
 import type { ProjectStore } from "../src/project-store.js";
-import { formatConflictError, formatConflictList } from "../src/dedup.js";
+import { formatConflictError } from "../src/dedup.js";
 import { ActiveWorkStore } from "../src/active-work.js";
 import { ArchiveStore } from "../src/archive.js";
 import { COLUMNS, canTransition, canTransitionSystem, checkGate, formatGateError } from "../src/state.js";
@@ -133,9 +133,9 @@ Examples:
         linked_card_id = opts.linkedCardId;
       }
       // Pre-create similar card check
-      const similarCards = store.checkSimilarCards(opts.title, opts.problem, { projectId: opts.project });
-      if (similarCards.length > 0 && !opts.force) {
-        console.error(formatConflictList(opts.title, similarCards));
+      const conflict = store.checkTitleConflict(opts.title, { projectId: opts.project });
+      if (conflict !== null && !opts.force) {
+        console.error(formatConflictError(opts.title, conflict));
         // If stdin is a TTY, prompt for confirmation; otherwise exit
         if (process.stdin.isTTY) {
           const rl = readline.createInterface({ input: process.stdin, output: process.stdout });


### PR DESCRIPTION
## Summary
- Fix `mc-board create` crash: `store.checkSimilarCards is not a function`
- Replace non-existent `checkSimilarCards()` with existing `checkTitleConflict()` method
- Replace non-existent `formatConflictList()` with existing `formatConflictError()` helper
- Clean up stale import of `formatConflictList` from dedup.ts

## Card
crd_ab4939f2

## Test plan
- [x] `openclaw mc-board create --title test` succeeds without crash
- [x] No remaining references to `checkSimilarCards` or `formatConflictList` in codebase