### PR TITLE
fix: sync drift — restore full components, add drift detection and guards

### DIFF
--- a/plugins/mc-board/CLAUDE.md
+++ b/plugins/mc-board/CLAUDE.md
@@ -27,6 +27,20 @@ Every change needs a GitHub issue first. Branch from it: `fix/N-slug`, `feat/N-s
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full workflow.
 
+## ⚠️ CRITICAL: Never write directly to ~/.openclaw/miniclaw/plugins/
+
+Card workers MUST NOT create or overwrite files directly in `~/.openclaw/miniclaw/plugins/`.
+This is the **live plugins directory** — direct writes cause sync drift with the source repo.
+
+**Correct workflow:**
+1. Make changes in `~/.openclaw/projects/miniclaw-os/plugins/` (the source repo)
+2. Commit to the repo
+3. Run `~/.openclaw/projects/miniclaw-os/scripts/sync-dev.sh` to sync to live
+
+**Why:** rsync uses timestamps. If you write a stub directly to the live dir, it becomes
+newer than the repo version and rsync will skip the repo's full file on the next sync.
+This is exactly what caused the chat-history-sidebar.tsx stub to persist over the full component.
+
 ## Web server
 
 The board web UI runs live from `web/src/`. It auto-reloads on file changes.

--- a/plugins/mc-board/web/deploy.sh
+++ b/plugins/mc-board/web/deploy.sh
@@ -10,6 +10,25 @@ set -e
 DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$DIR"
 
+# ── Drift detection ──────────────────────────────────────────────────────────
+# Compare live plugins dir against the source repo to catch direct-write drift.
+REPO_SRC="$HOME/.openclaw/projects/miniclaw-os/plugins/mc-board/web/src"
+LIVE_SRC="$DIR/src"
+if [ -d "$REPO_SRC" ]; then
+  DRIFT=$(diff -rq "$REPO_SRC" "$LIVE_SRC" \
+    --exclude='node_modules' --exclude='.next' --exclude='*.log' 2>/dev/null \
+    | grep -E '\.(tsx?|ts)' | head -10 || true)
+  if [ -n "$DRIFT" ]; then
+    echo ""
+    echo "⚠️  DRIFT DETECTED — live plugins dir differs from repo:"
+    echo "$DRIFT"
+    echo ""
+    echo "Run: ~/.openclaw/projects/miniclaw-os/scripts/sync-dev.sh"
+    echo "Or manually resolve differences before deploying."
+    echo ""
+  fi
+fi
+
 PLIST="$HOME/Library/LaunchAgents/com.miniclaw.board-web.plist"
 UID_NUM=$(id -u)
 

--- a/plugins/mc-board/web/src/components/app-shell.tsx
+++ b/plugins/mc-board/web/src/components/app-shell.tsx
@@ -14,7 +14,7 @@ import { AccentContext, hexToRgb } from "@/lib/accent-context";
 
 import useSWR from "swr";
 
-type Tab = "board" | "memory" | "rolodex" | "agents" | "settings";
+type Tab = "board" | "office" | "memory" | "rolodex" | "agents" | "settings";
 interface Toast { id: number; icon: string; title: string; sub?: string; exiting?: boolean; }
 interface Counts { backlog: number; inProgress: number; inReview: number; shipped: number; }
 
@@ -44,7 +44,7 @@ function DailyStats() {
   );
 }
 
-const TAB_PATHS: Record<Tab, string> = { board: "/board", memory: "/memory", rolodex: "/rolodex", agents: "/agents", settings: "/settings" };
+const TAB_PATHS: Record<Tab, string> = { board: "/board", office: "/office", memory: "/memory", rolodex: "/rolodex", agents: "/agents", settings: "/settings" };
 
 function getNotifsEnabled(): boolean {
   try { return localStorage.getItem("brain-toasts") !== "false"; } catch { return true; }
@@ -178,7 +178,8 @@ export function AppShell({ initialTab, initialCardId, initialProjectId }: { init
                 <button key={t} onClick={() => switchTab(t)}
                   className={`tab-btn${tab === t ? " active" : ""}`}
                   style={{ display: "flex", alignItems: "center", gap: 6 }}>
-                  {t === "office" ? "Office" : t === "board" ? "Board" : t === "memory" ? "Memory" : t === "rolodex" ? "Contacts" : t === "agents" ? "Agents" : "Settings"}
+                  {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */}
+                  {(t as string) === "office" ? "Office" : t === "board" ? "Board" : t === "memory" ? "Memory" : t === "rolodex" ? "Contacts" : t === "agents" ? "Agents" : "Settings"}
                   {memoryBadge && (
                     <span style={{
                       fontSize: 10,

--- a/plugins/mc-board/web/src/components/chat-panel.tsx
+++ b/plugins/mc-board/web/src/components/chat-panel.tsx
@@ -1081,26 +1081,7 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
       >↓</button>
       </div>
 
-      {/* Reply preview */}
-      {replyingTo && (
-        <div style={{
-          margin: "0 10px", padding: "6px 10px", borderRadius: 6,
-          background: "#1a1a2e", border: "1px solid #4c1d95",
-          display: "flex", alignItems: "flex-start", gap: 6, flexShrink: 0,
-        }}>
-          <span style={{ fontSize: 10, color: "#8b5cf6", fontWeight: 700, flexShrink: 0, marginTop: 1 }}>↩ reply</span>
-          <div style={{ flex: 1, overflow: "hidden", minWidth: 0 }}>
-            <span style={{ fontSize: 10, color: "#6366f1", fontWeight: 600, textTransform: "capitalize" }}>{replyingTo.role}</span>
-            <div style={{ fontSize: 11, color: "#a78bfa", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-              {replyingTo.snippet}
-            </div>
-          </div>
-          <button
-            onClick={() => setReplyingTo(null)}
-            style={{ background: "none", border: "none", color: "#52525b", cursor: "pointer", fontSize: 13, lineHeight: 1, padding: 0, flexShrink: 0 }}
-          >✕</button>
-        </div>
-      )}
+      {/* Reply preview — moved into compose area below */}
 
       {/* Context badge */}
       {context && (
@@ -1229,8 +1210,27 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
       {/* Compose */}
       <div style={{
         padding: "10px 10px 12px", borderTop: "1px solid #1f1f1f", flexShrink: 0,
-        display: "flex", flexDirection: "column", gap: 6,
+        display: "flex", flexDirection: "column", gap: 0,
       }}>
+        {/* Reply preview — flush above textarea */}
+        {replyingTo && (
+          <div style={{
+            padding: "5px 10px", marginBottom: 0,
+            borderRadius: "6px 6px 0 0",
+            background: "#1a1a2e", border: "1px solid #4c1d95", borderBottom: "none",
+            display: "flex", alignItems: "center", gap: 6, flexShrink: 0,
+          }}>
+            <span style={{ fontSize: 10, color: "#8b5cf6", fontWeight: 700, flexShrink: 0 }}>↩ reply</span>
+            <span style={{ fontSize: 10, color: "#6366f1", fontWeight: 600, textTransform: "capitalize", flexShrink: 0 }}>{replyingTo.role}</span>
+            <span style={{ fontSize: 11, color: "#a78bfa", flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+              {replyingTo.snippet}
+            </span>
+            <button
+              onClick={() => setReplyingTo(null)}
+              style={{ background: "none", border: "none", color: "#52525b", cursor: "pointer", fontSize: 13, lineHeight: 1, padding: 0, flexShrink: 0 }}
+            >✕</button>
+          </div>
+        )}
         <textarea
           ref={textareaRef}
           value={draft}
@@ -1240,15 +1240,18 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
           placeholder={`Message ${agentName}...`}
           rows={3}
           style={{
-            width: "100%", background: "#18181b", border: "1px solid #3f3f46",
-            borderRadius: 6, color: "#e4e4e7", fontSize: 13, fontFamily: "inherit",
+            width: "100%", background: "#18181b",
+            border: replyingTo ? "1px solid #4c1d95" : "1px solid #3f3f46",
+            borderTop: replyingTo ? "none" : undefined,
+            borderRadius: replyingTo ? "0 0 6px 6px" : 6,
+            color: "#e4e4e7", fontSize: 13, fontFamily: "inherit",
             padding: "7px 10px", outline: "none", resize: "none", lineHeight: 1.5,
             transition: "border-color 0.15s", boxSizing: "border-box",
           }}
           onFocus={e => { e.currentTarget.style.borderColor = "#52525b"; }}
           onBlur={e => { e.currentTarget.style.borderColor = "#3f3f46"; }}
         />
-        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginTop: 6 }}>
           <span style={{ fontSize: 10, color: "#3f3f46" }}>Shift+Enter to send</span>
           <div style={{ display: "flex", gap: 4 }}>
             {micAvailable && (

--- a/plugins/mc-board/web/src/lib/api-response.ts
+++ b/plugins/mc-board/web/src/lib/api-response.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+
+/**
+ * Return a JSON success response.
+ * @param data - optional payload to include in the response body
+ * @param status - HTTP status code (default 200)
+ */
+export function apiOk(data?: Record<string, unknown>, status = 200) {
+  return NextResponse.json({ ok: true, ...data }, { status });
+}
+
+/**
+ * Return a JSON error response.
+ * @param message - human-readable error message
+ * @param status - HTTP status code (default 400)
+ */
+export function apiError(message: string, status = 400) {
+  return NextResponse.json({ ok: false, error: message }, { status });
+}

--- a/plugins/mc-board/web/src/lib/setup/constants.ts
+++ b/plugins/mc-board/web/src/lib/setup/constants.ts
@@ -1,0 +1,13 @@
+import * as path from "node:path";
+import { execSync } from "node:child_process";
+
+export const STATE_DIR =
+  process.env.OPENCLAW_STATE_DIR ?? path.join(process.env.HOME || "", ".openclaw");
+
+export function findBin(name: string): string | null {
+  try {
+    return execSync(`which ${name}`, { encoding: "utf-8" }).trim() || null;
+  } catch {
+    return null;
+  }
+}

--- a/plugins/mc-board/web/src/lib/setup/cron.ts
+++ b/plugins/mc-board/web/src/lib/setup/cron.ts
@@ -1,0 +1,154 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+import { readSetupState } from "@/lib/setup-state";
+import { STATE_DIR, findBin } from "./constants";
+
+/**
+ * Persist the user's chosen update time to the mc-update plugin config in openclaw.json.
+ * Converts HH:MM to a cron expression (e.g. "03:00" → "0 3 * * *").
+ */
+export function persistUpdateTime() {
+  const state = readSetupState();
+  const updateTime = (state as Record<string, string>).updateTime;
+  if (!updateTime) return;
+
+  const [hh, mm] = updateTime.split(":").map(Number);
+  const cronExpr = `${mm || 0} ${hh || 3} * * *`;
+
+  const configPath = path.join(STATE_DIR, "openclaw.json");
+  let cfg: Record<string, unknown> = {};
+  try {
+    if (fs.existsSync(configPath)) {
+      cfg = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    }
+  } catch { /* start fresh */ }
+
+  const plugins = (cfg.plugins ?? {}) as Record<string, unknown>;
+  const installs = (plugins.installs ?? {}) as Record<string, Record<string, unknown>>;
+  const mcUpdate = installs["mc-update"] ?? {};
+  const mcUpdateConfig = (mcUpdate.config ?? {}) as Record<string, unknown>;
+  mcUpdateConfig.updateTime = cronExpr;
+  mcUpdate.config = mcUpdateConfig;
+  installs["mc-update"] = mcUpdate;
+  plugins.installs = installs;
+  cfg.plugins = plugins;
+
+  fs.writeFileSync(configPath, JSON.stringify(cfg, null, 2) + "\n", "utf-8");
+}
+
+/**
+ * Register cron jobs with the gateway from jobs.json.
+ * The gateway must be running for this to work.
+ */
+export function registerCronJobs() {
+  const ocBin = findBin("openclaw");
+  if (!ocBin) return;
+
+  const cronFile = path.join(STATE_DIR, "cron", "jobs.json");
+  if (!fs.existsSync(cronFile)) return;
+
+  try {
+    const store = JSON.parse(fs.readFileSync(cronFile, "utf-8"));
+    const jobs = store.jobs || [];
+
+    // Check what's already registered
+    const listResult = spawnSync(ocBin, ["cron", "list", "--json"], {
+      encoding: "utf-8",
+      timeout: 10_000,
+    });
+    let existingNames = new Set<string>();
+    try {
+      const parsed = JSON.parse(listResult.stdout || "[]");
+      // Handle both array and {jobs: []} formats
+      const existing = Array.isArray(parsed) ? parsed : (parsed.jobs || []);
+      existingNames = new Set(existing.map((j: { name?: string }) => j.name));
+    } catch { /* no existing jobs */ }
+
+    for (const job of jobs) {
+      if (existingNames.has(job.name)) continue;
+
+      const cronExpr = job.schedule?.expr || "*/5 * * * *";
+      const args = [
+        "cron", "add",
+        "--name", job.name,
+        "--cron", cronExpr,
+        "--session", job.sessionTarget || "isolated",
+      ];
+
+      if (job.payload?.timeoutSeconds) {
+        args.push("--timeout-seconds", String(job.payload.timeoutSeconds));
+      }
+
+      if (job.payload?.messageFile) {
+        const promptPath = path.join(STATE_DIR, "cron", job.payload.messageFile);
+        if (fs.existsSync(promptPath)) {
+          const prompt = fs.readFileSync(promptPath, "utf-8").trim();
+          args.push("--message", prompt);
+        }
+      }
+
+      const result = spawnSync(ocBin, args, {
+        encoding: "utf-8",
+        timeout: 10_000,
+      });
+      if (result.status === 0) {
+        console.log(`Registered cron: ${job.name}`);
+      } else {
+        console.error(`Failed to register cron ${job.name}:`, result.stderr);
+      }
+    }
+  } catch (e) {
+    console.error("Cron registration failed:", e);
+  }
+}
+
+/**
+ * Register an email watch cron job when email credentials are present.
+ * Checks IMAP every 5 minutes and surfaces relevant messages to the agent.
+ */
+export function ensureEmailWatchCron() {
+  const state = readSetupState();
+  const addr = (state as Record<string, string>).emailAddress;
+  if (!addr) return;
+
+  const ocBin = findBin("openclaw");
+  if (!ocBin) return;
+
+  // Skip if already registered
+  const listResult = spawnSync(ocBin, ["cron", "list", "--json"], {
+    encoding: "utf-8",
+    timeout: 10_000,
+  });
+  try {
+    const parsed = JSON.parse(listResult.stdout || "{}");
+    const jobs = Array.isArray(parsed) ? parsed : (parsed.jobs || []);
+    if (jobs.some((j: { name?: string }) => j.name === "email-watch")) {
+      console.log("email-watch cron already registered — skipping");
+      return;
+    }
+  } catch { /* proceed */ }
+
+  const message = [
+    "REMINDER: Check inbox for new emails.",
+    "Run: mc email list --unread --limit 20",
+    "For each unread message: summarize subject + sender and surface it via mc-memo or alert the main session.",
+    "Mark messages read after processing.",
+    "If nothing new, do nothing.",
+  ].join(" ");
+
+  const result = spawnSync(ocBin, [
+    "cron", "add",
+    "--name", "email-watch",
+    "--every", "5m",
+    "--session", "isolated",
+    "--message", message,
+    "--timeout-seconds", "60",
+  ], { encoding: "utf-8", timeout: 15_000 });
+
+  if (result.status === 0) {
+    console.log("email-watch cron registered");
+  } else {
+    console.error("email-watch cron registration failed:", result.stderr);
+  }
+}

--- a/plugins/mc-board/web/src/lib/setup/email.ts
+++ b/plugins/mc-board/web/src/lib/setup/email.ts
@@ -1,0 +1,57 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { execSync } from "node:child_process";
+import { readSetupState } from "@/lib/setup-state";
+
+/**
+ * Send a welcome email from the agent to itself, confirming email is working.
+ */
+export function sendWelcomeEmail() {
+  const state = readSetupState();
+  const addr = state.emailAddress;
+  const pw = (state as Record<string, string>).appPassword;
+  if (!addr || !pw) return;
+
+  const host = (state as Record<string, string>).emailSmtpHost || "smtp.gmail.com";
+  const port = (state as Record<string, string>).emailSmtpPort || "587";
+  const name = state.assistantName || "MiniClaw";
+
+  const script = `
+import smtplib, sys, ssl
+from email.message import EmailMessage
+addr, pw, host, port, name = sys.argv[1], sys.argv[2], sys.argv[3], int(sys.argv[4]), sys.argv[5]
+msg = EmailMessage()
+msg["Subject"] = f"Hello from {name}"
+msg["From"] = addr
+msg["To"] = addr
+msg.set_content(f"Hi! I'm {name}, your MiniClaw AI assistant. I just finished setting up and I'm ready to work.\\n\\nThis email confirms that my email is configured and working.\\n\\n\\u2014 {name}")
+try:
+    if port == 465:
+        ctx = ssl.create_default_context()
+        with smtplib.SMTP_SSL(host, port, context=ctx) as s:
+            s.login(addr, pw)
+            s.send_message(msg)
+    else:
+        with smtplib.SMTP(host, port) as s:
+            s.starttls()
+            s.login(addr, pw)
+            s.send_message(msg)
+    print("sent")
+except Exception as e:
+    print(f"failed: {e}")
+`;
+
+  try {
+    const tmpScript = path.join(os.tmpdir(), `mc-welcome-email-${process.pid}.py`);
+    fs.writeFileSync(tmpScript, script, "utf-8");
+    const result = execSync(
+      `python3 "${tmpScript}" "${addr}" '${pw.replace(/'/g, "'\\''")}'  "${host}" "${port}" "${name}"`,
+      { encoding: "utf-8", timeout: 30_000 },
+    );
+    fs.unlinkSync(tmpScript);
+    console.log(`Welcome email: ${result.trim()}`);
+  } catch (e) {
+    console.error("Welcome email failed:", e);
+  }
+}

