### PR TITLE
fix(mc-memo): add set/get/clear aliases

### DIFF
--- a/plugins/mc-memo/cli/commands.ts
+++ b/plugins/mc-memo/cli/commands.ts
@@ -21,41 +21,74 @@ export function registerMemoCommands(ctx: CliContext, memoDir: string): void {
     .command("mc-memo")
     .description("Short-term working memory — per-card scratchpad for agent runs");
 
-  // ---- mc-memo write ----
+  // ---- mc-memo write / set ----
+  const writeAction = (cardId: string, note: string) => {
+    try {
+      fs.mkdirSync(memoDir, { recursive: true });
+      const filePath = path.join(memoDir, `${cardId}.md`);
+      const timestamp = new Date().toISOString();
+      const line = `${timestamp} ${note}\n`;
+      fs.appendFileSync(filePath, line, { encoding: "utf-8", flag: "a" });
+      console.log(`Memo written to ${filePath}`);
+    } catch (err) {
+      console.error(`Error: ${err instanceof Error ? err.message : err}`);
+      process.exit(1);
+    }
+  };
+
   memo
     .command("write <cardId> <note>")
     .description("Append a timestamped note to the card's memo file")
-    .action((cardId: string, note: string) => {
-      try {
-        fs.mkdirSync(memoDir, { recursive: true });
-        const filePath = path.join(memoDir, `${cardId}.md`);
-        const timestamp = new Date().toISOString();
-        const line = `${timestamp} ${note}\n`;
-        fs.appendFileSync(filePath, line, { encoding: "utf-8", flag: "a" });
-        console.log(`Memo written to ${filePath}`);
-      } catch (err) {
-        console.error(`Error: ${err instanceof Error ? err.message : err}`);
-        process.exit(1);
-      }
-    });
+    .action(writeAction);
 
-  // ---- mc-memo read ----
+  memo
+    .command("set <cardId> <note>")
+    .description("Alias for write — append a timestamped note to the card's memo file")
+    .action(writeAction);
+
+  // ---- mc-memo read / get ----
+  const readAction = (cardId: string) => {
+    try {
+      const filePath = path.join(memoDir, `${cardId}.md`);
+      if (!fs.existsSync(filePath)) {
+        console.log("(no memos yet)");
+        return;
+      }
+      const content = fs.readFileSync(filePath, "utf-8");
+      if (!content.trim()) {
+        console.log("(no memos yet)");
+        return;
+      }
+      console.log(content);
+    } catch (err) {
+      console.error(`Error: ${err instanceof Error ? err.message : err}`);
+      process.exit(1);
+    }
+  };
+
   memo
     .command("read <cardId>")
     .description("Print all memo notes for a card")
+    .action(readAction);
+
+  memo
+    .command("get <cardId>")
+    .description("Alias for read — print all memo notes for a card")
+    .action(readAction);
+
+  // ---- mc-memo clear ----
+  memo
+    .command("clear <cardId>")
+    .description("Remove the memo file for a card")
     .action((cardId: string) => {
       try {
         const filePath = path.join(memoDir, `${cardId}.md`);
         if (!fs.existsSync(filePath)) {
-          console.log("(no memos yet)");
+          console.log("(no memos for this card)");
           return;
         }
-        const content = fs.readFileSync(filePath, "utf-8");
-        if (!content.trim()) {
-          console.log("(no memos yet)");
-          return;
-        }
-        console.log(content);
+        fs.unlinkSync(filePath);
+        console.log(`Memo cleared: ${filePath}`);
       } catch (err) {
         console.error(`Error: ${err instanceof Error ? err.message : err}`);
         process.exit(1);


### PR DESCRIPTION
## Summary
- mc-memo CLI only registered `write`/`read`/`list` commands but TOOLS.md and all callers (card workers, agent-runner, vending_bench_task.py) use `set`/`get`/`clear`/`list`
- Added `set` as alias for `write`, `get` as alias for `read`, and new `clear` command
- Extracted shared action handlers to avoid code duplication
- Backward compatible: `write` and `read` still work

## Test plan
- [x] `openclaw mc-memo set <key> <note>` — exit 0, writes timestamped note
- [x] `openclaw mc-memo get <key>` — exit 0, prints content
- [x] `openclaw mc-memo clear <key>` — exit 0, removes file
- [x] `openclaw mc-memo list` — exit 0, shows all memos
- [x] `openclaw mc-memo write` / `read` backward compat
- [x] Existing 55 memo files unaffected

Fixes crd_4b030303