### PR TITLE
fix(mc-transduck): apply review fixes

### DIFF
--- a/plugins/mc-transduck/cli/commands.ts
+++ b/plugins/mc-transduck/cli/commands.ts
@@ -105,7 +105,7 @@ Examples:
         }
 
         logger.info(`Warming cache for languages: ${langs.join(", ")}...`);
-        const { translated, errors } = await warmCache(
+        const { translated, errors, failedStrings } = await warmCache(
           entries,
           langs,
           (done, total) => {
@@ -113,10 +113,22 @@ Examples:
               process.stdout.write(`\r  Progress: ${done}/${total}`);
             }
           },
+          (text, lang, err) => {
+            logger.warn(`Failed to translate "${text}" → ${lang}: ${err}`);
+          },
         );
         console.log(
           `\nDone. Translated: ${translated}, Errors: ${errors}`,
         );
+        if (failedStrings.length > 0) {
+          console.log("Failed strings:");
+          for (const f of failedStrings.slice(0, 10)) {
+            console.log(`  "${f.text}" → ${f.lang}: ${f.error}`);
+          }
+          if (failedStrings.length > 10) {
+            console.log(`  ... and ${failedStrings.length - 10} more`);
+          }
+        }
       } catch (err) {
         logger.error(`warm failed: ${err}`);
         process.exit(1);

--- a/plugins/mc-transduck/index.ts
+++ b/plugins/mc-transduck/index.ts
@@ -1,5 +1,5 @@
 /**
- * mc-transduck — OpenClaw plugin
+ * mc-transduck — OpenClaw plugin (0.1.10-prerelease)
  *
  * AI translation framework for MiniClaw i18n.
  * Wraps the transduck library for translating strings, warming caches,

--- a/plugins/mc-transduck/package.json
+++ b/plugins/mc-transduck/package.json
@@ -8,10 +8,10 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "commander": "^14.0.3",
     "transduck": "^0.6.3"
   },
   "devDependencies": {
-    "commander": "^14.0.3",
     "openclaw": "file:../../../openclaw",
     "vitest": "^4.1.0"
   },

--- a/plugins/mc-transduck/src/client.ts
+++ b/plugins/mc-transduck/src/client.ts
@@ -8,7 +8,8 @@ import * as path from "node:path";
 import * as os from "node:os";
 import * as fs from "node:fs";
 import { spawnSync } from "node:child_process";
-import { initialize, setLanguage, ait, _getStore, _resetState } from "transduck";
+import { initialize, setLanguage, ait, _getStore, _resetState, type TranslationStore } from "transduck";
+import type { TransduckConfig } from "transduck/dist/config.js";
 import { scanPluginDirs, type ScanEntry } from "./scanner.js";
 
 export { type ScanEntry } from "./scanner.js";
@@ -83,7 +84,7 @@ export async function initClient(cfg: TransduckPluginConfig): Promise<void> {
 
   const storagePath = path.join(cfg.dbDir, "translations.db");
 
-  await initialize({
+  const tdConfig: Partial<TransduckConfig> = {
     projectName: "miniclaw",
     projectContext: "MiniClaw plugin ecosystem — an Agentic OS built on OpenClaw",
     sourceLang: cfg.defaultSourceLang,
@@ -92,7 +93,9 @@ export async function initClient(cfg: TransduckPluginConfig): Promise<void> {
     provider: cfg.provider,
     apiKeyEnv: cfg.apiKeyEnv,
     backendModel: cfg.backendModel,
-  } as any);
+  };
+
+  await initialize(tdConfig as TransduckConfig);
 
   _initialized = true;
 }
@@ -109,7 +112,7 @@ export async function translateText(
 }
 
 /** Get the underlying TranslationStore for stats/clear operations. */
-export function getStore(): any {
+export function getStore(): TranslationStore | null {
   return _getStore();
 }
 
@@ -118,9 +121,11 @@ export async function warmCache(
   entries: ScanEntry[],
   targetLangs: string[],
   onProgress?: (done: number, total: number) => void,
-): Promise<{ translated: number; errors: number }> {
+  onError?: (text: string, lang: string, err: unknown) => void,
+): Promise<{ translated: number; errors: number; failedStrings: Array<{ text: string; lang: string; error: string }> }> {
   let translated = 0;
   let errors = 0;
+  const failedStrings: Array<{ text: string; lang: string; error: string }> = [];
   const total = entries.length * targetLangs.length;
   let done = 0;
 
@@ -131,15 +136,18 @@ export async function warmCache(
         if (!entry.text) continue;
         await ait(entry.text, entry.context ? { context: entry.context } : undefined);
         translated++;
-      } catch {
+      } catch (err) {
         errors++;
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        failedStrings.push({ text: entry.text, lang, error: errorMsg });
+        onError?.(entry.text, lang, err);
       }
       done++;
       onProgress?.(done, total);
     }
   }
 
-  return { translated, errors };
+  return { translated, errors, failedStrings };
 }
 
 /** Reset state (for testing). */

