### PR TITLE
fix(mc-board): annotate all bare catch blocks with explanatory comments

### DIFF
--- a/mc-board/web/src/app/api/chat/route.ts
+++ b/mc-board/web/src/app/api/chat/route.ts
@@ -16,13 +16,13 @@ function getAssistantName(): string {
   try {
     const raw = JSON.parse(fs.readFileSync(path.join(STATE_DIR, "USER", "setup-state.json"), "utf-8"));
     return raw.shortName || raw.assistantName || "Assistant";
-  } catch {
+  } catch { // setup-state.json not found or invalid JSON — fall back to default
     return "Assistant";
   }
 }
 
 function readWorkspaceFile(filename: string): string {
-  try { return fs.readFileSync(path.join(STATE_DIR, "workspace", filename), "utf-8").trim(); } catch { return ""; }
+  try { return fs.readFileSync(path.join(STATE_DIR, "workspace", filename), "utf-8").trim(); } catch { return ""; } // file not found or unreadable
 }
 
 function getSystemPrompt(): string {
@@ -119,7 +119,7 @@ export async function POST(req: NextRequest) {
     const stream = new ReadableStream({
       start(controller) {
         const send = (obj: object) => {
-          try { controller.enqueue(encoder.encode(`data: ${JSON.stringify(obj)}\n\n`)); } catch {}
+          try { controller.enqueue(encoder.encode(`data: ${JSON.stringify(obj)}\n\n`)); } catch { /* client-disconnected */ }
         };
 
         send({ type: "session", sessionId: sid });
@@ -128,7 +128,7 @@ export async function POST(req: NextRequest) {
           send(evt);
           if (evt.type === "done") {
             session.removeListener("event", handler);
-            try { controller.close(); } catch {}
+            try { controller.close(); } catch { /* client-disconnected */ }
           }
         };
 
@@ -136,12 +136,12 @@ export async function POST(req: NextRequest) {
         session.send(userText, imagePaths.length > 0 ? imagePaths : undefined).catch((err) => {
           send({ type: "error", text: String(err) });
           session.removeListener("event", handler);
-          try { controller.close(); } catch {}
+          try { controller.close(); } catch { /* client-disconnected */ }
         });
 
         req.signal.addEventListener("abort", () => {
           session.removeListener("event", handler);
-          try { controller.close(); } catch {}
+          try { controller.close(); } catch { /* client-disconnected */ }
         });
       },
     });

--- a/mc-board/web/src/app/api/cron/tick/route.ts
+++ b/mc-board/web/src/app/api/cron/tick/route.ts
@@ -117,8 +117,7 @@ function agentStillRunning(cardId: string, column: string): boolean {
     const m = content.match(/pid (\d+)/);
     if (m) {
       const pid = parseInt(m[1]);
-      try { process.kill(pid, 0); return true; } catch {
-        // Process does not exist or no permission — agent not running
+      try { process.kill(pid, 0); return true; } catch { // process does not exist or no permission — agent not running
         return false;
       }
     }

--- a/mc-board/web/src/app/api/office/layouts/active/route.ts
+++ b/mc-board/web/src/app/api/office/layouts/active/route.ts
@@ -18,7 +18,7 @@ export function GET() {
       const data = JSON.parse(fs.readFileSync(filePath, "utf-8"));
       return NextResponse.json({ active: data.active ?? "default" });
     }
-  } catch {}
+  } catch { /* _active.json missing or malformed */ }
   return NextResponse.json({ active: "default" });
 }
 

--- a/mc-board/web/src/app/api/office/zones/route.ts
+++ b/mc-board/web/src/app/api/office/zones/route.ts
@@ -15,7 +15,7 @@ export function GET() {
       const data = JSON.parse(fs.readFileSync(ZONES_PATH, "utf-8"));
       return NextResponse.json(data);
     }
-  } catch {}
+  } catch { /* zones file missing or malformed */ }
   return NextResponse.json({ zones: {} });
 }
 

