### PR TITLE
release(0.1.9): version bump and final cleanup

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -1,11 +1,11 @@
 {
   "name": "miniclaw-os",
-  "version": "0.1.9-prerelease",
+  "version": "0.1.9",
   "openclaw": {
     "npm": "@miniclaw_official/openclaw",
     "npmVersion": "2026.3.12",
     "repo": "augmentedmike/openclaw",
-    "tag": "v0.1.9-prerelease"
+    "tag": "v0.1.9"
   },
   "description": "AugmentedMike's AI operating system \u2014 plugins, tools, and infrastructure for OpenClaw",
   "dependencies": {
@@ -120,7 +120,7 @@
       "cli": true,
       "tools": [],
       "config": {
-        "storagePath": "~/.openclaw/miniclaw/USER/rolodex/contacts.json"
+        "storagePath": "~/.openclaw/miniclaw/USER/rolodex/contacts.db"
       }
     },
     {

--- a/apps/am-setup/app/api/setup/anthropic/route.ts
+++ b/apps/am-setup/app/api/setup/anthropic/route.ts
@@ -4,8 +4,8 @@ import { NextResponse } from "next/server";
 import { execSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 
-const CLAUDE_BIN = "/Users/michaeloneal/.local/bin/claude";
 const HOME = process.env.HOME || "";
+const CLAUDE_BIN = `${HOME}/.local/bin/claude`;
 
 function isAnthropicAuthed(): boolean {
   // Claude Code stores OAuth token in macOS keychain under "Claude Code-credentials"

--- a/plugins/mc-board/web/src/app/api/settings/anthropic/route.ts
+++ b/plugins/mc-board/web/src/app/api/settings/anthropic/route.ts
@@ -5,8 +5,8 @@ import { execSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { consumeToken } from "@/lib/sensitive-auth";
 
-const CLAUDE_BIN = "/Users/michaeloneal/.local/bin/claude";
 const HOME = process.env.HOME || "";
+const CLAUDE_BIN = `${HOME}/.local/bin/claude`;
 
 function isAnthropicAuthed(): boolean {
   try {

--- a/plugins/mc-board/web/src/app/api/setup/anthropic/route.ts
+++ b/plugins/mc-board/web/src/app/api/setup/anthropic/route.ts
@@ -8,8 +8,8 @@ import { isSetupComplete } from "@/lib/setup-state";
 import { apiOk, apiError } from "@/lib/api-response";
 import { stateDir } from "@/lib/paths";
 
-const CLAUDE_BIN = "/Users/michaeloneal/.local/bin/claude";
 const HOME = process.env.HOME || "";
+const CLAUDE_BIN = `${HOME}/.local/bin/claude`;
 
 function isAnthropicAuthed(): boolean {
   // Claude Code stores OAuth token in macOS keychain under "Claude Code-credentials"


### PR DESCRIPTION
## Summary
- Remove hardcoded `/Users/michaeloneal` paths from 2 remaining anthropic route handlers
- Bump MANIFEST.json version `0.1.9-prerelease` → `0.1.9`
- Bump MANIFEST.json tag `v0.1.9-prerelease` → `v0.1.9`
- Update mc-rolodex storagePath from `contacts.json` to `contacts.db` (SQLite migration)

## Test plan
- [x] `mc-smoke` passes with no errors
- [x] Board web UI loads at localhost:4220
- [x] `mc-rolodex list` returns 94 contacts
- [x] No hardcoded `/Users/` paths in source (excluding node_modules, package-lock, path sanitizers)