--- a/plugins/mc-transduck/src/scanner.test.ts
+++ b/plugins/mc-transduck/src/scanner.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { scanPluginDirs } from "./scanner.js";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mc-transduck-scan-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeFile(relPath: string, content: string) {
+  const full = path.join(tmpDir, relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content, "utf-8");
+}
+
+describe("scanPluginDirs", () => {
+  it("extracts simple ait() calls with double quotes", () => {
+    writeFile("src/index.ts", `const msg = await ait("Hello world");`);
+    const entries = scanPluginDirs([tmpDir]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].text).toBe("Hello world");
+    expect(entries[0].context).toBeUndefined();
+  });
+
+  it("extracts ait() calls with single quotes", () => {
+    writeFile("src/index.ts", `const msg = await ait('Goodbye');`);
+    const entries = scanPluginDirs([tmpDir]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].text).toBe("Goodbye");
+  });
+
+  it("extracts ait() calls with backtick quotes", () => {
+    writeFile("src/index.ts", "const msg = await ait(`Welcome back`);");
+    const entries = scanPluginDirs([tmpDir]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].text).toBe("Welcome back");
+  });
+
+  it("extracts ait() calls with context argument (double quotes)", () => {
+    writeFile(
+      "src/index.ts",
+      `const msg = await ait("Hello", "greeting context");`,
+    );
+    const entries = scanPluginDirs([tmpDir]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].text).toBe("Hello");
+    expect(entries[0].context).toBe("greeting context");
+  });
+
+  it("extracts ait() calls with context argument (single quotes)", () => {
+    writeFile(
+      "src/index.ts",
+      `const msg = await ait('Submit', 'button label');`,
+    );
+    const entries = scanPluginDirs([tmpDir]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].text).toBe("Submit");
+    expect(entries[0].context).toBe("button label");
+  });
+
+  it("extracts multiple ait() calls from the same file", () => {
+    writeFile(
+      "src/index.ts",
+      `
+      const a = await ait("Hello");
+      const b = await ait("Goodbye", "farewell");
+      const c = await ait('Thanks');
+      `,
+    );
+    const entries = scanPluginDirs([tmpDir]);
+    expect(entries).toHaveLength(3);
+    expect(entries.map((e) => e.text).sort()).toEqual(
+      ["Goodbye", "Hello", "Thanks"].sort(),
+    );
+  });
+
+  it("deduplicates identical strings across files", () => {
+    writeFile("src/a.ts", `await ait("Hello");`);
+    writeFile("src/b.ts", `await ait("Hello");`);
+    const entries = scanPluginDirs([tmpDir]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].text).toBe("Hello");
+    expect(entries[0].files).toHaveLength(2);
+  });
+
+  it("skips node_modules directories", () => {
+    writeFile("node_modules/foo/index.ts", `await ait("Skip me");`);
+    writeFile("src/index.ts", `await ait("Include me");`);
+    const entries = scanPluginDirs([tmpDir]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].text).toBe("Include me");
+  });
+
+  it("only scans supported file extensions", () => {
+    writeFile("src/data.json", `{"key": "ait(\\"Nope\\")"}`);
+    writeFile("src/index.ts", `await ait("Yes");`);
+    const entries = scanPluginDirs([tmpDir]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].text).toBe("Yes");
+  });
+
+  it("returns empty array for directory with no ait() calls", () => {
+    writeFile("src/index.ts", `const x = 42;`);
+    const entries = scanPluginDirs([tmpDir]);
+    expect(entries).toHaveLength(0);
+  });
+});

--- a/plugins/mc-transduck/src/scanner.ts
+++ b/plugins/mc-transduck/src/scanner.ts
@@ -31,7 +31,8 @@ function extractStrings(content: string, filename: string): ScanEntry[] {
   const entries: ScanEntry[] = [];
 
   // Match ait("string literal", ...) and ait('string literal', ...)
-  const aitRegex = /\bait\(\s*(['"`])((?:(?!\1).)*)\1(?:\s*,\s*(?:['"`])((?:(?!\3).)*)\3)?\s*\)/g;
+  // Groups: 1=text quote, 2=text content, 3=context quote, 4=context content
+  const aitRegex = /\bait\(\s*(['"`])((?:(?!\1).)*)\1(?:\s*,\s*(['"`])((?:(?!\3).)*)\3)?\s*\)/g;
   let match: RegExpExecArray | null;
 
   while ((match = aitRegex.exec(content)) !== null) {


### PR DESCRIPTION
## Summary
- Fix scanner regex: context quote is now a capturing group so `\3` backreference correctly matches the closing quote character (was silently missing all `ait()` calls with context args)
- Replace `as any` cast with `Partial<TransduckConfig>` in `initClient()`
- Type `getStore()` return as `TranslationStore | null`
- `warmCache` now returns `failedStrings` array and accepts `onError` callback
- Move `commander` from devDependencies to dependencies (required at runtime)
- CLI warm command logs individual string failures
- Add 10 scanner behavior tests (`scanner.test.ts`)

## Test plan
- [x] All 20 tests pass (`vitest run`)
- [x] Scanner regex verified against `ait("Hello", "greeting context")` — now correctly returns match
- [ ] CI status check passes

Card: crd_54e36609