--- a/mc-board/web/src/app/api/process/[column]/[cardId]/route.ts
+++ b/mc-board/web/src/app/api/process/[column]/[cardId]/route.ts
@@ -16,7 +16,7 @@ function countCardsInColumn(column: string): number {
   try {
     const row = db.prepare(`SELECT COUNT(*) as cnt FROM cards WHERE col = ?`).get(column) as { cnt: number };
     return row.cnt;
-  } catch { return 0; }
+  } catch { return 0; /* DB query failed — treat as zero cards */ }
 }
 
 function countQueuedOrRunning(column: string): number {
@@ -27,7 +27,7 @@ function countQueuedOrRunning(column: string): number {
       `SELECT COUNT(*) as cnt FROM agent_queue WHERE col = ? AND status IN ('pending', 'running')`,
     ).get(column) as { cnt: number };
     return row.cnt;
-  } catch { return 0; }
+  } catch { return 0; /* DB query failed — treat as zero queued */ }
 }
 
 export async function POST(

--- a/plugins/mc-board/web/src/app/api/agents/route.ts
+++ b/plugins/mc-board/web/src/app/api/agents/route.ts
@@ -71,7 +71,7 @@ export function GET() {
   let manifest: Manifest;
   try {
     manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
-  } catch {
+  } catch { // MANIFEST.json unreadable or contains invalid JSON
     return NextResponse.json({ ok: false, error: "Failed to parse MANIFEST.json" }, { status: 500 });
   }
 

--- a/plugins/mc-board/web/src/app/api/backlog-prompt/test/route.ts
+++ b/plugins/mc-board/web/src/app/api/backlog-prompt/test/route.ts
@@ -208,7 +208,7 @@ export async function POST(req: Request) {
           writeStream(msg.result);
           writeFile(msg.result);
         }
-      } catch {
+      } catch { // JSON parse failed — raw line from agent, pass through as-is
         writeStream(line + "\n");
         writeFile(line + "\n");
       }

--- a/plugins/mc-board/web/src/app/api/budget/route.ts
+++ b/plugins/mc-board/web/src/app/api/budget/route.ts
@@ -28,7 +28,7 @@ function getSubscription(): { plan: string; tier: string; price: number; multipl
       multiplier: info.multiplier,
       discount_factor: 1 / info.multiplier,
     };
-  } catch {
+  } catch { /* keychain-unavailable */
     return { plan: "pro", tier: "default_claude_pro", price: 20, multiplier: 1, discount_factor: 1 };
   }
 }