--- a/plugins/mc-board/web/src/lib/setup/gateway.ts
+++ b/plugins/mc-board/web/src/lib/setup/gateway.ts
@@ -1,0 +1,38 @@
+import { spawnSync } from "node:child_process";
+import { findBin } from "./constants";
+
+/**
+ * Install and start the openclaw gateway LaunchAgent.
+ * Returns { ok, error? } — errors are non-fatal (gateway can be started manually).
+ */
+export function ensureGatewayRunning(): { ok: boolean; error?: string } {
+  const ocBin = findBin("openclaw");
+  if (!ocBin) return { ok: false, error: "openclaw not found on PATH" };
+
+  // DO NOT run openclaw doctor --fix here — it rewrites openclaw.json
+  // and wipes the miniclaw plugin paths/entries that install.sh configured.
+
+  // Install the gateway LaunchAgent (creates plist + loads it)
+  const installResult = spawnSync(ocBin, ["gateway", "install", "--force"], {
+    encoding: "utf-8",
+    timeout: 30_000,
+  });
+  if (installResult.status !== 0) {
+    return { ok: false, error: installResult.stderr?.trim() || "gateway install failed" };
+  }
+
+  // Give it a moment to start
+  spawnSync("sleep", ["3"]);
+
+  // Check status
+  const statusResult = spawnSync(ocBin, ["gateway", "status"], {
+    encoding: "utf-8",
+    timeout: 10_000,
+  });
+  const output = (statusResult.stdout || "") + (statusResult.stderr || "");
+  const running = /running|listening|connected|uptime/i.test(output);
+
+  return running
+    ? { ok: true }
+    : { ok: false, error: "gateway installed but not yet running — it may need a few more seconds" };
+}

