### PR TITLE
fix(mc-board): card header tags wrap on overflow

### DIFF
--- a/mc-board/web/src/app/globals.css
+++ b/mc-board/web/src/app/globals.css
@@ -289,7 +289,7 @@ a { color: inherit; }
 .card--active { border-color: rgba(34,197,94,.35); }
 .card--held { border-color: rgba(217,119,6,.35); background: rgba(28,25,23,.85); }
 .card--held:hover { border-color: rgba(217,119,6,.5); }
-.card-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 4px; }
+.card-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 4px; flex-wrap: wrap; gap: 4px; }
 .card-id { font-size: 11px; color: #52525b; font-family: monospace; }
 .card-id--clickable { cursor: pointer; user-select: none; transition: color 0.15s; }
 .card-id--clickable:hover { color: #a1a1aa; }
@@ -304,7 +304,7 @@ a { color: inherit; }
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 100%;
+  width: 100%;
   margin-bottom: 4px;
 }
 .card--active .card-worker { display: flex; }

--- a/mc-board/web/src/components/card-item.tsx
+++ b/mc-board/web/src/components/card-item.tsx
@@ -135,7 +135,7 @@ export const CardItem = memo(function CardItem({ card, projectName, isActive, wo
             });
           }}
         >{idCopied ? "copied!" : card.id}</span>
-        <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 4, flexWrap: "wrap" }}>
           <HoldBadge held={held} onToggle={onHoldToggle ? (e) => { e.stopPropagation(); onHoldToggle(card.id); } : undefined} />
           <FocusBadge focused={focused} onToggle={onFocusToggle ? (e) => { e.stopPropagation(); onFocusToggle(card.id, !focused); } : undefined} />
           <span style={{


### PR DESCRIPTION
## Summary
- Add `flex-wrap: wrap` + `gap: 4px` to `.card-header` CSS so tags wrap to next line on overflow instead of clipping
- Add `flexWrap: "wrap"` to badges container in `card-item.tsx`
- Change `.card-worker` from `max-width: 100%` to `width: 100%` so status bar fills full container width

Fixes card crd_acd18a6e.

## Test plan
- [ ] Verify cards with many tags show wrapped tags instead of clipping
- [ ] Verify worker status bar spans full card width
- [ ] Visual regression check on board view