### PR TITLE
fix: deploy.sh kill stale port + watch-deploy.sh lock file

### DIFF
--- a/plugins/mc-board/web/deploy.sh
+++ b/plugins/mc-board/web/deploy.sh
@@ -15,6 +15,7 @@ UID_NUM=$(id -u)
 
 # Stop the server FIRST — no more serving stale chunks during build
 launchctl bootout "gui/$UID_NUM" "$PLIST" 2>/dev/null || true
+pgrep -f "next-server|next start.*4220" 2>/dev/null | xargs kill -9 2>/dev/null || true
 sleep 1
 
 # Back up the current build in case this one fails
@@ -36,7 +37,11 @@ else
   fi
 fi
 
+# Kill anything still on the port
+pgrep -f "next-server|next start.*4220" 2>/dev/null | xargs kill -9 2>/dev/null || true
+sleep 1
+
 # Start the server (with new or restored build)
-launchctl bootstrap "gui/$UID_NUM" "$PLIST"
+launchctl bootstrap "gui/$UID_NUM" "$PLIST" 2>/dev/null || launchctl load "$PLIST" 2>/dev/null
 
 echo "deployed"

--- a/plugins/mc-board/web/watch-deploy.sh
+++ b/plugins/mc-board/web/watch-deploy.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # watch-deploy.sh — Watch mc-board web source files and auto-deploy on changes
 # Uses fswatch with debounce to detect changes, then runs deploy.sh
+# Uses a lock file to prevent concurrent deploys
 set -euo pipefail
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -9,6 +10,7 @@ cd "$DIR"
 LOG_DIR="$HOME/.openclaw/logs"
 LOG_FILE="$LOG_DIR/board-web-watcher.log"
 DEPLOY_SCRIPT="$DIR/deploy.sh"
+LOCK_FILE="$DIR/.deploy.lock"
 COOLDOWN=3  # seconds between deploys
 
 mkdir -p "$LOG_DIR"
@@ -19,7 +21,7 @@ log() {
 
 log "Watcher starting — monitoring $DIR for changes"
 log "Watching: src/, public/, next.config.ts, package.json"
-log "Ignoring: .next/, node_modules/, .git/"
+log "Ignoring: .next/, .next-backup/, node_modules/, .git/, deploy.sh, watch-deploy.sh"
 log "Debounce latency: ${COOLDOWN}s"
 
 # fswatch flags:
@@ -36,15 +38,26 @@ fswatch \
   --exclude '\.git' \
   --exclude '\.swp$' \
   --exclude '\.DS_Store' \
+  --exclude 'deploy\.sh' \
+  --exclude 'watch-deploy\.sh' \
+  --exclude '\.deploy\.lock' \
   "$DIR/src" \
   "$DIR/public" \
   "$DIR/next.config.ts" \
   "$DIR/package.json" \
   | while read -r event; do
+    # Skip if a deploy is already running
+    if [ -f "$LOCK_FILE" ]; then
+      log "Change detected — deploy already running, skipping"
+      continue
+    fi
+
     log "Change detected — starting deploy..."
+    touch "$LOCK_FILE"
     if bash "$DEPLOY_SCRIPT" >> "$LOG_FILE" 2>&1; then
       log "Deploy completed successfully"
     else
       log "Deploy FAILED (exit code $?)"
     fi
+    rm -f "$LOCK_FILE"
   done


### PR DESCRIPTION
## Summary
- deploy.sh: kills stale next-server processes before restart to prevent EADDRINUSE
- watch-deploy.sh: lock file prevents concurrent deploys, fswatch excludes deploy scripts

Without these fixes, every deploy leaves a ghost process on :4220 and the new server can't start. The watcher triggers concurrent deploys that corrupt .next.

## Test plan
- [ ] Run `bash deploy.sh` — verify no EADDRINUSE
- [ ] Run `bash deploy.sh` twice in parallel — verify lock prevents second run
- [ ] Verify board loads at :4220 after deploy