### PR TITLE
test(mc-kb): embedder, search, store test coverage

### DIFF
--- a/mc-kb/src/embedder.test.ts
+++ b/mc-kb/src/embedder.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Embedder } from "./embedder.js";
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "mc-kb-embedder-test-"));
+}
+
+describe("Embedder", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // ── Missing model path ────────────────────────────────────────────
+
+  describe("missing model path", () => {
+    it("load() completes without throwing when model path does not exist", async () => {
+      const embedder = new Embedder(join(dir, "nonexistent.gguf"));
+      await expect(embedder.load()).resolves.not.toThrow();
+    });
+
+    it("embed() returns null when model path does not exist", async () => {
+      const embedder = new Embedder(join(dir, "nonexistent.gguf"));
+      const result = await embedder.embed("test text");
+      expect(result).toBeNull();
+    });
+
+    it("isReady() returns false when model is unavailable", async () => {
+      const embedder = new Embedder(join(dir, "nonexistent.gguf"));
+      await embedder.load();
+      expect(embedder.isReady()).toBe(false);
+    });
+  });
+
+  // ── Corrupt GGUF magic bytes ──────────────────────────────────────
+
+  describe("corrupt model file (bad magic bytes)", () => {
+    it("load() completes without throwing for corrupt GGUF", async () => {
+      const corruptPath = join(dir, "corrupt.gguf");
+      writeFileSync(corruptPath, "NOT_GGUF_CONTENT_HERE");
+      const embedder = new Embedder(corruptPath);
+      await expect(embedder.load()).resolves.not.toThrow();
+    });
+
+    it("embed() returns null for corrupt GGUF file", async () => {
+      const corruptPath = join(dir, "corrupt.gguf");
+      writeFileSync(corruptPath, "NOT_GGUF_CONTENT_HERE");
+      const embedder = new Embedder(corruptPath);
+      const result = await embedder.embed("test text");
+      expect(result).toBeNull();
+    });
+
+    it("isReady() returns false for corrupt GGUF file", async () => {
+      const corruptPath = join(dir, "corrupt.gguf");
+      writeFileSync(corruptPath, "BAAD_MAGIC_BYTES_CONTENT");
+      const embedder = new Embedder(corruptPath);
+      await embedder.load();
+      expect(embedder.isReady()).toBe(false);
+    });
+  });
+
+  // ── Zero-byte model file ──────────────────────────────────────────
+
+  describe("zero-byte model file", () => {
+    it("load() completes without throwing for empty file", async () => {
+      const emptyPath = join(dir, "empty.gguf");
+      writeFileSync(emptyPath, "");
+      const embedder = new Embedder(emptyPath);
+      await expect(embedder.load()).resolves.not.toThrow();
+    });
+
+    it("embed() returns null for empty file", async () => {
+      const emptyPath = join(dir, "empty.gguf");
+      writeFileSync(emptyPath, "");
+      const embedder = new Embedder(emptyPath);
+      const result = await embedder.embed("test text");
+      expect(result).toBeNull();
+    });
+
+    it("isReady() returns false for empty file", async () => {
+      const emptyPath = join(dir, "empty.gguf");
+      writeFileSync(emptyPath, "");
+      const embedder = new Embedder(emptyPath);
+      await embedder.load();
+      expect(embedder.isReady()).toBe(false);
+    });
+  });
+
+  // ── Valid GGUF magic but truncated ────────────────────────────────
+
+  describe("valid GGUF magic but truncated file", () => {
+    it("load() completes without throwing for truncated GGUF", async () => {
+      const truncatedPath = join(dir, "truncated.gguf");
+      // Write valid GGUF magic bytes followed by garbage
+      const buf = Buffer.alloc(16);
+      buf.write("GGUF", 0, 4, "ascii");
+      writeFileSync(truncatedPath, buf);
+      const embedder = new Embedder(truncatedPath);
+      // load() will pass magic check but fail on node-llama-cpp import/load
+      // It should handle this gracefully (catch block in _doLoad)
+      await expect(embedder.load()).resolves.not.toThrow();
+    });
+
+    it("embed() returns null for truncated GGUF", async () => {
+      const truncatedPath = join(dir, "truncated.gguf");
+      const buf = Buffer.alloc(16);
+      buf.write("GGUF", 0, 4, "ascii");
+      writeFileSync(truncatedPath, buf);
+      const embedder = new Embedder(truncatedPath);
+      const result = await embedder.embed("test text");
+      expect(result).toBeNull();
+    });
+  });
+
+  // ── load() idempotency ────────────────────────────────────────────
+
+  describe("load() idempotency", () => {
+    it("second load() call returns immediately without re-attempting", async () => {
+      const embedder = new Embedder(join(dir, "nonexistent.gguf"));
+
+      // First load — sets loadAttempted
+      await embedder.load();
+      expect(embedder.isReady()).toBe(false);
+
+      // Second load — should be a no-op (loadAttempted is true)
+      await embedder.load();
+      expect(embedder.isReady()).toBe(false);
+    });
+
+    it("concurrent load() calls return the same promise", async () => {
+      const corruptPath = join(dir, "corrupt.gguf");
+      writeFileSync(corruptPath, "NOT_GGUF");
+      const embedder = new Embedder(corruptPath);
+
+      // Fire two loads concurrently — they should resolve the same promise
+      const [r1, r2] = await Promise.all([embedder.load(), embedder.load()]);
+      expect(r1).toBeUndefined();
+      expect(r2).toBeUndefined();
+      expect(embedder.isReady()).toBe(false);
+    });
+  });
+
+  // ── getDims ────────────────────────────────────────────────────────
+
+  it("getDims() returns 768", () => {
+    const embedder = new Embedder(join(dir, "any.gguf"));
+    expect(embedder.getDims()).toBe(768);
+  });
+});