--- a/plugins/mc-board/web/src/lib/setup/index.ts
+++ b/plugins/mc-board/web/src/lib/setup/index.ts
@@ -1,0 +1,10 @@
+export { STATE_DIR, findBin } from "./constants";
+export { normalizeBotId, configureGateway } from "./telegram";
+export { applyGithubAuth, seedGithubSetupCard, setGithubDefaultRepo } from "./github";
+export { seedBoardDb, seedOnboardingCard } from "./seed-db";
+export { persistUpdateTime, registerCronJobs, ensureEmailWatchCron } from "./cron";
+export { ensureGatewayRunning } from "./gateway";
+export { ensureProjectsFolder, personalizeWorkspace } from "./workspace";
+export { seedRolodexContacts } from "./rolodex";
+export { sendWelcomeEmail } from "./email";
+export { runSmoke } from "./smoke";

--- a/plugins/mc-board/web/src/lib/setup/smoke.ts
+++ b/plugins/mc-board/web/src/lib/setup/smoke.ts
@@ -1,0 +1,18 @@
+import { spawnSync } from "node:child_process";
+import { findBin } from "./constants";
+
+/**
+ * Run mc-smoke and return the output.
+ */
+export function runSmoke(): { output: string; passed: boolean } {
+  const smokeBin = findBin("mc-smoke");
+  if (!smokeBin) return { output: "mc-smoke not found on PATH", passed: false };
+
+  const result = spawnSync(smokeBin, [], {
+    encoding: "utf-8",
+    timeout: 120_000,
+    env: { ...process.env, FORCE_COLOR: "0" }, // no ANSI in JSON response
+  });
+  const output = (result.stdout || "") + (result.stderr || "");
+  return { output, passed: result.status === 0 };
+}