--- a/plugins/mc-board/web/src/app/api/chat/route.ts
+++ b/plugins/mc-board/web/src/app/api/chat/route.ts
@@ -16,13 +16,13 @@ function getAssistantName(): string {
   try {
     const raw = JSON.parse(fs.readFileSync(path.join(STATE_DIR, "USER", "setup-state.json"), "utf-8"));
     return raw.shortName || raw.assistantName || "Assistant";
-  } catch {
+  } catch { // setup-state.json not found or invalid JSON — fall back to default
     return "Assistant";
   }
 }
 
 function readWorkspaceFile(filename: string): string {
-  try { return fs.readFileSync(path.join(STATE_DIR, "workspace", filename), "utf-8").trim(); } catch { return ""; }
+  try { return fs.readFileSync(path.join(STATE_DIR, "workspace", filename), "utf-8").trim(); } catch { return ""; } // file not found or unreadable
 }
 
 function getSystemPrompt(): string {
@@ -119,7 +119,7 @@ export async function POST(req: NextRequest) {
     const stream = new ReadableStream({
       start(controller) {
         const send = (obj: object) => {
-          try { controller.enqueue(encoder.encode(`data: ${JSON.stringify(obj)}\n\n`)); } catch {}
+          try { controller.enqueue(encoder.encode(`data: ${JSON.stringify(obj)}\n\n`)); } catch { /* client-disconnected */ }
         };
 
         send({ type: "session", sessionId: sid });
@@ -128,7 +128,7 @@ export async function POST(req: NextRequest) {
           send(evt);
           if (evt.type === "done") {
             session.removeListener("event", handler);
-            try { controller.close(); } catch {}
+            try { controller.close(); } catch { /* client-disconnected */ }
           }
         };
 
@@ -136,12 +136,12 @@ export async function POST(req: NextRequest) {
         session.send(userText, imagePaths.length > 0 ? imagePaths : undefined).catch((err) => {
           send({ type: "error", text: String(err) });
           session.removeListener("event", handler);
-          try { controller.close(); } catch {}
+          try { controller.close(); } catch { /* client-disconnected */ }
         });
 
         req.signal.addEventListener("abort", () => {
           session.removeListener("event", handler);
-          try { controller.close(); } catch {}
+          try { controller.close(); } catch { /* client-disconnected */ }
         });
       },
     });

--- a/plugins/mc-board/web/src/app/api/cron/tick/route.ts
+++ b/plugins/mc-board/web/src/app/api/cron/tick/route.ts
@@ -117,8 +117,7 @@ function agentStillRunning(cardId: string, column: string): boolean {
     const m = content.match(/pid (\d+)/);
     if (m) {
       const pid = parseInt(m[1]);
-      try { process.kill(pid, 0); return true; } catch {
-        // Process does not exist or no permission — agent not running
+      try { process.kill(pid, 0); return true; } catch { // process does not exist or no permission — agent not running
         return false;
       }
     }

--- a/plugins/mc-board/web/src/app/api/file/route.ts
+++ b/plugins/mc-board/web/src/app/api/file/route.ts
@@ -49,7 +49,7 @@ function isPathAllowed(resolved: string): boolean {
       try {
         const realRoot = fs.realpathSync(root);
         return real.startsWith(realRoot + path.sep) || real === realRoot;
-      } catch {
+      } catch { // root doesn't exist or unreadable — not allowed
         return false;
       }
     });
@@ -62,11 +62,11 @@ function isPathAllowed(resolved: string): boolean {
         try {
           const realRoot = fs.realpathSync(root);
           return realDir.startsWith(realRoot + path.sep) || realDir === realRoot;
-        } catch {
+        } catch { // root dir doesn't exist — can't match, skip
           return false;
         }
       });
-    } catch {
+    } catch { // parent directory doesn't exist — path is invalid
       return false;
     }
   }
@@ -93,7 +93,7 @@ function findInRoot(roots: string[], relativePath: string, maxDepth = 8): string
     let entries: fs.Dirent[];
     try {
       entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch {
+    } catch { // directory unreadable or doesn't exist — skip
       return null;
     }
     for (const entry of entries) {

--- a/plugins/mc-board/web/src/app/api/health/route.ts
+++ b/plugins/mc-board/web/src/app/api/health/route.ts
@@ -11,7 +11,7 @@ function getVersion(): string {
   try {
     const manifest = JSON.parse(fs.readFileSync(path.join(stateDir, "miniclaw", "MANIFEST.json"), "utf-8"));
     return manifest.version || "0.0.0";
-  } catch {
+  } catch { // MANIFEST.json missing or unreadable — return default version
     return "0.0.0";
   }
 }
@@ -24,7 +24,7 @@ async function checkWeb(): Promise<{ status: "ok" | "down" }> {
     clearTimeout(timer);
     if (res.ok) return { status: "ok" };
     return { status: "down" };
-  } catch {
+  } catch { // fetch failed — web service unreachable or timed out
     return { status: "down" };
   }
 }
@@ -49,7 +49,7 @@ async function checkChat(): Promise<{ status: "ok" | "down" }> {
         sock.destroy();
         resolve({ status: "down" });
       });
-    } catch {
+    } catch { // socket connection setup failed — chat service down
       resolve({ status: "down" });
     }
   });
@@ -70,11 +70,10 @@ async function checkTelegram(): Promise<{ status: "ok" | "down" | "unconfigured"
       clearTimeout(timer);
       const data = await res.json();
       return { status: data.ok ? "ok" : "down" };
-    } catch {
-      // Token exists but API unreachable — still "configured but down"
+    } catch { // Telegram API unreachable or timed out — token exists but service down
       return { status: "down" };
     }
-  } catch {
+  } catch { // setup-state.json missing or malformed — Telegram not configured
     return { status: "unconfigured" };
   }
 }

--- a/plugins/mc-board/web/src/app/api/office/layouts/active/route.ts
+++ b/plugins/mc-board/web/src/app/api/office/layouts/active/route.ts
@@ -16,7 +16,7 @@ export function GET() {
       const data = JSON.parse(fs.readFileSync(filePath, "utf-8"));
       return NextResponse.json({ active: data.active ?? "default" });
     }
