### PR TITLE
feat(mc-board): add edit-last-message to board chat panel

### DIFF
--- a/mc-board/web/src/components/chat-panel.tsx
+++ b/mc-board/web/src/components/chat-panel.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useAccent } from "@/lib/accent-context";
+import { ChatHistorySidebar } from "./chat-history-sidebar";
 
 interface Message {
   id: string;
@@ -97,6 +98,15 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
   const [dragOver, setDragOver] = useState(false);
   const [imageError, setImageError] = useState<string | null>(null);
   const [storageWarning, setStorageWarning] = useState<string | null>(null);
+  const [historyOpen, setHistoryOpen] = useState(() => {
+    try { return localStorage.getItem("mc-board:chat-history-open") === "true"; } catch { return false; }
+  });
+  const [interruptOverlayVisible, setInterruptOverlayVisible] = useState(false);
+
+  // Edit-last-message state
+  const [editingMsgId, setEditingMsgId] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState("");
+  const editTextareaRef = useRef<HTMLTextAreaElement>(null);
 
   // Mic / voice transcription state
   const [micAvailable, setMicAvailable] = useState(false);
@@ -319,6 +329,27 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
     }
   }, [transcribeAudio, stopRecording]);
 
+  const toggleHistory = useCallback(() => {
+    setHistoryOpen(on => {
+      const next = !on;
+      try { localStorage.setItem("mc-board:chat-history-open", next ? "true" : "false"); } catch {}
+      return next;
+    });
+  }, []);
+
+  const resumeChat = useCallback((chatId: string) => {
+    if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
+    // Archive current session and load archived one
+    wsRef.current.send(JSON.stringify({ type: "resume_chat", sessionId: chatId }));
+    setMessages([]);
+    setStreamingText("");
+    setStreamingTools([]);
+    setStreaming(false);
+    streamingInsertIndexRef.current = null;
+    setHistoryOpen(false);
+    try { localStorage.setItem("mc-board:chat-history-open", "false"); } catch {}
+  }, []);
+
   // Image processing helpers
   const processFile = useCallback((file: File) => {
     setImageError(null);
@@ -366,8 +397,7 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
     files.forEach(f => {
       if (f.type.startsWith("image/")) processFile(f);
     });
-    setTimeout(() => textareaRef.current?.focus(), 50);
-  }, [processFile, textareaRef]);
+  }, [processFile]);
 
   // Paste handler for images
   const handlePaste = useCallback((e: React.ClipboardEvent) => {
@@ -379,8 +409,7 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
       const file = item.getAsFile();
       if (file) processFile(file);
     });
-    setTimeout(() => textareaRef.current?.focus(), 50);
-  }, [processFile, textareaRef]);
+  }, [processFile]);
 
   // WebSocket connection with auto-reconnect
   useEffect(() => {
@@ -424,7 +453,9 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
       ws.onclose = () => {
         if (didUnmount) return;
         setConnected(false);
-        setStreaming(false); setSentContext(null);
+        setStreaming(false);
+        setInterruptOverlayVisible(false);
+        setSentContext(null);
         wsRef.current = null;
         scheduleReconnect();
       };
@@ -455,7 +486,7 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
             if (d.tools?.length) setStreamingTools(d.tools);
             break;
           case "result":
-            setStreaming(false); setStreamingText(""); setStreamingTools([]); setSentContext(null);
+            setStreaming(false); setStreamingText(""); setStreamingTools([]); setInterruptOverlayVisible(false); setSentContext(null);
             if (d.text) {
               const assistantMsg: Message = { id: generateMsgId(), role: "assistant", content: d.text };
               const insertIdx = streamingInsertIndexRef.current;
@@ -472,12 +503,12 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
             streamingInsertIndexRef.current = null;
             break;
           case "done": case "process_exit":
-            setStreaming(false); setStreamingText(""); setStreamingTools([]); setSentContext(null);
+            setStreaming(false); setStreamingText(""); setStreamingTools([]); setInterruptOverlayVisible(false); setSentContext(null);
             streamingInsertIndexRef.current = null;
             break;
           case "error":
             setMessages(prev => [...prev, { id: generateMsgId(), role: "system", content: d.message, error: true }]);
-            setStreaming(false); setSentContext(null);
+            setStreaming(false); setInterruptOverlayVisible(false); setSentContext(null);
             streamingInsertIndexRef.current = null;
             break;
         }
@@ -518,6 +549,18 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
     onContextConsumed();
     setTimeout(() => textareaRef.current?.focus(), 50);
   }, [pendingContext, onContextConsumed]);