--- a/mc-kb/src/search.test.ts
+++ b/mc-kb/src/search.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -18,6 +18,46 @@ class NullEmbedder implements IEmbedder {
   async load(): Promise<void> {}
   async embed(_text: string): Promise<Float32Array | null> {
     return null;
+  }
+}
+
+/**
+ * Mock embedder that returns deterministic Float32Array vectors based on
+ * a simple hash of the input text. This exercises the vector search code path
+ * without requiring a real embedding model.
+ */
+class VecMockEmbedder implements IEmbedder {
+  private dims = 768;
+  isReady(): boolean {
+    return true;
+  }
+  getDims(): number {
+    return this.dims;
+  }
+  async load(): Promise<void> {}
+  async embed(text: string): Promise<Float32Array | null> {
+    return VecMockEmbedder.deterministicVector(text, this.dims);
+  }
+
+  /** Generate a deterministic unit vector from text via simple hash */
+  static deterministicVector(text: string, dims = 768): Float32Array {
+    const vec = new Float32Array(dims);
+    // Simple hash-based seeding: each char shifts the seed
+    let seed = 0;
+    for (let i = 0; i < text.length; i++) {
+      seed = ((seed << 5) - seed + text.charCodeAt(i)) | 0;
+    }
+    // Fill vector with pseudo-random values derived from the seed
+    for (let i = 0; i < dims; i++) {
+      seed = ((seed * 1103515245 + 12345) & 0x7fffffff);
+      vec[i] = (seed / 0x7fffffff) * 2 - 1; // range [-1, 1]
+    }
+    // Normalize to unit vector (cosine similarity requires it)
+    let norm = 0;
+    for (let i = 0; i < dims; i++) norm += vec[i] * vec[i];
+    norm = Math.sqrt(norm);
+    if (norm > 0) for (let i = 0; i < dims; i++) vec[i] /= norm;
+    return vec;
   }
 }
 
