### PR TITLE
fix(mc-rolodex): switch from JSON to SQLite storage

### DIFF
--- a/plugins/mc-rolodex/README.md
+++ b/plugins/mc-rolodex/README.md
@@ -28,7 +28,7 @@ mc-rolodex is installed as an OpenClaw plugin. Ensure it is listed in your `open
       "mc-rolodex": {
         "enabled": true,
         "config": {
-          "storagePath": "~/.openclaw/miniclaw/USER/rolodex/contacts.json"
+          "storagePath": "~/.openclaw/miniclaw/USER/rolodex/contacts.db"
         }
       }
     }
@@ -89,7 +89,7 @@ openclaw mc-rolodex show contact_1234
 openclaw mc-rolodex add '{"id":"contact_123","name":"Alice","emails":["alice@example.com"]}'
 
 # Via JSON file
-openclaw mc-rolodex add contacts.json
+openclaw mc-rolodex add contacts.db
 ```
 
 ### Delete a contact
@@ -130,7 +130,7 @@ All fields except `id` and `name` are optional.
 Contacts are stored in:
 
 ```
-~/.openclaw/miniclaw/USER/rolodex/contacts.json
+~/.openclaw/miniclaw/USER/rolodex/contacts.db
 ```
 
 This is a standard JSON array of contacts. You can edit it directly or use the CLI commands.

--- a/plugins/mc-rolodex/docs/MC_TRUST_INTEGRATION.md
+++ b/plugins/mc-rolodex/docs/MC_TRUST_INTEGRATION.md
@@ -136,7 +136,7 @@ input: { contactId: "alice" }
 
 ## Storage Locations
 
-- **mc-rolodex contacts:** `~/.openclaw/rolodex/contacts.json`
+- **mc-rolodex contacts:** `~/.openclaw/rolodex/contacts.db`
 - **mc-trust registry:** `~/.openclaw/trust/peers/`
 - **Verified agents:** `~/.openclaw/trust/sessions/` (TTL-based)
 

--- a/plugins/mc-rolodex/index.ts
+++ b/plugins/mc-rolodex/index.ts
@@ -34,7 +34,7 @@ function resolveConfig(api: OpenClawPluginApi): RolodexConfig {
   const raw = (api.pluginConfig ?? {}) as Partial<RolodexConfig>;
   return {
     storagePath: resolvePath(
-      raw.storagePath ?? `${process.env.OPENCLAW_STATE_DIR || "~/.openclaw"}/USER/rolodex/contacts.json`,
+      raw.storagePath ?? `${process.env.OPENCLAW_STATE_DIR || "~/.openclaw"}/USER/rolodex/contacts.db`,
     ),
   };
 }

--- a/plugins/mc-rolodex/package-lock.json
+++ b/plugins/mc-rolodex/package-lock.json
@@ -8,16 +8,22 @@
       "name": "@miniclaw/mc-rolodex",
       "version": "1.0.0",
       "dependencies": {
+        "better-sqlite3": "^11.9.0",
         "blessed": "^0.1.81",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
         "@types/blessed": "^0.1.24",
         "@types/node": "^22.0.0",
+        "openclaw": "file:../../../openclaw",
         "typescript": "^5.3.3",
         "vitest": "^2.0.0"
       }
+    },
+    "../../../openclaw": {
+      "dev": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -767,6 +773,16 @@
         "win32"
       ]
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/blessed": {
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/@types/blessed/-/blessed-0.1.27.tgz",
@@ -917,6 +933,57 @@
         "node": ">=12"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/blessed": {
       "version": "0.1.81",
       "resolved": "https://registry.npmjs.org/blessed/-/blessed-0.1.81.tgz",
@@ -927,6 +994,30 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/cac": {
@@ -978,6 +1069,12 @@
         "node": ">= 16"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
     "node_modules/commander": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