-  } catch {}
+  } catch { /* _active.json missing or malformed */ }
   return NextResponse.json({ active: "default" });
 }
 

--- a/plugins/mc-board/web/src/app/api/office/layouts/route.ts
+++ b/plugins/mc-board/web/src/app/api/office/layouts/route.ts
@@ -24,7 +24,7 @@ export function GET() {
           cols: data.cols ?? 0,
           rows: data.rows ?? 0,
         };
-      } catch {
+      } catch { // layout JSON unreadable or malformed — return placeholder
         return { name: path.basename(f, ".json"), cols: 0, rows: 0 };
       }
     });

--- a/plugins/mc-board/web/src/app/api/office/zones/route.ts
+++ b/plugins/mc-board/web/src/app/api/office/zones/route.ts
@@ -12,7 +12,7 @@ export function GET() {
       const data = JSON.parse(fs.readFileSync(zp, "utf-8"));
       return NextResponse.json(data);
     }
-  } catch {}
+  } catch { /* zones file missing or malformed */ }
   return NextResponse.json({ zones: {} });
 }
 

--- a/plugins/mc-board/web/src/app/api/process/[column]/[cardId]/route.ts
+++ b/plugins/mc-board/web/src/app/api/process/[column]/[cardId]/route.ts
@@ -26,7 +26,7 @@ function countCardsInColumn(column: string): number {
   try {
     const row = db.prepare(`SELECT COUNT(*) as cnt FROM cards WHERE col = ?`).get(column) as { cnt: number };
     return row.cnt;
-  } catch { return 0; }
+  } catch { return 0; /* DB query failed — treat as zero cards */ }
 }
 
 function countQueuedOrRunning(column: string): number {
@@ -37,7 +37,7 @@ function countQueuedOrRunning(column: string): number {
       `SELECT COUNT(*) as cnt FROM agent_queue WHERE col = ? AND status IN ('pending', 'running')`,
     ).get(column) as { cnt: number };
     return row.cnt;
-  } catch { return 0; }
+  } catch { return 0; /* DB query failed — treat as zero queued */ }
 }
 
 export async function POST(

--- a/plugins/mc-board/web/src/app/api/process/[column]/route.ts
+++ b/plugins/mc-board/web/src/app/api/process/[column]/route.ts
@@ -37,7 +37,7 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ col
   try {
     const prompt = fs.existsSync(p) ? fs.readFileSync(p, "utf8") : DEFAULT_PROCESS_PROMPT;
     return NextResponse.json({ prompt, path: p });
-  } catch {
+  } catch { // prompt file read failed — fall back to default
     return NextResponse.json({ prompt: DEFAULT_PROCESS_PROMPT, path: p });
   }
 }

--- a/plugins/mc-board/web/src/app/api/rolodex/[id]/route.ts
+++ b/plugins/mc-board/web/src/app/api/rolodex/[id]/route.ts
@@ -19,7 +19,7 @@ export async function PATCH(
   let body: Record<string, unknown>;
   try {
     body = await req.json();
-  } catch {
+  } catch { // request body is not valid JSON
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
 

--- a/plugins/mc-board/web/src/app/api/rolodex/route.ts
+++ b/plugins/mc-board/web/src/app/api/rolodex/route.ts
@@ -20,7 +20,7 @@ export async function POST(req: NextRequest) {
   let body: Record<string, unknown>;
   try {
     body = await req.json();
-  } catch {
+  } catch { // request body is not valid JSON
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
 

--- a/plugins/mc-board/web/src/app/api/settings/anthropic/route.ts
+++ b/plugins/mc-board/web/src/app/api/settings/anthropic/route.ts
@@ -16,7 +16,7 @@ function isAnthropicAuthed(): boolean {
     ).trim();
     const creds = JSON.parse(raw);
     if (creds?.claudeAiOauth?.accessToken) return true;
-  } catch {}
+  } catch { /* keychain lookup failed */ }
 
   const candidates = [
     `${HOME}/.openclaw/agents/main/agent/auth-profiles.json`,
@@ -29,7 +29,7 @@ function isAnthropicAuthed(): boolean {
       if (Object.keys(profiles).some((k) => k.startsWith("anthropic") && profiles[k]?.token)) {
         return true;
       }
-    } catch {}
+    } catch { /* auth profile unreadable */ }
   }
 
   return false;

--- a/plugins/mc-board/web/src/app/api/settings/verify-password/route.ts
+++ b/plugins/mc-board/web/src/app/api/settings/verify-password/route.ts
@@ -27,10 +27,10 @@ export async function POST(req: Request) {
       });
       const sensitiveToken = issueToken();
       return NextResponse.json({ ok: true, sensitiveToken });