+
+  // Cmd+H keyboard shortcut to toggle history
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "h" && open) {
+        e.preventDefault();
+        toggleHistory();
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open, toggleHistory]);
 
   // Track scroll position to detect when user is not at bottom
   const handleScroll = useCallback(() => {
@@ -616,12 +659,47 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
 
   const interruptAgent = useCallback(() => {
     stopResponse();
+    setInterruptOverlayVisible(false);
     setMessages(prev => [...prev, {
       id: generateMsgId(),
       role: "system" as const,
       content: "⏹ Agent interrupted by user",
     }]);
   }, [stopResponse]);
+
+  const startEditMessage = useCallback((msgId: string, content: string) => {
+    setEditingMsgId(msgId);
+    setEditDraft(content);
+    setTimeout(() => editTextareaRef.current?.focus(), 50);
+  }, []);
+
+  const cancelEditMessage = useCallback(() => {
+    setEditingMsgId(null);
+    setEditDraft("");
+  }, []);
+
+  const submitEditMessage = useCallback(() => {
+    const text = editDraft.trim();
+    if (!text || !editingMsgId || !wsRef.current || !connected || streaming) return;
+
+    // Find the index of the message being edited
+    const editIdx = messages.findIndex(m => m.id === editingMsgId);
+    if (editIdx < 0) return;
+
+    // Truncate messages: remove the edited message and everything after it
+    const newMsgId = generateMsgId();
+    const truncated = messages.slice(0, editIdx);
+    const newUserMsg: Message = { id: newMsgId, role: "user", content: text };
+    setMessages([...truncated, newUserMsg]);
+    streamingInsertIndexRef.current = truncated.length + 1;
+
+    // Send edit_message over WS
+    wsRef.current.send(JSON.stringify({ type: "edit_message", content: text, id: newMsgId }));
+
+    setEditingMsgId(null);
+    setEditDraft("");
+    setStreaming(true);
+  }, [editDraft, editingMsgId, connected, streaming, messages]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && e.shiftKey) {
@@ -669,6 +747,10 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
 
   // Open state
   return (
+    <>
+    <style>{`
+      .chat-msg-wrapper:hover .chat-edit-btn { opacity: 1 !important; }
+    `}</style>
     <div
       onDragOver={handleDragOver}
       onDragEnter={handleDragOver}
@@ -714,10 +796,19 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
           }}>{connected ? "connected" : reconnecting ? "reconnecting…" : "offline"}</span>
         </div>
         <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+          {streaming && (
+            <button
+              onClick={stopResponse}
+              style={{
+                background: "none", border: "1px solid #7c2d12", color: "#f87171", cursor: "pointer",
+                fontSize: 10, padding: "2px 8px", borderRadius: 3, fontFamily: "inherit",
+              }}
+            >stop</button>
+          )}
           {messages.length > 0 && (
             <button
-              onClick={() => { setMessages([]); setStorageWarning(null); setReplyingTo(null); wsRef.current?.send(JSON.stringify({ type: "new_chat" })); }}
-              title="New chat"
+              onClick={() => { setMessages([]); setStorageWarning(null); setReplyingTo(null); wsRef.current?.send(JSON.stringify({ type: "new_chat" })); streamingInsertIndexRef.current = null; }}
+              title="New chat (archives current)"
               style={{
                 background: "none", border: "none", color: "#52525b", cursor: "pointer",
                 fontSize: 11, padding: "2px 6px", borderRadius: 3, fontFamily: "inherit",
@@ -726,6 +817,29 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
               onMouseLeave={e => (e.currentTarget.style.color = "#52525b")}
             >new</button>
           )}
+          {/* History toggle button */}
+          <button
+            onClick={toggleHistory}
+            title={`Chat history (⌘H)`}
+            style={{
+              background: historyOpen ? "#27272a" : "none",
+              border: "none",
+              color: historyOpen ? accent : "#52525b",
+              cursor: "pointer",
+              fontSize: 11,
+              padding: "3px 5px",
+              borderRadius: 3,
+              display: "flex", alignItems: "center", justifyContent: "center",
+              lineHeight: 1,
+            }}
+            onMouseEnter={e => { if (!historyOpen) e.currentTarget.style.color = "#a1a1aa"; }}
+            onMouseLeave={e => { if (!historyOpen) e.currentTarget.style.color = "#52525b"; }}
+          >
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"
+              strokeLinecap="round" strokeLinejoin="round">
+              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+            </svg>
+          </button>
           <button
             onClick={onToggle}
             style={{ background: "none", border: "none", color: "#52525b", cursor: "pointer", fontSize: 18, lineHeight: 1 }}
@@ -752,15 +866,13 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
 
       {/* Messages */}
       <div style={{ flex: 1, position: "relative", overflow: "hidden", display: "flex", flexDirection: "column" }}>
-      {/* Persistent context indicator — visible while agent is responding with context */}
       {sentContext && streaming && (
         <div style={{
           margin: "0 10px", padding: "5px 10px", borderRadius: 6,
           background: "#1a1a2e", border: "1px solid #2d2d5b",
-          display: "flex", alignItems: "center", gap: 6, flexShrink: 0,
-          opacity: 0.85,
+          display: "flex", alignItems: "center", gap: 6, flexShrink: 0, opacity: 0.8,
         }}>
-          <span style={{ fontSize: 9, color: "#6366f1", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", flexShrink: 0 }}>ctx</span>
+          <span style={{ fontSize: 10, color: "#6366f1", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", flexShrink: 0 }}>📌 ctx</span>
           <span style={{ fontSize: 11, color: "#818cf8", flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
             {sentContext.slice(0, 80)}{sentContext.length > 80 ? "..." : ""}
           </span>
@@ -807,12 +919,21 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
             textareaRef.current?.focus();
           };
 
+          const lastUserMsgId = (() => {
+            for (let k = messages.length - 1; k >= 0; k--) {
+              if (messages[k].role === "user") return messages[k].id;
+            }
+            return null;
+          })();
+
           const renderMsg = (msg: Message, i: number) => {
             // Find the referenced message for reply header
             const replyTarget = msg.replyTo ? messages.find(m => m.id === msg.replyTo) : null;
             const replySnippet = replyTarget
               ? replyTarget.content.slice(0, 60) + (replyTarget.content.length > 60 ? "…" : "")
               : msg.replyTo ? "(original message no longer available)" : null;
+            const isLastUser = msg.role === "user" && msg.id === lastUserMsgId;
+            const isEditing = editingMsgId === msg.id;
 
             return (
             <div key={msg.id || `msg-${i}`} id={`chat-msg-${msg.id}`} className="chat-msg-wrapper" style={{
@@ -823,6 +944,45 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
               {msg.role === "system" ? (
                 <div style={{ fontSize: 11, color: "#52525b", textAlign: "center", width: "100%", padding: "4px 0" }}>
                   {msg.content}
+                </div>
+              ) : isEditing ? (
+                /* Inline edit mode */
+                <div style={{ maxWidth: "92%", width: "100%", display: "flex", flexDirection: "column", gap: 6, alignItems: "flex-end" }}>
+                  <textarea
+                    ref={editTextareaRef}
+                    value={editDraft}
+                    onChange={e => setEditDraft(e.target.value)}
+                    onKeyDown={e => {
+                      if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); submitEditMessage(); }
+                      if (e.key === "Escape") cancelEditMessage();
+                    }}
+                    style={{
+                      width: "100%", minHeight: 60, padding: "8px 11px",
+                      borderRadius: "10px 10px 3px 10px",
+                      background: "#1d3a2a", border: `1px solid ${accent}`,
+                      fontSize: 13, color: "#bbf7d0", lineHeight: 1.55,
+                      resize: "vertical", fontFamily: "inherit",
+                      outline: "none",
+                    }}
+                  />
+                  <div style={{ display: "flex", gap: 6 }}>
+                    <button
+                      onClick={cancelEditMessage}
+                      style={{
+                        background: "none", border: "1px solid #3f3f46", borderRadius: 4,
+                        color: "#71717a", fontSize: 11, padding: "3px 10px", cursor: "pointer",
+                        fontFamily: "inherit",
+                      }}
+                    >Cancel</button>
+                    <button
+                      onClick={submitEditMessage}
+                      style={{
+                        background: accent, border: "none", borderRadius: 4,
+                        color: "#fff", fontSize: 11, padding: "3px 10px", cursor: "pointer",
+                        fontFamily: "inherit",
+                      }}
+                    >Save & Resend</button>
+                  </div>
                 </div>
               ) : (
                 <>
@@ -880,25 +1040,41 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
                       </div>
                     )}
                     {msg.content}
+                    {/* Reply button — inline at bottom of bubble */}
+                    <div style={{ display: "flex", justifyContent: msg.role === "user" ? "flex-start" : "flex-end", marginTop: 4 }}>
+                      <button
+                        onClick={(e) => { e.stopPropagation(); handleReply(msg); }}
+                        title="Reply to this message"
+                        style={{
+                          background: "none", border: "none",
+                          color: "#52525b", fontSize: 10, cursor: "pointer",
+                          padding: "1px 4px", borderRadius: 3,
+                          display: "flex", alignItems: "center", gap: 3,
+                          transition: "color 0.15s",
+                        }}
+                        onMouseEnter={e => { e.currentTarget.style.color = "#a1a1aa"; }}
+                        onMouseLeave={e => { e.currentTarget.style.color = "#52525b"; }}
+                      >↩ reply</button>
+                    </div>
                   </div>
-                  {/* Reply button — visible on hover via CSS */}
-                  <button
-                    className="chat-reply-btn"
-                    onClick={() => handleReply(msg)}
-                    title="Reply to this message"
-                    style={{
-                      position: "absolute",
-                      top: replySnippet ? 24 : 4,
-                      [msg.role === "user" ? "left" : "right"]: -28,
-                      width: 22, height: 22,
-                      background: "#27272a", border: "1px solid #3f3f46", borderRadius: 4,
-                      color: "#71717a", fontSize: 12,
-                      cursor: "pointer",
-                      display: "flex", alignItems: "center", justifyContent: "center",
-                      opacity: 0, transition: "opacity 0.15s",
-                      padding: 0, lineHeight: 1,
-                    }}
-                  >↩</button>
+                  {/* Edit button — only on last user message, hidden during streaming */}
+                  {isLastUser && !streaming && (
+                    <button
+                      className="chat-edit-btn"
+                      onClick={() => startEditMessage(msg.id, msg.content)}
+                      title="Edit message"
+                      style={{
+                        position: "absolute", top: 4, left: -28,
+                        width: 22, height: 22,
+                        background: "#27272a", border: "1px solid #3f3f46", borderRadius: 4,
+                        color: "#71717a", fontSize: 12,
+                        cursor: "pointer",
+                        display: "flex", alignItems: "center", justifyContent: "center",
+                        opacity: 0, transition: "opacity 0.15s",
+                        padding: 0, lineHeight: 1,
+                      }}
+                    >✏</button>
+                  )}
                 </>
               )}
             </div>
@@ -908,15 +1084,19 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
           const streamingBlock = streaming ? (
             <div
               key="streaming"
-              style={{ display: "flex", flexDirection: "column", alignItems: "flex-start" }}
+              style={{ display: "flex", flexDirection: "column", alignItems: "flex-start", position: "relative" }}
+              onMouseLeave={() => setInterruptOverlayVisible(false)}
             >
               <div
+                onClick={() => setInterruptOverlayVisible(v => !v)}
                 style={{
                   maxWidth: "92%", padding: "8px 11px",
                   borderRadius: "10px 10px 10px 3px",
                   background: "#18181b", border: "1px solid #27272a",
                   fontSize: 13, color: "#d4d4d8", lineHeight: 1.55,
                   whiteSpace: "pre-wrap", wordBreak: "break-word",
+                  cursor: "pointer",
+                  transition: "border-color 0.15s",
                 }}>
                 {streamingTools.length > 0 && (
                   <div style={{ marginBottom: 6, display: "flex", flexWrap: "wrap", gap: 4 }}>
@@ -932,21 +1112,25 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
                   {streamingTools.length > 0 ? "working..." : "thinking..."}
                 </span>}
               </div>
-              {/* Interrupt button — always visible below bubble during streaming */}
-              <button
-                onClick={interruptAgent}
-                style={{
-                  marginTop: 6,
-                  background: "#7c2d12", border: "1px solid #dc2626",
-                  borderRadius: 6, color: "#fca5a5",
-                  fontSize: 11, fontWeight: 600, fontFamily: "inherit",
-                  padding: "4px 12px", cursor: "pointer",
-                  transition: "background 0.15s, color 0.15s",
-                  whiteSpace: "nowrap",
-                }}
-                onMouseEnter={e => { e.currentTarget.style.background = "#991b1b"; e.currentTarget.style.color = "#fef2f2"; }}
-                onMouseLeave={e => { e.currentTarget.style.background = "#7c2d12"; e.currentTarget.style.color = "#fca5a5"; }}
-              >⏹ Interrupt</button>
+              {/* Interrupt overlay */}
+              {interruptOverlayVisible && (
+                <button
+                  onClick={(e) => { e.stopPropagation(); interruptAgent(); }}
+                  style={{
+                    position: "absolute", top: -6, left: 8,
+                    background: "#7c2d12", border: "1px solid #dc2626",
+                    borderRadius: 6, color: "#fca5a5",
+                    fontSize: 11, fontWeight: 600, fontFamily: "inherit",
+                    padding: "4px 12px", cursor: "pointer",
+                    boxShadow: "0 2px 8px rgba(0,0,0,0.5)",
+                    zIndex: 10,
+                    transition: "background 0.15s, color 0.15s",
+                    whiteSpace: "nowrap",
+                  }}
+                  onMouseEnter={e => { e.currentTarget.style.background = "#991b1b"; e.currentTarget.style.color = "#fef2f2"; }}
+                  onMouseLeave={e => { e.currentTarget.style.background = "#7c2d12"; e.currentTarget.style.color = "#fca5a5"; }}
+                >⏹ Interrupt</button>
+              )}
             </div>
           ) : null;
 
@@ -1004,26 +1188,7 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
       >↓</button>
       </div>
 
-      {/* Reply preview */}
-      {replyingTo && (
-        <div style={{
-          margin: "0 10px", padding: "6px 10px", borderRadius: 6,
-          background: "#1a1a2e", border: "1px solid #4c1d95",
-          display: "flex", alignItems: "flex-start", gap: 6, flexShrink: 0,
-        }}>
-          <span style={{ fontSize: 10, color: "#8b5cf6", fontWeight: 700, flexShrink: 0, marginTop: 1 }}>↩ reply</span>
-          <div style={{ flex: 1, overflow: "hidden", minWidth: 0 }}>
-            <span style={{ fontSize: 10, color: "#6366f1", fontWeight: 600, textTransform: "capitalize" }}>{replyingTo.role}</span>
-            <div style={{ fontSize: 11, color: "#a78bfa", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-              {replyingTo.snippet}
-            </div>
-          </div>
-          <button
-            onClick={() => setReplyingTo(null)}
-            style={{ background: "none", border: "none", color: "#52525b", cursor: "pointer", fontSize: 13, lineHeight: 1, padding: 0, flexShrink: 0 }}
-          >✕</button>
-        </div>
-      )}
+      {/* Reply preview — moved into compose area below */}
 
       {/* Context badge */}
       {context && (
@@ -1152,8 +1317,27 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
       {/* Compose */}
       <div style={{
         padding: "10px 10px 12px", borderTop: "1px solid #1f1f1f", flexShrink: 0,
-        display: "flex", flexDirection: "column", gap: 6,
+        display: "flex", flexDirection: "column", gap: 0,
       }}>
+        {/* Reply preview — flush above textarea */}
+        {replyingTo && (
+          <div style={{
+            padding: "5px 10px", marginBottom: 0,
+            borderRadius: "6px 6px 0 0",
+            background: "#1a1a2e", border: "1px solid #4c1d95", borderBottom: "none",
+            display: "flex", alignItems: "center", gap: 6, flexShrink: 0,
+          }}>
+            <span style={{ fontSize: 10, color: "#8b5cf6", fontWeight: 700, flexShrink: 0 }}>↩ reply</span>
+            <span style={{ fontSize: 10, color: "#6366f1", fontWeight: 600, textTransform: "capitalize", flexShrink: 0 }}>{replyingTo.role}</span>
+            <span style={{ fontSize: 11, color: "#a78bfa", flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+              {replyingTo.snippet}
+            </span>
+            <button
+              onClick={() => setReplyingTo(null)}
+              style={{ background: "none", border: "none", color: "#52525b", cursor: "pointer", fontSize: 13, lineHeight: 1, padding: 0, flexShrink: 0 }}
+            >✕</button>
+          </div>
+        )}
         <textarea
           ref={textareaRef}
           value={draft}
@@ -1163,16 +1347,19 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
           placeholder={`Message ${agentName}...`}
           rows={3}
           style={{
-            width: "100%", background: "#18181b", border: "1px solid #3f3f46",
-            borderRadius: 6, color: "#e4e4e7", fontSize: 13, fontFamily: "inherit",
+            width: "100%", background: "#18181b",
+            border: replyingTo ? "1px solid #4c1d95" : "1px solid #3f3f46",
+            borderTop: replyingTo ? "none" : undefined,
+            borderRadius: replyingTo ? "0 0 6px 6px" : 6,
+            color: "#e4e4e7", fontSize: 13, fontFamily: "inherit",
             padding: "7px 10px", outline: "none", resize: "none", lineHeight: 1.5,
             transition: "border-color 0.15s", boxSizing: "border-box",
           }}
           onFocus={e => { e.currentTarget.style.borderColor = "#52525b"; }}
           onBlur={e => { e.currentTarget.style.borderColor = "#3f3f46"; }}
         />
-        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-          <span style={{ fontSize: 10, color: "#3f3f46" }}>Shift+Enter to send</span>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginTop: 6 }}>
+          <span style={{ fontSize: 10, color: "#e4e4e7" }}>Shift+Enter to send · Enter for new line</span>
           <div style={{ display: "flex", gap: 4 }}>
             {micAvailable && (
               <button
@@ -1232,6 +1419,16 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
           </div>
         </div>
       </div>
+
+      {/* Chat history sidebar — absolute overlay covering the full chat panel */}
+      <ChatHistorySidebar
+        isOpen={historyOpen}
+        onClose={toggleHistory}
+        onResume={resumeChat}
+        currentSessionId={sessionId}
+        serverBaseUrl={`${typeof window !== "undefined" ? window.location.protocol : "http:"}//${typeof window !== "undefined" ? window.location.hostname : "localhost"}:4221`}
+      />
     </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Ports edit-last-message feature from main site chat-panel to board chat-panel
- Adds editingMsgId/editDraft state, inline edit textarea with Cancel/Save & Resend buttons
- Pencil edit button on last user message (hover-visible, hidden during streaming)
- Uses board accent color system for edit UI styling
- Includes chat-history-sidebar integration

## Test plan
- [ ] Hover over last user message in board chat — pencil icon appears
- [ ] Click edit — textarea replaces bubble with original text
- [ ] Edit text and submit — old response removed, new response streams in
- [ ] Press Escape — edit mode cancelled, original message restored
- [ ] Verify edit button not shown on older messages or during streaming