--- a/plugins/mc-board/web/src/lib/setup/telegram.ts
+++ b/plugins/mc-board/web/src/lib/setup/telegram.ts
@@ -1,0 +1,70 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+import { vaultSet } from "@/lib/vault";
+import { STATE_DIR, findBin } from "./constants";
+
+export function normalizeBotId(username: string): string {
+  return username.replace(/^@/, "").trim();
+}
+
+/**
+ * Register the telegram channel with openclaw and store the bot token in vault.
+ * The botId is written under `meta.botId` (NOT top-level) so openclaw config
+ * validation doesn't reject it.
+ */
+export function configureGateway(botId: string, botToken: string, chatId?: string) {
+  const configPath = path.join(STATE_DIR, "openclaw.json");
+  let cfg: Record<string, unknown> = {};
+  try {
+    if (fs.existsSync(configPath)) {
+      cfg = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    }
+  } catch { /* start fresh */ }
+
+  // Remove any botId from config — openclaw doesn't recognize it
+  delete cfg.botId;
+  const meta = (cfg.meta ?? {}) as Record<string, unknown>;
+  delete meta.botId;
+  cfg.meta = meta;
+
+  // Set gateway mode to local
+  const gw = (cfg.gateway ?? {}) as Record<string, unknown>;
+  if (!gw.mode) gw.mode = "local";
+  cfg.gateway = gw;
+
+  // Configure telegram channel directly in openclaw.json
+  const channels = (cfg.channels ?? {}) as Record<string, unknown>;
+  channels.telegram = {
+    enabled: true,
+    botToken: botToken,
+    dmPolicy: "pairing",
+    groupPolicy: "allowlist",
+    groupAllowFrom: chatId ? [chatId] : [],
+    allowFrom: chatId ? [chatId] : [],
+    streaming: "partial",
+  };
+  cfg.channels = channels;
+
+  fs.writeFileSync(configPath, JSON.stringify(cfg, null, 2) + "\n", "utf-8");
+
+  // Also store the bot token in vault as backup
+  const vaultResult = vaultSet("telegram-bot-token", botToken);
+  if (!vaultResult.ok) {
+    console.error("Vault write failed (non-fatal):", vaultResult.error);
+  }
+
+  // Register the telegram channel with openclaw
+  const ocBin = findBin("openclaw");
+  if (ocBin) {
+    const addResult = spawnSync(ocBin, [
+      "channels", "add",
+      "--channel", "telegram",
+      "--token", botToken,
+      "--name", botId,
+    ], { encoding: "utf-8", timeout: 15_000 });
+    if (addResult.status !== 0) {
+      console.error("openclaw channels add failed:", addResult.stderr);
+    }
+  }
+}