-    } catch {
+    } catch { // sudo validation failed — wrong password
       return NextResponse.json({ ok: false, error: "Incorrect password" }, { status: 401 });
     }
-  } catch {
+  } catch { // request body parse failure or missing fields
     return NextResponse.json({ ok: false, error: "Invalid request" }, { status: 400 });
   }
 }

--- a/plugins/mc-board/web/src/app/api/setup/anthropic/route.ts
+++ b/plugins/mc-board/web/src/app/api/setup/anthropic/route.ts
@@ -20,7 +20,7 @@ function isAnthropicAuthed(): boolean {
     ).trim();
     const creds = JSON.parse(raw);
     if (creds?.claudeAiOauth?.accessToken) return true;
-  } catch {}
+  } catch { /* keychain lookup failed */ }
 
   // Fallback: check openclaw auth-profiles
   const candidates = [
@@ -34,7 +34,7 @@ function isAnthropicAuthed(): boolean {
       if (Object.keys(profiles).some((k) => k.startsWith("anthropic") && profiles[k]?.token)) {
         return true;
       }
-    } catch {}
+    } catch { /* auth profile unreadable */ }
   }
 
   return false;

--- a/plugins/mc-board/web/src/app/api/setup/complete/route.ts
+++ b/plugins/mc-board/web/src/app/api/setup/complete/route.ts
@@ -79,7 +79,7 @@ function configureGateway(botId: string, botToken: string, chatId?: string) {
 function findBin(name: string): string | null {
   try {
     return execSync(`which ${name}`, { encoding: "utf-8" }).trim() || null;
-  } catch {
+  } catch { // binary not found in PATH
     return null;
   }
 }
@@ -272,8 +272,7 @@ function ensureProjectsFolder(): { ok: boolean; path: string; symlink: string } 
       fs.unlinkSync(symlinkPath);
       fs.symlinkSync(projectsDir, symlinkPath);
     }
-  } catch {
-    // symlink doesn't exist or isn't a symlink — create it
+  } catch { // symlink doesn't exist or isn't a symlink — create it
     try { fs.unlinkSync(symlinkPath); } catch { /* ignore */ }
     fs.symlinkSync(projectsDir, symlinkPath);
   }

--- a/plugins/mc-board/web/src/app/api/setup/install/log/route.ts
+++ b/plugins/mc-board/web/src/app/api/setup/install/log/route.ts
@@ -36,7 +36,7 @@ export async function GET(req: Request) {
       offset: allLines.length,
       done,
     });
-  } catch {
+  } catch { // log file read failed — may have been removed
     return Response.json({ lines: [], offset: 0, done: false });
   }
 }

--- a/plugins/mc-board/web/src/app/api/setup/verify-password/route.ts
+++ b/plugins/mc-board/web/src/app/api/setup/verify-password/route.ts
@@ -30,10 +30,10 @@ export async function POST(req: Request) {
       // Issue a single-use token for the subsequent save request
       const sensitiveToken = issueToken();
       return NextResponse.json({ ok: true, sensitiveToken });
-    } catch {
+    } catch { // sudo validation failed — wrong password
       return NextResponse.json({ ok: false, error: "Incorrect password" }, { status: 401 });
     }
-  } catch {
+  } catch { // request body parse failure or missing fields
     return NextResponse.json({ ok: false, error: "Invalid request" }, { status: 400 });
   }
 }

