### PR TITLE
test(mc-memory): catch truncation and routing failures

### DIFF
--- a/plugins/mc-memory/smoke.test.ts
+++ b/plugins/mc-memory/smoke.test.ts
@@ -12,7 +12,7 @@ import * as os from "node:os";
 import { route } from "./src/router.js";
 import { episodicQualityGate } from "./src/writer.js";
 import { write } from "./src/writer.js";
-import { promote } from "./src/promote.js";
+import { promote, annotateMemo } from "./src/promote.js";
 import type { KBStore, Embedder, KBEntry, KBEntryCreate, SearchResult } from "./src/types.js";
 
 /* ── Shared mocks ──────────────────────────────────────────────────────── */
@@ -599,6 +599,24 @@ describe("mc-memory promote()", () => {
     expect(entry!.tags).toContain("from-episodic");
   });
 
+  it("promotes episodic content with from-episodic tag", async () => {
+    const store = makeMockStore();
+    const result = await promote(store, mockEmbedder, {
+      content: "How to reset the development database: run npm run db:reset then seed with npm run db:seed. This guide is for new developers joining the team.",
+      source_type: "episodic",
+      source_ref: "2024-01-15",
+    });
+
+    expect(result.kb_id).toBeDefined();
+    expect(result.source_type).toBe("episodic");
+    expect(result.source_ref).toBe("2024-01-15");
+
+    const entry = store.entries.find((e) => e.id === result.kb_id);
+    expect(entry).toBeDefined();
+    expect(entry!.tags).toContain("promoted");
+    expect(entry!.tags).toContain("from-episodic");
+  });
+
   it("respects title and type overrides", async () => {
     const store = makeMockStore();
     const result = await promote(store, mockEmbedder, {
@@ -619,5 +637,518 @@ describe("mc-memory promote()", () => {
     expect(entry!.type).toBe("workflow");
     expect(entry!.tags).toContain("custom-tag");
     expect(entry!.tags).toContain("promoted");
+  });
+});
+
+/* ── KB write via write() ──────────────────────────────────────────────── */
+
+describe("mc-memory writeKb path (write with KB signals or forceTarget)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mc-memory-kb-write-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("routes to KB when content has strong KB signals", async () => {
+    const memoDir = path.join(tmpDir, "memos");
+    const episodicDir = path.join(tmpDir, "episodic");
+    const store = makeMockStore();
+
+    const content = "Error: ENOSPC when running webpack. Fix: increase inotify watchers via sysctl. Solution is permanent. Always apply this fix on new machines.";
+    const result = await write(store, mockEmbedder, memoDir, episodicDir, content, {});
+
+    expect(result.stored_in).toBe("kb");
+    expect(result.id).toBeDefined();
+
+    // Verify store.add() was called with correct content
+    expect(store.entries.length).toBe(1);
+    expect(store.entries[0].content).toBe(content);
+    expect(store.entries[0].tags).toContain("auto-routed");
+  });
+
+  it("routes to KB with forceTarget override", async () => {
+    const memoDir = path.join(tmpDir, "memos");
+    const episodicDir = path.join(tmpDir, "episodic");
+    const store = makeMockStore();
+
+    const content = "Simple note that would normally go to episodic but we force it to KB for archival purposes and long-term knowledge retention.";
+    const result = await write(store, mockEmbedder, memoDir, episodicDir, content, {
+      forceTarget: "kb",
+    });
+
+    expect(result.stored_in).toBe("kb");
+    expect(result.id).toBeDefined();
+    expect(store.entries.length).toBe(1);
+    expect(store.entries[0].content).toBe(content);
+  });
+
+  it("KB write includes card tag when cardId is provided", async () => {
+    const memoDir = path.join(tmpDir, "memos");
+    const episodicDir = path.join(tmpDir, "episodic");
+    const store = makeMockStore();
+
+    const content = "Error: EACCES permission denied on /var/log. Fix: chmod the directory. Solution verified and permanent.";
+    const result = await write(store, mockEmbedder, memoDir, episodicDir, content, {
+      forceTarget: "kb",
+      cardId: "crd_kb_card_tag",
+    });
+
+    expect(result.stored_in).toBe("kb");
+    expect(store.entries[0].tags).toContain("card:crd_kb_card_tag");
+    expect(store.entries[0].tags).toContain("auto-routed");
+  });
+
+  it("KB write generates title from first line of content", async () => {
+    const memoDir = path.join(tmpDir, "memos");
+    const episodicDir = path.join(tmpDir, "episodic");
+    const store = makeMockStore();
+
+    const content = "How to configure ESLint for TypeScript projects. Always install @typescript-eslint/parser and use the recommended config.";
+    const result = await write(store, mockEmbedder, memoDir, episodicDir, content, {
+      forceTarget: "kb",
+    });
+
+    expect(result.stored_in).toBe("kb");
+    expect(store.entries[0].title).toBeTruthy();
+    expect(store.entries[0].title.length).toBeGreaterThan(0);
+    expect(store.entries[0].title.length).toBeLessThanOrEqual(80);
+  });
+});
+
+/* ── Recall on empty/non-existent dirs ─────────────────────────────────── */
+
+describe("mc-memory recall on empty dirs", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mc-memory-empty-recall-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty array when memo and episodic dirs do not exist", async () => {
+    const memoDir = path.join(tmpDir, "nonexistent-memos");
+    const episodicDir = path.join(tmpDir, "nonexistent-episodic");
+    const store = makeMockStore();
+
+    // Dirs do NOT exist — not even created
+    expect(fs.existsSync(memoDir)).toBe(false);
+    expect(fs.existsSync(episodicDir)).toBe(false);
+
+    const { recall } = await import("./src/recall.js");
+    const mockHybridSearch = async () => [] as SearchResult[];
+
+    const results = await recall(
+      store,
+      mockEmbedder,
+      mockHybridSearch,
+      memoDir,
+      episodicDir,
+      "anything at all",
+      { daysBack: 7 },
+    );
+
+    expect(Array.isArray(results)).toBe(true);
+    expect(results.length).toBe(0);
+  });
+
+  it("returns empty array when dirs exist but are empty", async () => {
+    const memoDir = path.join(tmpDir, "empty-memos");
+    const episodicDir = path.join(tmpDir, "empty-episodic");
+    fs.mkdirSync(memoDir, { recursive: true });
+    fs.mkdirSync(episodicDir, { recursive: true });
+
+    const store = makeMockStore();
+    const { recall } = await import("./src/recall.js");
+    const mockHybridSearch = async () => [] as SearchResult[];
+
+    const results = await recall(
+      store,
+      mockEmbedder,
+      mockHybridSearch,
+      memoDir,
+      episodicDir,
+      "search for anything",
+      { daysBack: 7 },
+    );
+
+    expect(Array.isArray(results)).toBe(true);
+    expect(results.length).toBe(0);
+  });
+});
+
+/* ── annotateMemo tests ────────────────────────────────────────────────── */
+
+describe("mc-memory annotateMemo()", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mc-memory-annotate-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("appends promotion marker to the matching line in memo file", () => {
+    const memoDir = path.join(tmpDir, "memos");
+    fs.mkdirSync(memoDir, { recursive: true });
+
+    const originalLine = "2024-01-15T10:00:00.000Z tried Redis cache, got timeout on port 6379";
+    const memoContent = `${originalLine}\n2024-01-15T11:00:00.000Z another unrelated note\n`;
+    fs.writeFileSync(path.join(memoDir, "crd_annotate1.md"), memoContent, "utf-8");
+
+    annotateMemo(memoDir, "crd_annotate1", originalLine, "kb-42");
+
+    const updated = fs.readFileSync(path.join(memoDir, "crd_annotate1.md"), "utf-8");
+    expect(updated).toContain("→ promoted to kb-42");
+    expect(updated).toContain(originalLine);
+    // The other line should be unchanged
+    expect(updated).toContain("another unrelated note");
+  });
+
+  it("does not modify file when lineContent is not found", () => {
+    const memoDir = path.join(tmpDir, "memos");
+    fs.mkdirSync(memoDir, { recursive: true });
+
+    const memoContent = "2024-01-15T10:00:00.000Z existing note about something\n";
+    const filePath = path.join(memoDir, "crd_annotate2.md");
+    fs.writeFileSync(filePath, memoContent, "utf-8");
+
+    annotateMemo(memoDir, "crd_annotate2", "this line does not exist in the file", "kb-99");
+
+    const unchanged = fs.readFileSync(filePath, "utf-8");
+    expect(unchanged).toBe(memoContent);
+    expect(unchanged).not.toContain("promoted");
+  });
+
+  it("does nothing when memo file does not exist", () => {
+    const memoDir = path.join(tmpDir, "memos");
+    fs.mkdirSync(memoDir, { recursive: true });
+
+    // Should not throw
+    expect(() => {
+      annotateMemo(memoDir, "crd_nonexistent", "some line", "kb-1");
+    }).not.toThrow();
+  });
+});
+
+/* ── Acceptance criteria: write+recall round-trip content integrity ───── */
+
+describe("AC: write+recall round-trip (episodic) — content intact", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mc-mem-ac-rt-ep-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("write episodic content, recall it, assert content intact and source=episodic", async () => {
+    const memoDir = path.join(tmpDir, "memos");
+    const episodicDir = path.join(tmpDir, "episodic");
+    const store = makeMockStore();
+
+    const content = "Discovered that the CI runner needs explicit Docker image tagging before pushing to the registry. Without tags, latest is overwritten and rollback becomes impossible. This was verified on both staging and production clusters.";
+    const writeResult = await write(store, mockEmbedder, memoDir, episodicDir, content, {});
+    expect(writeResult.stored_in).toBe("episodic");
+    expect(writeResult.path).toBeDefined();
+
+    // Verify full content on disk (not truncated)
+    const fileContent = fs.readFileSync(writeResult.path!, "utf-8");
+    expect(fileContent).toContain(content);
+
+    // Recall and verify content integrity in results
+    const { recall } = await import("./src/recall.js");
+    const mockHybridSearch = async () => [] as SearchResult[];
+
+    const results = await recall(
+      store, mockEmbedder, mockHybridSearch, memoDir, episodicDir,
+      "Docker image tagging registry rollback",
+      { daysBack: 7 },
+    );
+
+    expect(results.length).toBeGreaterThan(0);
+    const episodicResult = results.find((r) => r.source === "episodic");
+    expect(episodicResult).toBeDefined();
+    expect(episodicResult!.content).toContain("Docker image tagging");
+    expect(episodicResult!.content).toContain("rollback becomes impossible");
+    expect(episodicResult!.content!.length).toBe(content.length);
+  });
+});
+
+describe("AC: write+recall round-trip (memo) — line matches", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mc-mem-ac-rt-memo-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("write with cardId, recall scoped to card, assert source=memo and line matches", async () => {
+    const memoDir = path.join(tmpDir, "memos");
+    const episodicDir = path.join(tmpDir, "episodic");
+    const store = makeMockStore();
+
+    const content = "tried using playwright for browser automation, got ECONNREFUSED on port 9222, do not retry without VPN";
+    const writeResult = await write(store, mockEmbedder, memoDir, episodicDir, content, {
+      cardId: "crd_ac_memo_rt",
+    });
+    expect(writeResult.stored_in).toBe("memo");
+    expect(writeResult.cardId).toBe("crd_ac_memo_rt");
+
+    // Recall scoped to card
+    const { recall } = await import("./src/recall.js");
+    const mockHybridSearch = async () => [] as SearchResult[];
+
+    const results = await recall(
+      store, mockEmbedder, mockHybridSearch, memoDir, episodicDir,
+      "playwright ECONNREFUSED port 9222",
+      { cardId: "crd_ac_memo_rt" },
+    );
+
+    expect(results.length).toBeGreaterThan(0);
+    const memoResult = results.find((r) => r.source === "memo");
+    expect(memoResult).toBeDefined();
+    expect(memoResult!.line).toContain("playwright");
+    expect(memoResult!.line).toContain("ECONNREFUSED");
+  });
+});
+
+/* ── Acceptance criteria: routing verification ───────────────────────── */
+
+describe("AC: routing — memo-signal with cardId stores to memo file", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mc-mem-ac-route-memo-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("memo-signal content with cardId → stored_in=memo, file exists at memoDir/cardId.md", async () => {
+    const memoDir = path.join(tmpDir, "memos");
+    const episodicDir = path.join(tmpDir, "episodic");
+    const store = makeMockStore();
+
+    const content = "tried using fs.watch but it doesn't work on this OS, do not retry this approach";
+    const result = await write(store, mockEmbedder, memoDir, episodicDir, content, {
+      cardId: "crd_ac_route_memo",
+    });
+
+    expect(result.stored_in).toBe("memo");
+    expect(result.cardId).toBe("crd_ac_route_memo");
+
+    // File must exist at the expected path
+    const filePath = path.join(memoDir, "crd_ac_route_memo.md");
+    expect(fs.existsSync(filePath)).toBe(true);
+    const fileContent = fs.readFileSync(filePath, "utf-8");
+    expect(fileContent).toContain(content);
+  });
+});
+
+describe("AC: routing — kb-signal content routes to KB", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mc-mem-ac-route-kb-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("kb-signal content → stored_in=kb, mockStore.add called with correct type", async () => {
+    const memoDir = path.join(tmpDir, "memos");
+    const episodicDir = path.join(tmpDir, "episodic");
+    const store = makeMockStore();
+
+    const content = "Error: ENOSPC when running webpack. Fix: increase inotify watchers via sysctl. Solution is permanent and always works on Linux.";
+    const result = await write(store, mockEmbedder, memoDir, episodicDir, content, {});
+
+    expect(result.stored_in).toBe("kb");
+    expect(result.id).toBeDefined();
+    expect(store.entries.length).toBe(1);
+    expect(store.entries[0].content).toBe(content);
+    expect(store.entries[0].type).toBeTruthy();
+    expect(store.entries[0].tags).toContain("auto-routed");
+  });
+});
+
+describe("AC: routing — neutral content without cardId routes to episodic", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mc-mem-ac-route-ep-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("neutral content without cardId → stored_in=episodic, file exists in episodicDir", async () => {
+    const memoDir = path.join(tmpDir, "memos");
+    const episodicDir = path.join(tmpDir, "episodic");
+    const store = makeMockStore();
+
+    // Truly neutral content — no memo signals, no kb signals, no cardId
+    const content = "Spent the afternoon reading through the codebase documentation. The architecture diagrams were helpful for understanding the data flow between services.";
+    const result = await write(store, mockEmbedder, memoDir, episodicDir, content, {});
+
+    expect(result.stored_in).toBe("episodic");
+    expect(result.path).toBeDefined();
+    expect(fs.existsSync(result.path!)).toBe(true);
+
+    // Verify file is inside episodicDir
+    expect(result.path!.startsWith(episodicDir)).toBe(true);
+
+    // Verify content on disk
+    const fileContent = fs.readFileSync(result.path!, "utf-8");
+    expect(fileContent).toContain(content);
+  });
+});
+
+/* ── Acceptance criteria: promotion lifecycle ─────────────────────────── */
+
+describe("AC: promotion lifecycle — episodic → KB with tags", () => {
+  it("episodic → KB promotion creates entry with promoted+from-episodic tags", async () => {
+    const store = makeMockStore();
+    const content = "Learned that the staging database needs to be refreshed every Monday morning. The cron job runs at 06:00 UTC and takes approximately fifteen minutes to complete the full data sync.";
+
+    const result = await promote(store, mockEmbedder, {
+      content,
+      source_type: "episodic",
+      source_ref: "2024-03-15",
+    });
+
+    expect(result.kb_id).toBeDefined();
+    expect(result.source_type).toBe("episodic");
+    expect(result.source_ref).toBe("2024-03-15");
+
+    // Verify KB entry
+    const entry = store.get(result.kb_id);
+    expect(entry).toBeDefined();
+    expect(entry!.tags).toContain("promoted");
+    expect(entry!.tags).toContain("from-episodic");
+    expect(entry!.content).toBe(content);
+  });
+});
+
+/* ── Acceptance criteria: content integrity ───────────────────────────── */
+
+describe("AC: content integrity — no truncation", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mc-mem-ac-integrity-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("2000+ char episodic write preserves full content on disk (no truncation)", async () => {
+    const memoDir = path.join(tmpDir, "memos");
+    const episodicDir = path.join(tmpDir, "episodic");
+    const store = makeMockStore();
+
+    // Build content that is 2000+ characters
+    const base = "Today we conducted a thorough investigation of the memory subsystem to identify the root cause of the data truncation issue. ";
+    let content = "";
+    while (content.length < 2100) {
+      content += base;
+    }
+    expect(content.length).toBeGreaterThan(2000);
+
+    const result = await write(store, mockEmbedder, memoDir, episodicDir, content, {});
+    expect(result.stored_in).toBe("episodic");
+    expect(result.path).toBeDefined();
+
+    // Read back from disk and verify FULL content (no truncation)
+    const fileContent = fs.readFileSync(result.path!, "utf-8");
+    expect(fileContent).toContain(content);
+    // Verify the content portion equals exactly the original
+    const bodyMatch = fileContent.match(/^---\n[\s\S]*?\n---\n\n([\s\S]*)$/);
+    expect(bodyMatch).toBeTruthy();
+    const body = bodyMatch![1].trimEnd();
+    expect(body).toBe(content.trimEnd());
+    expect(body.length).toBeGreaterThanOrEqual(2000);
+  });
+
+  it("KB write preserves full content in store entry", async () => {
+    const memoDir = path.join(tmpDir, "memos");
+    const episodicDir = path.join(tmpDir, "episodic");
+    const store = makeMockStore();
+
+    // Build long KB content
+    const lines = [];
+    for (let i = 0; i < 30; i++) {
+      lines.push(`Step ${i + 1}: Configure the deployment pipeline component ${i + 1} with the correct environment variables and secrets.`);
+    }
+    const content = "Error: full deployment guide. Fix: follow all steps below. Solution is permanent.\n" + lines.join("\n");
+    expect(content.length).toBeGreaterThan(2000);
+
+    const result = await write(store, mockEmbedder, memoDir, episodicDir, content, {
+      forceTarget: "kb",
+    });
+
+    expect(result.stored_in).toBe("kb");
+    expect(store.entries.length).toBe(1);
+    // Full content preserved — no truncation
+    expect(store.entries[0].content).toBe(content);
+    expect(store.entries[0].content.length).toBe(content.length);
+  });
+});
+
+/* ── Acceptance criteria: mc-memo health check ────────────────────────── */
+
+describe("AC: mc-memo health — correct file format", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mc-mem-ac-memo-health-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("memo write creates correct file format (ISO timestamp + space + content + newline)", async () => {
+    const memoDir = path.join(tmpDir, "memos");
+    const episodicDir = path.join(tmpDir, "episodic");
+    const store = makeMockStore();
+
+    const content = "installed dependencies via npm ci, do not re-run unless lockfile changes";
+    const result = await write(store, mockEmbedder, memoDir, episodicDir, content, {
+      cardId: "crd_ac_memo_health",
+    });
+
+    expect(result.stored_in).toBe("memo");
+
+    // Read back the file
+    const filePath = path.join(memoDir, "crd_ac_memo_health.md");
+    expect(fs.existsSync(filePath)).toBe(true);
+
+    const fileContent = fs.readFileSync(filePath, "utf-8");
+    const lines = fileContent.split("\n").filter((l) => l.trim());
+    expect(lines.length).toBeGreaterThan(0);
+
+    // Each line must match: ISO-timestamp SPACE content
+    const isoPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\s+.+$/;
+    for (const line of lines) {
+      expect(line).toMatch(isoPattern);
+    }
+
+    // Verify content is present after timestamp
+    expect(lines[0]).toContain(content);
+
+    // File must end with newline
+    expect(fileContent.endsWith("\n")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Add 9 new test cases to mc-memory smoke.test.ts covering write+recall round-trips, routing verification, promotion lifecycle, content integrity (2000+ chars), and memo format health
- Tests target the truncation bugs from crd_48eda7d6 and crd_f9267aa8
- Total: 50 tests, 177 assertions, all passing

## Test plan
- [x] `bun test smoke.test.ts` passes (50/50, 177 assertions)
- [x] Write+recall round-trip verified for both episodic and memo
- [x] Routing tests confirm memo/kb/episodic targets with file existence checks
- [x] Content integrity test writes 2000+ chars and verifies no truncation on disk
- [x] Memo health check validates ISO timestamp format