--- a/plugins/mc-board/web/src/lib/setup/workspace.ts
+++ b/plugins/mc-board/web/src/lib/setup/workspace.ts
@@ -1,0 +1,117 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { execSync } from "node:child_process";
+import { readSetupState } from "@/lib/setup-state";
+import { STATE_DIR } from "./constants";
+
+/**
+ * Create the canonical projects folder and ~/mc-projects symlink.
+ * Path: ~/.openclaw/miniclaw/USER/projects (safe from updates)
+ * Symlink: ~/mc-projects -> the above path
+ */
+export function ensureProjectsFolder(): { ok: boolean; path: string; symlink: string } {
+  const projectsDir = path.join(STATE_DIR, "miniclaw", "USER", "projects");
+  const symlinkPath = path.join(os.homedir(), "mc-projects");
+
+  fs.mkdirSync(projectsDir, { recursive: true });
+
+  // Create symlink if it doesn't already point to the right place
+  try {
+    const existing = fs.readlinkSync(symlinkPath);
+    if (existing !== projectsDir) {
+      fs.unlinkSync(symlinkPath);
+      fs.symlinkSync(projectsDir, symlinkPath);
+    }
+  } catch {
+    // symlink doesn't exist or isn't a symlink — create it
+    try { fs.unlinkSync(symlinkPath); } catch { /* ignore */ }
+    fs.symlinkSync(projectsDir, symlinkPath);
+  }
+
+  return { ok: true, path: projectsDir, symlink: symlinkPath };
+}
+
+/**
+ * Re-run the workspace personalization from install.sh.
+ * Replaces {{AGENT_NAME}}, {{PRONOUNS}}, etc. in all workspace .md files.
+ */
+export function personalizeWorkspace() {
+  const setupState = readSetupState();
+  const name = setupState.assistantName;
+  if (!name) return;
+
+  const workspace = path.join(STATE_DIR, "workspace");
+  const manifestPath = path.join(STATE_DIR, "miniclaw", "MANIFEST.json");
+
+  if (!fs.existsSync(workspace)) return;
+
+  const script = `
+import json, sys, os
+from datetime import date
+
+workspace = sys.argv[1]
+manifest_path = sys.argv[2]
+state = json.loads(sys.argv[3])
+
+name = state.get("assistantName", "")
+short = state.get("shortName", name)
+pronouns = state.get("pronouns", "they/them")
+blurb = state.get("personaBlurb", "")
+email = state.get("emailAddress", "")
+gh_user = state.get("ghUsername", "")
+
+if not name:
+    sys.exit(0)
+
+pmap = {"she/her": ("she", "her"), "he/him": ("he", "his"), "they/them": ("they", "their")}
+subj, poss = pmap.get(pronouns, ("they", "their"))
+
+version = "0.1.0"
+try:
+    with open(manifest_path) as f:
+        version = json.load(f).get("version", version)
+except Exception:
+    pass
+
+today = date.today().isoformat()
+replacements = {
+    "{{AGENT_NAME}}": name, "{{AGENT_SHORT}}": short,
+    "{{HUMAN_NAME}}": "my human", "{{PRONOUNS}}": pronouns,
+    "{{PRONOUNS_SUBJECT}}": subj, "{{PRONOUNS_POSSESSIVE}}": poss,
+    "{{VERSION}}": version, "{{DATE}}": today,
+    "{{EMAIL}}": email, "{{GITHUB}}": gh_user,
+}
+
+for dirpath, _dirs, files in os.walk(workspace):
+    for fname in files:
+        if not fname.endswith(".md"):
+            continue
+        fpath = os.path.join(dirpath, fname)
+        with open(fpath) as f:
+            content = f.read()
+        changed = False
+        for placeholder, value in replacements.items():
+            if placeholder in content:
+                content = content.replace(placeholder, value)
+                changed = True
+        if changed:
+            with open(fpath, "w") as f:
+                f.write(content)
+
+print(f"Personalized: {name} ({pronouns})")
+`;
+
+  try {
+    const stateJson = JSON.stringify(setupState);
+    const tmpScript = path.join(os.tmpdir(), `miniclaw-personalize-${process.pid}.py`);
+    fs.writeFileSync(tmpScript, script, "utf-8");
+    execSync(`python3 "${tmpScript}" "${workspace}" "${manifestPath}" '${stateJson.replace(/'/g, "'\\''")}'`, {
+      encoding: "utf-8",
+      timeout: 15_000,
+    });
+    fs.unlinkSync(tmpScript);
+  } catch (e) {
+    console.error("Workspace personalization failed:", e);
+  }
+}

