### PR TITLE
fix(mc-board): correct verify-ship default paths

### DIFF
--- a/plugins/mc-board/cli/commands.ts
+++ b/plugins/mc-board/cli/commands.ts
@@ -1019,8 +1019,8 @@ Useful for auditing which agent processed which ticket and when.
   brain
     .command("verify-ship <cardId>")
     .description("Verify a shipped/reviewed card: commit on main, code in live plugins, PR merged")
-    .option("--repo <path>", "Path to miniclaw-os repo", path.join(ctx.stateDir, "miniclaw", "USER", "projects", "miniclaw-os"))
-    .option("--plugins <path>", "Path to live plugins dir", path.join(ctx.stateDir, "miniclaw", "plugins"))
+    .option("--repo <path>", "Path to miniclaw-os repo", path.join(os.homedir(), ".openclaw", "miniclaw", "USER", "projects", "miniclaw-os"))
+    .option("--plugins <path>", "Path to live plugins dir", path.join(os.homedir(), ".openclaw", "miniclaw", "plugins"))
     .action((cardId: string, opts: { repo: string; plugins: string }) => {
       const card = store.findById(cardId);
       if (!card) {


### PR DESCRIPTION
## Summary
- Fix verify-ship CLI default paths: `ctx.stateDir` is the brain dir, not the OpenClaw root
- Repo default: `~/.openclaw/miniclaw/USER/projects/miniclaw-os` (was incorrectly `stateDir/miniclaw/USER/...`)
- Plugins default: `~/.openclaw/miniclaw/plugins` (was incorrectly `stateDir/miniclaw/plugins`)

Follow-up fix for #481 (crd_dc067485)

## Test plan
- [x] 59/59 tests pass
- [x] verify-ship no longer crashes with ENOENT