@@ -200,5 +240,310 @@ describe("hybridSearch", () => {
     for (const r of results) {
       expect(r.entry.type).toBe("lesson");
     }
+  });
+
+  // ── Vector search path (mocked vec) ────────────────────────────────
+
+  describe("with vector search enabled (mocked)", () => {
+    let vecEmbedder: VecMockEmbedder;
+    let vecDir: string;
+    let vecStore: KBStore;
+
+    // Track entry IDs for vec result mocking
+    let dockerGuideId: string;
+    let postgresId: string;
+    let dockerErrorId: string;
+    let ciPipelineId: string;
+
+    beforeEach(() => {
+      vecDir = makeTmpDir();
+      vecStore = new KBStore(vecDir);
+      vecEmbedder = new VecMockEmbedder();
+
+      // Seed same data, capturing IDs
+      dockerGuideId = vecStore.add(
+        sampleEntry({
+          type: "guide",
+          title: "Docker Setup Guide",
+          content: "Install Docker on macOS using Homebrew. Configure daemon settings.",
+          tags: ["docker", "setup"],
+        }),
+      ).id;
+      postgresId = vecStore.add(
+        sampleEntry({
+          type: "fact",
+          title: "PostgreSQL Tuning",
+          content: "Optimize PostgreSQL with shared_buffers and work_mem settings.",
+          tags: ["postgres", "performance"],
+        }),
+      ).id;
+      dockerErrorId = vecStore.add(
+        sampleEntry({
+          type: "error",
+          title: "Docker Build Failure",
+          content: "Docker build fails when COPY references files outside context.",
+          tags: ["docker", "error"],
+        }),
+      ).id;
+      ciPipelineId = vecStore.add(
+        sampleEntry({
+          type: "workflow",
+          title: "CI Pipeline Setup",
+          content: "Configure GitHub Actions with Docker containers for testing.",
+          tags: ["ci", "docker"],
+        }),
+      ).id;
+
+      // Mock vec availability: stub isVecLoaded → true and vecSearch → results
+      vi.spyOn(vecStore, "isVecLoaded").mockReturnValue(true);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      vecStore.close();
+      rmSync(vecDir, { recursive: true, force: true });
+    });
+
+    it("returns results with vecDistance when embedder provides vectors", async () => {
+      // Mock vecSearch to return entries with distances
+      vi.spyOn(vecStore, "vecSearch").mockReturnValue([
+        { id: dockerGuideId, distance: 0.2 },
+        { id: dockerErrorId, distance: 0.4 },
+        { id: ciPipelineId, distance: 0.6 },
+      ]);
+
+      const results = await hybridSearch(vecStore, vecEmbedder, "Docker");
+      expect(results.length).toBeGreaterThan(0);
+
+      // At least one result should have vecDistance set
+      const withVecDist = results.filter((r) => r.vecDistance !== undefined);
+      expect(withVecDist.length).toBeGreaterThan(0);
+
+      for (const r of withVecDist) {
+        expect(typeof r.vecDistance).toBe("number");
+        expect(r.vecDistance).toBeGreaterThanOrEqual(0);
+      }
+    });
+
+    it("RRF merge produces higher scores for dual-signal matches", async () => {
+      // Docker Guide matches both FTS ("Docker") and vec (low distance)
+      // PostgreSQL only matches vec (not FTS for "Docker" query)
+      vi.spyOn(vecStore, "vecSearch").mockReturnValue([
+        { id: dockerGuideId, distance: 0.1 },   // matches both FTS + vec
+        { id: postgresId, distance: 0.3 },       // vec-only (FTS won't match "Docker")
+      ]);
+
+      const results = await hybridSearch(vecStore, vecEmbedder, "Docker");
+
+      // Find the Docker Guide and PostgreSQL entries
+      const dockerResult = results.find((r) => r.entry.id === dockerGuideId);
+      const pgResult = results.find((r) => r.entry.id === postgresId);
+
+      expect(dockerResult).toBeDefined();
+      // Docker Guide has both FTS rank + vec rank → higher RRF score
+      // PostgreSQL has only vec rank → lower RRF score
+      if (dockerResult && pgResult) {
+        expect(dockerResult.score).toBeGreaterThan(pgResult.score);
+      }
+    });
+
+    it("vecThreshold filters out distant vectors", async () => {
+      // Return vec results with varying distances
+      vi.spyOn(vecStore, "vecSearch").mockReturnValue([
+        { id: dockerGuideId, distance: 0.3 },
+        { id: postgresId, distance: 1.8 },       // above threshold
+        { id: dockerErrorId, distance: 1.9 },     // above threshold
+      ]);
+
+      // Use a strict threshold that excludes distant entries
+      const results = await hybridSearch(vecStore, vecEmbedder, "Docker", {
+        vecThreshold: 0.5,
+      });
+
+      // PostgreSQL (distance 1.8) should NOT have a vecDistance because it was filtered
+      const pgResult = results.find((r) => r.entry.id === postgresId);
+      // If it appears at all, it's from FTS only — vecDistance should be undefined
+      // (PostgreSQL won't match FTS for "Docker" query, so it shouldn't appear)
+      if (pgResult) {
+        expect(pgResult.vecDistance).toBeUndefined();
+      }
+
+      // Docker Guide (distance 0.3) should have vecDistance
+      const dockerResult = results.find((r) => r.entry.id === dockerGuideId);
+      if (dockerResult) {
+        expect(dockerResult.vecDistance).toBe(0.3);
+      }
+    });
+
+    it("vec-only results appear when FTS misses", async () => {
+      // Add an entry with non-FTS-tokenizable content
+      const weirdId = vecStore.add(
+        sampleEntry({
+          type: "fact",
+          title: "αβγ δεζ ηθι",
+          content: "κλμ νξο πρσ τυφ χψω",
+          tags: ["greek"],
+        }),
+      ).id;
+
+      // FTS won't match this query, but vec will
+      vi.spyOn(vecStore, "vecSearch").mockReturnValue([
+        { id: weirdId, distance: 0.15 },
+      ]);
+
+      const results = await hybridSearch(vecStore, vecEmbedder, "αβγ δεζ");
+      // The entry should appear via vec path even though FTS can't tokenize Greek
+      const found = results.find((r) => r.entry.id === weirdId);
+      expect(found).toBeDefined();
+      expect(found!.vecDistance).toBe(0.15);
+    });
+  });
+
+  // ── Non-matching query returns empty ────────────────────────────────
+
+  it("returns empty array for non-matching query (not error)", async () => {
+    const results = await hybridSearch(store, embedder, "xyznonexistent12345qqq");
+    expect(Array.isArray(results)).toBe(true);
+    expect(results.length).toBe(0);
+  });
+
+  // ── Add/search round-trip ─────────────────────────────────────────
+
+  it("add then search round-trip: finds newly added entry by unique content", async () => {
+    // Add an entry with a completely unique title and content
+    const uniqueTitle = "ZzUniqueRoundTrip98765";
+    const uniqueContent = "This entry has the unique marker AbCdEfGhIjKl for round-trip verification.";
+    store.add(
+      sampleEntry({
+        type: "fact",
+        title: uniqueTitle,
+        content: uniqueContent,
+        tags: ["roundtrip"],
+      }),
+    );
+
+    // Search for the unique title
+    const results = await hybridSearch(store, embedder, uniqueTitle);
+    expect(results.length).toBeGreaterThan(0);
+
+    const found = results.find((r) => r.entry.title === uniqueTitle);
+    expect(found).toBeDefined();
+    expect(found!.entry.content).toBe(uniqueContent);
+    expect(found!.entry.type).toBe("fact");
+    expect(found!.entry.tags).toContain("roundtrip");
+  });
+
+  // ── Edge cases ──────────────────────────────────────────────────────
+
+  describe("edge cases", () => {
+    it("handles unicode queries", async () => {
+      store.add(
+        sampleEntry({
+          title: "日本語ガイド",
+          content: "Dockerの使い方についての日本語ドキュメント。",
+          tags: ["japanese"],
+        }),
+      );
+
+      // Should not throw, may or may not find results depending on tokenizer
+      const results = await hybridSearch(store, embedder, "日本語");
+      // Substring fallback should find it
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].entry.title).toBe("日本語ガイド");
+    });
+
+    it("handles queries with special FTS characters", async () => {
+      // Characters like quotes, parens, brackets are stripped by ftsSearch
+      const results = await hybridSearch(store, embedder, '"Docker" (setup) [guide]');
+      // Should not throw and should find Docker results
+      expect(results.length).toBeGreaterThan(0);
+    });
+
+    it("handles very long content entries", async () => {
+      const longContent = "Docker ".repeat(5000) + "container orchestration is powerful.";
+      store.add(
+        sampleEntry({
+          title: "Long Content Entry",
+          content: longContent,
+          tags: ["long"],
+        }),
+      );
+
+      const results = await hybridSearch(store, embedder, "Docker");
+      expect(results.length).toBeGreaterThan(0);
+      // The long entry should be findable
+      const longResult = results.find((r) => r.entry.title === "Long Content Entry");
+      expect(longResult).toBeDefined();
+    });
+
+    it("handles queries with only special characters gracefully", async () => {
+      // All special chars get stripped, leaving empty tokens → falls back to substring
+      const results = await hybridSearch(store, embedder, "!@#$%^&*()");
+      // Should not throw — returns fallback results or empty
+      expect(Array.isArray(results)).toBe(true);
+    });
+
+    it("handles emoji in content and queries", async () => {
+      store.add(
+        sampleEntry({
+          title: "Emoji Guide 🚀",
+          content: "Deploy with confidence 🐳 using Docker containers.",
+          tags: ["emoji"],
+        }),
+      );
+
+      const results = await hybridSearch(store, embedder, "🐳");
+      // Substring fallback should find it
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].entry.content).toContain("🐳");
+    });
+  });
+
+  // ── Conditional vec integration (real sqlite-vec) ───────────────────
+
+  describe("real sqlite-vec integration", () => {
+    it.skipIf(!(() => {
+      try {
+        const d = makeTmpDir();
+        const s = new KBStore(d);
+        const loaded = s.isVecLoaded();
+        s.close();
+        rmSync(d, { recursive: true, force: true });
+        return loaded;
+      } catch { return false; }
+    })())("end-to-end vec search with real sqlite-vec", async () => {
+      // This test only runs when sqlite-vec is actually available
+      const d = makeTmpDir();
+      const s = new KBStore(d);
+      const vecEmb = new VecMockEmbedder();
+
+      try {
+        const vec1 = await vecEmb.embed("Docker setup");
+        const vec2 = await vecEmb.embed("PostgreSQL tuning");
+
+        s.add(
+          sampleEntry({
+            title: "Docker Real Vec",
+            content: "Docker setup with real vector indexing.",
+            tags: ["docker"],
+          }),
+          vec1!,
+        );
+        s.add(
+          sampleEntry({
+            title: "PG Real Vec",
+            content: "PostgreSQL tuning with real vector indexing.",
+            tags: ["postgres"],
+          }),
+          vec2!,
+        );
+
+        const results = await hybridSearch(s, vecEmb, "Docker setup");
+        expect(results.length).toBeGreaterThan(0);
+      } finally {
+        s.close();
+        rmSync(d, { recursive: true, force: true });
+      }
+    });
   });
 });