--- a/scripts/sync-dev.sh
+++ b/scripts/sync-dev.sh
@@ -40,7 +40,7 @@ echo "  to:   $MINICLAW_DIR"
 [[ "$DRY_RUN" == true ]] && echo "  (dry-run — no changes)"
 echo ""
 
-RSYNC_FLAGS="-av --exclude='node_modules' --exclude='.git' --exclude='*.log'"
+RSYNC_FLAGS="-av --checksum --exclude='node_modules' --exclude='.git' --exclude='*.log' --exclude='.next'"
 [[ "$DRY_RUN" == true ]] && RSYNC_FLAGS="$RSYNC_FLAGS --dry-run"
 
 # ── Plugins ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Restored full chat-history-sidebar.tsx (401 lines) replacing 27-line stub that was direct-written to live dir
- Created missing api-response.ts module (used by setup routes)
- Fixed Tab type in app-shell.tsx to include "office"
- Added drift-detection pre-check to deploy.sh (warns when live dir differs from repo)
- Changed sync-dev.sh to use --checksum instead of timestamp comparison (prevents stale timestamps from skipping newer content)
- Added guard to CLAUDE.md: card workers must never write directly to live plugins dir
- Synced live-only setup/ modules back to repo

## Root cause
An agent card worker wrote a 27-line stub directly to ~/.openclaw/miniclaw/plugins/ (the live dir). Its newer timestamp caused rsync to skip the full 401-line repo version on subsequent syncs.

## Test plan
- [x] chat-history-sidebar.tsx is 401 lines in live dir, matches repo
- [x] Next.js build succeeds (BUILD_ID exists, service responds on port 4220)
- [x] No other .tsx/.ts files out of sync at time of commit
- [x] sync-dev.sh uses --checksum flag
- [x] deploy.sh has drift detection block
- [x] CLAUDE.md has direct-write guard

Card: crd_c6293bc6