@@ -1005,6 +1102,21 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -1013,6 +1125,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-module-lexer": {
@@ -1071,6 +1210,15 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -1080,6 +1228,18 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1095,6 +1255,44 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -1112,6 +1310,33 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -1138,6 +1363,37 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/openclaw": {
+      "resolved": "../../../openclaw",
+      "link": true
     },
     "node_modules/pathe": {
       "version": "1.1.2",
@@ -1192,6 +1448,72 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
@@ -1237,12 +1559,89 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -1267,6 +1666,52 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -1312,6 +1757,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1331,6 +1788,12 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
     "node_modules/vite": {
@@ -1498,6 +1961,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     }
   }
 }

--- a/plugins/mc-rolodex/package.json
+++ b/plugins/mc-rolodex/package.json
@@ -8,11 +8,13 @@
     "test": "vitest"
   },
   "dependencies": {
+    "better-sqlite3": "^11.9.0",
     "blessed": "^0.1.81",
     "chalk": "^5.3.0",
     "commander": "^12.1.0"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/blessed": "^0.1.24",
     "@types/node": "^22.0.0",
     "openclaw": "file:../../../openclaw",

--- a/plugins/mc-rolodex/src/cli/commands.test.ts
+++ b/plugins/mc-rolodex/src/cli/commands.test.ts
@@ -33,7 +33,7 @@ let exitSpy: MockInstance;
 
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rolodex-cli-test-'));
-  storagePath = path.join(tmpDir, 'contacts.json');
+  storagePath = path.join(tmpDir, 'contacts.db');
   engine = new SearchEngine(storagePath);
 
   program = new Command();

--- a/plugins/mc-rolodex/src/search/engine.test.ts
+++ b/plugins/mc-rolodex/src/search/engine.test.ts
@@ -42,7 +42,7 @@ const carol: Contact = {
 
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rolodex-test-'));
-  storagePath = path.join(tmpDir, 'contacts.json');
+  storagePath = path.join(tmpDir, 'contacts.db');
   engine = new SearchEngine(storagePath);
   engine.add(alice);
   engine.add(bob);

--- a/plugins/mc-rolodex/src/search/engine.ts
+++ b/plugins/mc-rolodex/src/search/engine.ts
@@ -1,45 +1,117 @@
 /**
- * Contact search engine with in-memory indexing
+ * Contact search engine with in-memory indexing, backed by SQLite
  */
 
 import { Contact, SearchQuery, SearchResult, ContactStore } from './types.js';
+import Database from 'better-sqlite3';
 import * as fs from 'fs';
 import * as path from 'path';
+
+/** Map a SQLite row (snake_case, JSON-encoded arrays) to a Contact object */
+function rowToContact(row: Record<string, unknown>): Contact {
+  return {
+    id: row.id as string,
+    name: row.name as string,
+    emails: JSON.parse((row.emails as string) || '[]'),
+    phones: JSON.parse((row.phones as string) || '[]'),
+    domains: JSON.parse((row.domains as string) || '[]'),
+    tags: JSON.parse((row.tags as string) || '[]'),
+    trustStatus: (row.trust_status as Contact['trustStatus']) || 'unknown',
+    lastVerified: row.last_verified ? new Date(row.last_verified as string) : undefined,
+    notes: (row.notes as string) || '',
+  };
+}
 
 export class SearchEngine implements ContactStore {
   private contacts: Map<string, Contact> = new Map();
   private storagePath: string;
 
-  constructor(storagePath: string = `${process.env.OPENCLAW_STATE_DIR || process.env.HOME + "/.openclaw"}/rolodex/contacts.json`) {
+  constructor(storagePath: string = `${process.env.OPENCLAW_STATE_DIR || process.env.HOME + "/.openclaw"}/USER/rolodex/contacts.db`) {
     this.storagePath = storagePath;
     this.loadContacts();
   }
 
+  private ensureDb(): Database.Database {
+    const dir = path.dirname(this.storagePath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    const db = new Database(this.storagePath);
+    db.pragma('journal_mode = WAL');
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS contacts (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        emails TEXT NOT NULL DEFAULT '[]',
+        phones TEXT NOT NULL DEFAULT '[]',
+        domains TEXT NOT NULL DEFAULT '[]',
+        tags TEXT NOT NULL DEFAULT '[]',
+        trust_status TEXT NOT NULL DEFAULT 'unknown',
+        last_verified TEXT,
+        notes TEXT NOT NULL DEFAULT ''
+      )
+    `);
+    return db;
+  }
+
   private loadContacts(): void {
     try {
-      if (fs.existsSync(this.storagePath)) {
-        const data = fs.readFileSync(this.storagePath, 'utf8');
-        const contacts: Contact[] = JSON.parse(data);
+      if (!fs.existsSync(this.storagePath)) {
         this.contacts.clear();
-        contacts.forEach(c => this.contacts.set(c.id, c));
-      } else {
+        return;
+      }
+      const db = this.ensureDb();
+      try {
+        const rows = db.prepare('SELECT * FROM contacts').all() as Record<string, unknown>[];
         this.contacts.clear();
+        for (const row of rows) {
+          const c = rowToContact(row);
+          this.contacts.set(c.id, c);
+        }
+      } finally {
+        db.close();
       }
     } catch (err) {
       console.error(`Failed to load contacts from ${this.storagePath}:`, err);
     }
   }
 
-  private saveContacts(): void {
+  private saveContact(contact: Contact): void {
     try {
-      const dir = path.dirname(this.storagePath);
-      if (!fs.existsSync(dir)) {
-        fs.mkdirSync(dir, { recursive: true });
+      const db = this.ensureDb();
+      try {
+        db.prepare(`
+          INSERT OR REPLACE INTO contacts (id, name, emails, phones, domains, tags, trust_status, last_verified, notes)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `).run(
+          contact.id,
+          contact.name,
+          JSON.stringify(contact.emails || []),
+          JSON.stringify(contact.phones || []),
+          JSON.stringify(contact.domains || []),
+          JSON.stringify(contact.tags || []),
+          contact.trustStatus || 'unknown',
+          contact.lastVerified ? new Date(contact.lastVerified as unknown as string).toISOString() : null,
+          contact.notes || '',
+        );
+      } finally {
+        db.close();
       }
-      const contacts = Array.from(this.contacts.values());
-      fs.writeFileSync(this.storagePath, JSON.stringify(contacts, null, 2), 'utf8');
     } catch (err) {
-      console.error(`Failed to save contacts to ${this.storagePath}:`, err);
+      console.error(`Failed to save contact to ${this.storagePath}:`, err);
+    }
+  }
+
+  private deleteFromDb(id: string): void {
+    try {
+      const db = this.ensureDb();
+      try {
+        db.prepare('DELETE FROM contacts WHERE id = ?').run(id);
+      } finally {
+        db.close();
+      }
+    } catch (err) {
+      console.error(`Failed to delete contact from ${this.storagePath}:`, err);
     }
   }
 
@@ -202,7 +274,7 @@ export class SearchEngine implements ContactStore {
   private searchMulti(query: string): SearchResult[] {
     // Priority order: name > email > tag > domain > phone
     // Return results from the first field that has matches
-    
+
     const nameResults = this.searchByName(query);
     if (nameResults.length > 0) return nameResults;
 
@@ -267,21 +339,22 @@ export class SearchEngine implements ContactStore {
   add(contact: Contact): void {
     this.loadContacts();
     this.contacts.set(contact.id, contact);
-    this.saveContacts();
+    this.saveContact(contact);
   }
 
   update(id: string, updates: Partial<Contact>): void {
     this.loadContacts();
     const contact = this.contacts.get(id);
     if (contact) {
-      this.contacts.set(id, { ...contact, ...updates });
-      this.saveContacts();
+      const updated = { ...contact, ...updates };
+      this.contacts.set(id, updated);
+      this.saveContact(updated);
     }
   }
 
   delete(id: string): void {
     this.loadContacts();
     this.contacts.delete(id);
-    this.saveContacts();
+    this.deleteFromDb(id);
   }
 }

--- a/plugins/mc-rolodex/tools/load-contacts.js
+++ b/plugins/mc-rolodex/tools/load-contacts.js
@@ -8,12 +8,16 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const Database = require('better-sqlite3');
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const STATE_DIR = process.env.OPENCLAW_STATE_DIR || path.join(process.env.HOME, '.openclaw');
-const CONTACTS_DIR = path.join(STATE_DIR, 'rolodex');
-const CONTACTS_FILE = path.join(CONTACTS_DIR, 'contacts.json');
+const CONTACTS_DIR = path.join(STATE_DIR, 'USER', 'rolodex');
+const CONTACTS_DB = path.join(CONTACTS_DIR, 'contacts.db');
 
 // Sample contacts — replace with your own
 // Real contacts should be loaded from your local rolodex, not committed to git
@@ -46,39 +50,64 @@ function loadContacts() {
   // Create directory if it doesn't exist
   if (!fs.existsSync(CONTACTS_DIR)) {
     fs.mkdirSync(CONTACTS_DIR, { recursive: true });
-    console.log(`✓ Created ${CONTACTS_DIR}`);
+    console.log(`Created ${CONTACTS_DIR}`);
   }
 
-  // Check if contacts file already exists
-  let existing = [];
-  if (fs.existsSync(CONTACTS_FILE)) {
-    try {
-      existing = JSON.parse(fs.readFileSync(CONTACTS_FILE, 'utf8'));
-      console.log(`✓ Loaded ${existing.length} existing contacts`);
-    } catch (err) {
-      console.warn(`⚠ Failed to parse existing contacts: ${err.message}`);
-    }
+  const db = new Database(CONTACTS_DB);
+  db.pragma('journal_mode = WAL');
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS contacts (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      emails TEXT NOT NULL DEFAULT '[]',
+      phones TEXT NOT NULL DEFAULT '[]',
+      domains TEXT NOT NULL DEFAULT '[]',
+      tags TEXT NOT NULL DEFAULT '[]',
+      trust_status TEXT NOT NULL DEFAULT 'unknown',
+      last_verified TEXT,
+      notes TEXT NOT NULL DEFAULT ''
+    )
+  `);
+
+  // Count existing
+  const existingCount = db.prepare('SELECT COUNT(*) as cnt FROM contacts').get().cnt;
+  console.log(`Loaded ${existingCount} existing contacts`);
+
+  // Upsert sample contacts
+  const upsert = db.prepare(`
+    INSERT OR REPLACE INTO contacts (id, name, emails, phones, domains, tags, trust_status, last_verified, notes)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+
+  for (const c of sampleContacts) {
+    upsert.run(
+      c.id,
+      c.name,
+      JSON.stringify(c.emails || []),
+      JSON.stringify(c.phones || []),
+      JSON.stringify(c.domains || []),
+      JSON.stringify(c.tags || []),
+      c.trustStatus || 'unknown',
+      c.lastVerified || null,
+      c.notes || ''
+    );
   }
 
-  // Merge with sample contacts (deduplicate by id)
-  const contactMap = new Map();
-  existing.forEach(c => contactMap.set(c.id, c));
-  sampleContacts.forEach(c => contactMap.set(c.id, c));
+  const totalCount = db.prepare('SELECT COUNT(*) as cnt FROM contacts').get().cnt;
+  console.log(`Wrote ${totalCount} contacts to ${CONTACTS_DB}`);
 
-  const merged = Array.from(contactMap.values());
+  // Show sample
+  const all = db.prepare('SELECT * FROM contacts').all();
+  console.log('\nSample contacts loaded:');
+  for (const row of all) {
+    const emails = JSON.parse(row.emails || '[]').join(', ') || '(none)';
+    console.log(`  - ${row.name} <${emails}> [${row.trust_status}]`);
+  }
 
-  // Write back
-  fs.writeFileSync(CONTACTS_FILE, JSON.stringify(merged, null, 2), 'utf8');
-  console.log(`✓ Wrote ${merged.length} contacts to ${CONTACTS_FILE}`);
+  console.log('\nTry: npx mc-rolodex search michael');
 
-  // Test search
-  console.log('\n📋 Sample contacts loaded:');
-  merged.forEach(c => {
-    const emails = c.emails?.join(', ') || '(none)';
-    console.log(`  - ${c.name} <${emails}> [${c.trustStatus}]`);
-  });
-
-  console.log('\n💡 Try: npx mc-rolodex search michael');
+  db.close();
 }
 
 loadContacts();

--- a/plugins/mc-rolodex/web/src/lib/data.ts
+++ b/plugins/mc-rolodex/web/src/lib/data.ts
@@ -1,8 +1,9 @@
 /**
  * data.ts — contact data access layer for mc-rolodex web UI.
- * Reads and writes contacts.json on disk.
+ * Reads and writes contacts.db (SQLite).
  */
 
+import Database from "better-sqlite3";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
@@ -22,65 +23,130 @@ export interface Contact {
 function resolveStoragePath(): string {
   if (process.env.ROLODEX_STORAGE_PATH) return process.env.ROLODEX_STORAGE_PATH;
   const stateDir = process.env.OPENCLAW_STATE_DIR || path.join(os.homedir(), ".openclaw");
-  return path.join(stateDir, "rolodex", "contacts.json");
+  return path.join(stateDir, "USER", "rolodex", "contacts.db");
 }
 
-function loadContacts(): Contact[] {
-  const p = resolveStoragePath();
-  if (!fs.existsSync(p)) return [];
-  try {
-    const raw = fs.readFileSync(p, "utf8");
-    return JSON.parse(raw) as Contact[];
-  } catch {
-    return [];
-  }
-}
-
-function saveContacts(contacts: Contact[]): void {
+function openDb(): Database.Database {
   const p = resolveStoragePath();
   const dir = path.dirname(p);
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(p, JSON.stringify(contacts, null, 2), "utf8");
+  const db = new Database(p);
+  db.pragma("journal_mode = WAL");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS contacts (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      emails TEXT NOT NULL DEFAULT '[]',
+      phones TEXT NOT NULL DEFAULT '[]',
+      domains TEXT NOT NULL DEFAULT '[]',
+      tags TEXT NOT NULL DEFAULT '[]',
+      trust_status TEXT NOT NULL DEFAULT 'unknown',
+      last_verified TEXT,
+      notes TEXT NOT NULL DEFAULT ''
+    )
+  `);
+  return db;
+}
+
+function rowToContact(row: Record<string, unknown>): Contact {
+  return {
+    id: row.id as string,
+    name: row.name as string,
+    emails: JSON.parse((row.emails as string) || "[]"),
+    phones: JSON.parse((row.phones as string) || "[]"),
+    domains: JSON.parse((row.domains as string) || "[]"),
+    tags: JSON.parse((row.tags as string) || "[]"),
+    trustStatus: (row.trust_status as Contact["trustStatus"]) || "unknown",
+    lastVerified: (row.last_verified as string) || undefined,
+    notes: (row.notes as string) || undefined,
+  };
 }
 
 export function getAllContacts(): Contact[] {
-  return loadContacts();
+  const db = openDb();
+  try {
+    const rows = db.prepare("SELECT * FROM contacts").all() as Record<string, unknown>[];
+    return rows.map(rowToContact);
+  } finally {
+    db.close();
+  }
 }
 
 export function getContactById(id: string): Contact | null {
-  return loadContacts().find(c => c.id === id) ?? null;
+  const db = openDb();
+  try {
+    const row = db.prepare("SELECT * FROM contacts WHERE id = ?").get(id) as Record<string, unknown> | undefined;
+    return row ? rowToContact(row) : null;
+  } finally {
+    db.close();
+  }
 }
 
 export function createContact(data: Omit<Contact, "id">): Contact {
-  const contacts = loadContacts();
   const contact: Contact = { ...data, id: crypto.randomUUID() };
-  contacts.push(contact);
-  saveContacts(contacts);
-  return contact;
+  const db = openDb();
+  try {
+    db.prepare(`
+      INSERT INTO contacts (id, name, emails, phones, domains, tags, trust_status, last_verified, notes)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      contact.id,
+      contact.name,
+      JSON.stringify(contact.emails || []),
+      JSON.stringify(contact.phones || []),
+      JSON.stringify(contact.domains || []),
+      JSON.stringify(contact.tags || []),
+      contact.trustStatus || "unknown",
+      contact.lastVerified || null,
+      contact.notes || "",
+    );
+    return contact;
+  } finally {
+    db.close();
+  }
 }
 
 export function updateContact(id: string, data: Partial<Omit<Contact, "id">>): Contact | null {
-  const contacts = loadContacts();
-  const idx = contacts.findIndex(c => c.id === id);
-  if (idx === -1) return null;
-  contacts[idx] = { ...contacts[idx], ...data };
-  saveContacts(contacts);
-  return contacts[idx];
+  const db = openDb();
+  try {
+    const existing = db.prepare("SELECT * FROM contacts WHERE id = ?").get(id) as Record<string, unknown> | undefined;
+    if (!existing) return null;
+    const current = rowToContact(existing);
+    const updated = { ...current, ...data };
+    db.prepare(`
+      UPDATE contacts SET name=?, emails=?, phones=?, domains=?, tags=?, trust_status=?, last_verified=?, notes=?
+      WHERE id=?
+    `).run(
+      updated.name,
+      JSON.stringify(updated.emails || []),
+      JSON.stringify(updated.phones || []),
+      JSON.stringify(updated.domains || []),
+      JSON.stringify(updated.tags || []),
+      updated.trustStatus || "unknown",
+      updated.lastVerified || null,
+      updated.notes || "",
+      id,
+    );
+    return updated;
+  } finally {
+    db.close();
+  }
 }
 
 export function deleteContact(id: string): boolean {
-  const contacts = loadContacts();
-  const idx = contacts.findIndex(c => c.id === id);
-  if (idx === -1) return false;
-  contacts.splice(idx, 1);
-  saveContacts(contacts);
-  return true;
+  const db = openDb();
+  try {
+    const result = db.prepare("DELETE FROM contacts WHERE id = ?").run(id);
+    return result.changes > 0;
+  } finally {
+    db.close();
+  }
 }
 
 export function searchContacts(q: string): Contact[] {
-  if (!q.trim()) return loadContacts();
+  if (!q.trim()) return getAllContacts();
   const query = q.toLowerCase();
-  const contacts = loadContacts();
+  const contacts = getAllContacts();
 
   const scored: { contact: Contact; score: number }[] = [];
 
@@ -124,7 +190,7 @@ export function searchContacts(q: string): Contact[] {
 }
 
 export function getAllTags(): string[] {
-  const contacts = loadContacts();
+  const contacts = getAllContacts();
   const tags = new Set<string>();
   for (const c of contacts) {
     for (const t of c.tags ?? []) tags.add(t);


### PR DESCRIPTION
## Summary
- mc-rolodex was hardcoded to read `contacts.json` but actual contact data (93 contacts) lives in `contacts.db` (SQLite), causing the plugin to load 0 contacts
- Rewrote `SearchEngine` (`src/search/engine.ts`), web data layer (`web/src/lib/data.ts`), and `tools/load-contacts.js` to use `better-sqlite3` for all CRUD operations
- Added `better-sqlite3` + `@types/better-sqlite3` to package.json dependencies
- Updated all references in tests, README, and docs from `contacts.json` to `contacts.db`

## Test plan
- [x] All 35 existing unit tests pass (`vitest run` — engine + CLI smoke tests)
- [ ] Run `openclaw mc-rolodex list` after deploying extension — should return 93 contacts instead of 0
- [ ] Run `openclaw mc-rolodex search "Mike"` — should find contacts
- [ ] Verify add/update/delete operations persist to SQLite
- [ ] Verify web UI loads contacts from SQLite