--- a/plugins/mc-board/web/src/app/api/setup/vpn/route.ts
+++ b/plugins/mc-board/web/src/app/api/setup/vpn/route.ts
@@ -26,7 +26,7 @@ function findBin(): string | null {
 function runSafe(bin: string, args: string[], timeout = 10_000): string | null {
   try {
     return execFileSync(bin, args, { timeout, encoding: "utf-8" }).trim();
-  } catch {
+  } catch { // command failed or timed out
     return null;
   }
 }
@@ -37,7 +37,7 @@ function readAutoconnect(): { enabled: boolean; defaultCountry: string } {
       const raw = JSON.parse(fs.readFileSync(AUTOCONNECT_FILE, "utf-8"));
       return { enabled: !!raw.enabled, defaultCountry: raw.defaultCountry || "" };
     }
-  } catch {}
+  } catch { /* autoconnect.json missing or malformed */ }
   return { enabled: false, defaultCountry: "" };
 }
 

--- a/plugins/mc-board/web/src/app/api/stats/runs/route.ts
+++ b/plugins/mc-board/web/src/app/api/stats/runs/route.ts
@@ -23,7 +23,7 @@ function getDiscountFactor(): { plan: string; multiplier: number; discount: numb
     const tier = oauth.rateLimitTier ?? "default_claude_pro";
     const info = tiers[tier] ?? tiers["default_claude_pro"];
     return { plan: info.plan, multiplier: info.mult, discount: 1 / info.mult };
-  } catch {
+  } catch { // keychain lookup failed — no Claude credentials or macOS security unavailable
     return { plan: "Pro ($20)", multiplier: 1, discount: 1 };
   }
 }
@@ -62,7 +62,7 @@ export async function GET() {
       plan,
       multiplier,
     });
-  } catch {
+  } catch { // DB open or query failed — return empty stats
     return NextResponse.json(EMPTY);
   }
 }

--- a/plugins/mc-board/web/src/app/api/watch/[cardId]/route.ts
+++ b/plugins/mc-board/web/src/app/api/watch/[cardId]/route.ts
@@ -25,7 +25,7 @@ function findActiveLog(cardId: string): string | null {
         const { mtimeMs } = fs.statSync(full);
         if (!best || mtimeMs > best.mtime) best = { file: full, mtime: mtimeMs };
       }
-    } catch {}
+    } catch { /* log dir scan failed */ }
   }
   return best?.file ?? null;
 }
@@ -46,7 +46,7 @@ function readNewBytes(file: string, lastSize: number): { text: string; size: num
     fs.readSync(fd, buf, 0, newBytes, lastSize);
     fs.closeSync(fd);
     return { text: buf.toString("utf8"), size: stat.size };
-  } catch {
+  } catch { // file read failed — return empty
     return { text: "", size: lastSize };
   }
 }
@@ -64,12 +64,12 @@ export async function GET(
   const cardsLog = cardsLogPath(cardId);
 
   // Start cards log offset at current end so we only show new lines
-  try { lastCardsSize = fs.statSync(cardsLog).size; } catch {}
+  try { lastCardsSize = fs.statSync(cardsLog).size; } catch { /* cards log doesn't exist yet */ }
 
   const stream = new ReadableStream({
     start(controller) {
       const send = (obj: object) => {
-        try { controller.enqueue(encoder.encode(`data: ${JSON.stringify(obj)}\n\n`)); } catch {}
+        try { controller.enqueue(encoder.encode(`data: ${JSON.stringify(obj)}\n\n`)); } catch { /* client-disconnected */ }
       };
 
       send({ type: "connected", cardId });
@@ -109,7 +109,7 @@ export async function GET(
       req.signal.addEventListener("abort", () => {
         closed = true;
         clearInterval(interval);
-        try { controller.close(); } catch {}
+        try { controller.close(); } catch { /* client-disconnected */ }
       });
     },
   });


### PR DESCRIPTION
## Summary
- Add inline comments to all bare `catch {}` blocks across 28 API route files in both `plugins/mc-board/web/` and `mc-board/web/` directories
- Categories: stream teardown (`/* client-disconnected */`), defensive returns (file/path guards), infrastructure checks (keychain, DB, binaries)
- Zero bare catch blocks remain without either logging or an explanatory comment

## Test plan
- [ ] `npm run build` passes with no regressions
- [ ] Grep confirms zero uncommented bare catches: `grep -rn 'catch\s*{' --include="*.ts" | grep -v '//' | grep -v '/\*'` returns nothing meaningful