--- a/mc-kb/src/store.test.ts
+++ b/mc-kb/src/store.test.ts
@@ -226,6 +226,12 @@ describe("KBStore", () => {
       expect(results.length).toBeGreaterThan(0);
     });
 
+    it("returns empty array (not error) for query matching no entries", () => {
+      const results = store.ftsSearch("xyznonexistent12345qqq");
+      expect(Array.isArray(results)).toBe(true);
+      expect(results.length).toBe(0);
+    });
+
     it("respects limit parameter", () => {
       const results = store.ftsSearch("Docker", 1);
       expect(results.length).toBeLessThanOrEqual(1);
@@ -236,6 +242,21 @@ describe("KBStore", () => {
       if (results.length >= 2) {
         // Results should be ordered by rank ascending (more negative = better match)
         expect(results[0].rank).toBeLessThanOrEqual(results[1].rank);
+      }
+    });
+  });
+
+  // ── Vec search (graceful when not loaded) ──────────────────────────
+
+  describe("vecSearch", () => {
+    it("returns empty array when vecLoaded is false", () => {
+      // By default, sqlite-vec may not be available in test env
+      // vecSearch should return empty array, not throw
+      if (!store.isVecLoaded()) {
+        const dummyVec = new Float32Array(768);
+        const results = store.vecSearch(dummyVec, 10);
+        expect(Array.isArray(results)).toBe(true);
+        expect(results.length).toBe(0);
       }
     });
   });


### PR DESCRIPTION
## Summary
- Add `src/embedder.test.ts` (14 tests) covering missing model path, corrupt GGUF magic bytes, zero-byte/truncated model files, load() idempotency, and getDims()
- Extend `search.test.ts` with non-matching query returns empty array, add/search round-trip, vector search path with mocked embedder
- Extend `store.test.ts` with explicit FTS no-match and vecSearch graceful degradation tests

All 63 tests pass. No real model download required.

Card: crd_50a61e43

## Test plan
- [x] All 63 tests pass via `npx vitest run`
- [x] No real model download needed — uses tmp dirs and mock embedders
- [x] Existing tests unaffected