### PR TITLE
feat(crd_59584b8c): git tree viewer + hygiene enforcement

### DIFF
--- a/plugins/mc-board/web/src/components/chat-panel.tsx
+++ b/plugins/mc-board/web/src/components/chat-panel.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useAccent } from "@/lib/accent-context";
+import { ChatHistorySidebar } from "./chat-history-sidebar";
+import { GitPanel } from "./git-panel";
 
 interface Message {
   id: string;
@@ -97,6 +99,15 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
   const [dragOver, setDragOver] = useState(false);
   const [imageError, setImageError] = useState<string | null>(null);
   const [storageWarning, setStorageWarning] = useState<string | null>(null);
+  const [historyOpen, setHistoryOpen] = useState(() => {
+    try { return localStorage.getItem("mc-board:chat-history-open") === "true"; } catch { return false; }
+  });
+  const [interruptOverlayVisible, setInterruptOverlayVisible] = useState(false);
+
+  // Edit-last-message state
+  const [editingMsgId, setEditingMsgId] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState("");
+  const editTextareaRef = useRef<HTMLTextAreaElement>(null);
 
   // Mic / voice transcription state
   const [micAvailable, setMicAvailable] = useState(false);
@@ -319,6 +330,27 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
     }
   }, [transcribeAudio, stopRecording]);
 
+  const toggleHistory = useCallback(() => {
+    setHistoryOpen(on => {
+      const next = !on;
+      try { localStorage.setItem("mc-board:chat-history-open", next ? "true" : "false"); } catch {}
+      return next;
+    });
+  }, []);
+
+  const resumeChat = useCallback((chatId: string) => {
+    if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
+    // Archive current session and load archived one
+    wsRef.current.send(JSON.stringify({ type: "resume_chat", sessionId: chatId }));
+    setMessages([]);
+    setStreamingText("");
+    setStreamingTools([]);
+    setStreaming(false);
+    streamingInsertIndexRef.current = null;
+    setHistoryOpen(false);
+    try { localStorage.setItem("mc-board:chat-history-open", "false"); } catch {}
+  }, []);
+
   // Image processing helpers
   const processFile = useCallback((file: File) => {
     setImageError(null);
@@ -366,8 +398,7 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
     files.forEach(f => {
       if (f.type.startsWith("image/")) processFile(f);
     });
-    setTimeout(() => textareaRef.current?.focus(), 50);
-  }, [processFile, textareaRef]);
+  }, [processFile]);
 
   // Paste handler for images
   const handlePaste = useCallback((e: React.ClipboardEvent) => {
@@ -379,8 +410,7 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
       const file = item.getAsFile();
       if (file) processFile(file);
     });
-    setTimeout(() => textareaRef.current?.focus(), 50);
-  }, [processFile, textareaRef]);
+  }, [processFile]);
 
   // WebSocket connection with auto-reconnect
   useEffect(() => {
@@ -424,7 +454,9 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
       ws.onclose = () => {
         if (didUnmount) return;
         setConnected(false);
-        setStreaming(false); setSentContext(null);
+        setStreaming(false);
+        setInterruptOverlayVisible(false);
+        setSentContext(null);
         wsRef.current = null;
         scheduleReconnect();
       };
@@ -455,7 +487,7 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
             if (d.tools?.length) setStreamingTools(d.tools);
             break;
           case "result":
-            setStreaming(false); setStreamingText(""); setStreamingTools([]); setSentContext(null);
+            setStreaming(false); setStreamingText(""); setStreamingTools([]); setInterruptOverlayVisible(false); setSentContext(null);
             if (d.text) {
               const assistantMsg: Message = { id: generateMsgId(), role: "assistant", content: d.text };
               const insertIdx = streamingInsertIndexRef.current;
@@ -472,12 +504,12 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
             streamingInsertIndexRef.current = null;
             break;
           case "done": case "process_exit":
-            setStreaming(false); setStreamingText(""); setStreamingTools([]); setSentContext(null);
+            setStreaming(false); setStreamingText(""); setStreamingTools([]); setInterruptOverlayVisible(false); setSentContext(null);
             streamingInsertIndexRef.current = null;
             break;
           case "error":
             setMessages(prev => [...prev, { id: generateMsgId(), role: "system", content: d.message, error: true }]);
-            setStreaming(false); setSentContext(null);
+            setStreaming(false); setInterruptOverlayVisible(false); setSentContext(null);
             streamingInsertIndexRef.current = null;
             break;
         }
@@ -518,6 +550,18 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
     onContextConsumed();
     setTimeout(() => textareaRef.current?.focus(), 50);
   }, [pendingContext, onContextConsumed]);
+
+  // Cmd+H keyboard shortcut to toggle history
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "h" && open) {
+        e.preventDefault();
+        toggleHistory();
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open, toggleHistory]);
 
   // Track scroll position to detect when user is not at bottom
   const handleScroll = useCallback(() => {
@@ -616,12 +660,47 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
 
   const interruptAgent = useCallback(() => {
     stopResponse();
+    setInterruptOverlayVisible(false);
     setMessages(prev => [...prev, {
       id: generateMsgId(),
       role: "system" as const,
       content: "⏹ Agent interrupted by user",
     }]);
   }, [stopResponse]);
+
+  const startEditMessage = useCallback((msgId: string, content: string) => {
+    setEditingMsgId(msgId);
+    setEditDraft(content);
+    setTimeout(() => editTextareaRef.current?.focus(), 50);
+  }, []);
+
+  const cancelEditMessage = useCallback(() => {
+    setEditingMsgId(null);
+    setEditDraft("");
+  }, []);
+
+  const submitEditMessage = useCallback(() => {
+    const text = editDraft.trim();
+    if (!text || !editingMsgId || !wsRef.current || !connected || streaming) return;
+
+    // Find the index of the message being edited
+    const editIdx = messages.findIndex(m => m.id === editingMsgId);
+    if (editIdx < 0) return;
+
+    // Truncate messages: remove the edited message and everything after it
+    const newMsgId = generateMsgId();
+    const truncated = messages.slice(0, editIdx);
+    const newUserMsg: Message = { id: newMsgId, role: "user", content: text };
+    setMessages([...truncated, newUserMsg]);
+    streamingInsertIndexRef.current = truncated.length + 1;
+
+    // Send edit_message over WS
+    wsRef.current.send(JSON.stringify({ type: "edit_message", content: text, id: newMsgId }));
+
+    setEditingMsgId(null);
+    setEditDraft("");
+    setStreaming(true);
+  }, [editDraft, editingMsgId, connected, streaming, messages]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && e.shiftKey) {
@@ -669,6 +748,10 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
 
   // Open state
   return (
+    <>
+    <style>{`
+      .chat-msg-wrapper:hover .chat-edit-btn { opacity: 1 !important; }
+    `}</style>
     <div
       onDragOver={handleDragOver}
       onDragEnter={handleDragOver}
@@ -714,10 +797,19 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
           }}>{connected ? "connected" : reconnecting ? "reconnecting…" : "offline"}</span>
         </div>
         <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+          {streaming && (
+            <button
+              onClick={stopResponse}
+              style={{
+                background: "none", border: "1px solid #7c2d12", color: "#f87171", cursor: "pointer",
+                fontSize: 10, padding: "2px 8px", borderRadius: 3, fontFamily: "inherit",
+              }}
+            >stop</button>
+          )}
           {messages.length > 0 && (
             <button
-              onClick={() => { setMessages([]); setStorageWarning(null); setReplyingTo(null); wsRef.current?.send(JSON.stringify({ type: "new_chat" })); }}
-              title="New chat"
+              onClick={() => { setMessages([]); setStorageWarning(null); setReplyingTo(null); wsRef.current?.send(JSON.stringify({ type: "new_chat" })); streamingInsertIndexRef.current = null; }}
+              title="New chat (archives current)"
               style={{
                 background: "none", border: "none", color: "#52525b", cursor: "pointer",
                 fontSize: 11, padding: "2px 6px", borderRadius: 3, fontFamily: "inherit",
@@ -726,6 +818,29 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
               onMouseLeave={e => (e.currentTarget.style.color = "#52525b")}
             >new</button>
           )}
+          {/* History toggle button */}
+          <button
+            onClick={toggleHistory}
+            title={`Chat history (⌘H)`}
+            style={{
+              background: historyOpen ? "#27272a" : "none",
+              border: "none",
+              color: historyOpen ? accent : "#52525b",
+              cursor: "pointer",
+              fontSize: 11,
+              padding: "3px 5px",
+              borderRadius: 3,
+              display: "flex", alignItems: "center", justifyContent: "center",
+              lineHeight: 1,
+            }}
+            onMouseEnter={e => { if (!historyOpen) e.currentTarget.style.color = "#a1a1aa"; }}
+            onMouseLeave={e => { if (!historyOpen) e.currentTarget.style.color = "#52525b"; }}
+          >
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"
+              strokeLinecap="round" strokeLinejoin="round">
+              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+            </svg>
+          </button>
           <button
             onClick={onToggle}
             style={{ background: "none", border: "none", color: "#52525b", cursor: "pointer", fontSize: 18, lineHeight: 1 }}
@@ -734,6 +849,9 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
           >✕</button>
         </div>
       </div>
+
+      {/* Git panel */}
+      <GitPanel accent={accent} />
 
       {/* Storage warning banner */}
       {storageWarning && (
@@ -752,15 +870,13 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
 
       {/* Messages */}
       <div style={{ flex: 1, position: "relative", overflow: "hidden", display: "flex", flexDirection: "column" }}>
-      {/* Persistent context indicator — visible while agent is responding with context */}
       {sentContext && streaming && (
         <div style={{
           margin: "0 10px", padding: "5px 10px", borderRadius: 6,
           background: "#1a1a2e", border: "1px solid #2d2d5b",
-          display: "flex", alignItems: "center", gap: 6, flexShrink: 0,
-          opacity: 0.85,
+          display: "flex", alignItems: "center", gap: 6, flexShrink: 0, opacity: 0.8,
         }}>
-          <span style={{ fontSize: 9, color: "#6366f1", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", flexShrink: 0 }}>ctx</span>
+          <span style={{ fontSize: 10, color: "#6366f1", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", flexShrink: 0 }}>📌 ctx</span>
           <span style={{ fontSize: 11, color: "#818cf8", flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
             {sentContext.slice(0, 80)}{sentContext.length > 80 ? "..." : ""}
           </span>
@@ -807,12 +923,21 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
             textareaRef.current?.focus();
           };
 
+          const lastUserMsgId = (() => {
+            for (let k = messages.length - 1; k >= 0; k--) {
+              if (messages[k].role === "user") return messages[k].id;
+            }
+            return null;
+          })();
+
           const renderMsg = (msg: Message, i: number) => {
             // Find the referenced message for reply header
             const replyTarget = msg.replyTo ? messages.find(m => m.id === msg.replyTo) : null;
             const replySnippet = replyTarget
               ? replyTarget.content.slice(0, 60) + (replyTarget.content.length > 60 ? "…" : "")
               : msg.replyTo ? "(original message no longer available)" : null;
+            const isLastUser = msg.role === "user" && msg.id === lastUserMsgId;
+            const isEditing = editingMsgId === msg.id;
 
             return (
             <div key={msg.id || `msg-${i}`} id={`chat-msg-${msg.id}`} className="chat-msg-wrapper" style={{
@@ -823,6 +948,45 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
               {msg.role === "system" ? (
                 <div style={{ fontSize: 11, color: "#52525b", textAlign: "center", width: "100%", padding: "4px 0" }}>
                   {msg.content}
+                </div>
+              ) : isEditing ? (
+                /* Inline edit mode */
+                <div style={{ maxWidth: "92%", width: "100%", display: "flex", flexDirection: "column", gap: 6, alignItems: "flex-end" }}>
+                  <textarea
+                    ref={editTextareaRef}
+                    value={editDraft}
+                    onChange={e => setEditDraft(e.target.value)}
+                    onKeyDown={e => {
+                      if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); submitEditMessage(); }
+                      if (e.key === "Escape") cancelEditMessage();
+                    }}
+                    style={{
+                      width: "100%", minHeight: 60, padding: "8px 11px",
+                      borderRadius: "10px 10px 3px 10px",
+                      background: "#1d3a2a", border: `1px solid ${accent}`,
+                      fontSize: 13, color: "#bbf7d0", lineHeight: 1.55,
+                      resize: "vertical", fontFamily: "inherit",
+                      outline: "none",
+                    }}
+                  />
+                  <div style={{ display: "flex", gap: 6 }}>
+                    <button
+                      onClick={cancelEditMessage}
+                      style={{
+                        background: "none", border: "1px solid #3f3f46", borderRadius: 4,
+                        color: "#71717a", fontSize: 11, padding: "3px 10px", cursor: "pointer",
+                        fontFamily: "inherit",
+                      }}
+                    >Cancel</button>
+                    <button
+                      onClick={submitEditMessage}
+                      style={{
+                        background: accent, border: "none", borderRadius: 4,
+                        color: "#fff", fontSize: 11, padding: "3px 10px", cursor: "pointer",
+                        fontFamily: "inherit",
+                      }}
+                    >Save & Resend</button>
+                  </div>
                 </div>
               ) : (
                 <>
@@ -880,25 +1044,41 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
                       </div>
                     )}
                     {msg.content}
+                    {/* Reply button — inline at bottom of bubble */}
+                    <div style={{ display: "flex", justifyContent: msg.role === "user" ? "flex-start" : "flex-end", marginTop: 4 }}>
+                      <button
+                        onClick={(e) => { e.stopPropagation(); handleReply(msg); }}
+                        title="Reply to this message"
+                        style={{
+                          background: "none", border: "none",
+                          color: "#52525b", fontSize: 10, cursor: "pointer",
+                          padding: "1px 4px", borderRadius: 3,
+                          display: "flex", alignItems: "center", gap: 3,
+                          transition: "color 0.15s",
+                        }}
+                        onMouseEnter={e => { e.currentTarget.style.color = "#a1a1aa"; }}
+                        onMouseLeave={e => { e.currentTarget.style.color = "#52525b"; }}
+                      >↩ reply</button>
+                    </div>
                   </div>
-                  {/* Reply button — visible on hover via CSS */}
-                  <button
-                    className="chat-reply-btn"
-                    onClick={() => handleReply(msg)}
-                    title="Reply to this message"
-                    style={{
-                      position: "absolute",
-                      top: replySnippet ? 24 : 4,
-                      [msg.role === "user" ? "left" : "right"]: -28,
-                      width: 22, height: 22,
-                      background: "#27272a", border: "1px solid #3f3f46", borderRadius: 4,
-                      color: "#71717a", fontSize: 12,
-                      cursor: "pointer",
-                      display: "flex", alignItems: "center", justifyContent: "center",
-                      opacity: 0, transition: "opacity 0.15s",
-                      padding: 0, lineHeight: 1,
-                    }}
-                  >↩</button>
+                  {/* Edit button — only on last user message, hidden during streaming */}
+                  {isLastUser && !streaming && (
+                    <button
+                      className="chat-edit-btn"
+                      onClick={() => startEditMessage(msg.id, msg.content)}
+                      title="Edit message"
+                      style={{
+                        position: "absolute", top: 4, left: -28,
+                        width: 22, height: 22,
+                        background: "#27272a", border: "1px solid #3f3f46", borderRadius: 4,
+                        color: "#71717a", fontSize: 12,
+                        cursor: "pointer",
+                        display: "flex", alignItems: "center", justifyContent: "center",
+                        opacity: 0, transition: "opacity 0.15s",
+                        padding: 0, lineHeight: 1,
+                      }}
+                    >✏</button>
+                  )}
                 </>
               )}
             </div>
@@ -908,15 +1088,19 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
           const streamingBlock = streaming ? (
             <div
               key="streaming"
-              style={{ display: "flex", flexDirection: "column", alignItems: "flex-start" }}
+              style={{ display: "flex", flexDirection: "column", alignItems: "flex-start", position: "relative" }}
+              onMouseLeave={() => setInterruptOverlayVisible(false)}
             >
               <div
+                onClick={() => setInterruptOverlayVisible(v => !v)}
                 style={{
                   maxWidth: "92%", padding: "8px 11px",
                   borderRadius: "10px 10px 10px 3px",
                   background: "#18181b", border: "1px solid #27272a",
                   fontSize: 13, color: "#d4d4d8", lineHeight: 1.55,
                   whiteSpace: "pre-wrap", wordBreak: "break-word",
+                  cursor: "pointer",
+                  transition: "border-color 0.15s",
                 }}>
                 {streamingTools.length > 0 && (
                   <div style={{ marginBottom: 6, display: "flex", flexWrap: "wrap", gap: 4 }}>
@@ -932,21 +1116,25 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
                   {streamingTools.length > 0 ? "working..." : "thinking..."}
                 </span>}
               </div>
-              {/* Interrupt button — always visible below bubble during streaming */}
-              <button
-                onClick={interruptAgent}
-                style={{
-                  marginTop: 6,
-                  background: "#7c2d12", border: "1px solid #dc2626",
-                  borderRadius: 6, color: "#fca5a5",
-                  fontSize: 11, fontWeight: 600, fontFamily: "inherit",
-                  padding: "4px 12px", cursor: "pointer",
-                  transition: "background 0.15s, color 0.15s",
-                  whiteSpace: "nowrap",
-                }}
-                onMouseEnter={e => { e.currentTarget.style.background = "#991b1b"; e.currentTarget.style.color = "#fef2f2"; }}
-                onMouseLeave={e => { e.currentTarget.style.background = "#7c2d12"; e.currentTarget.style.color = "#fca5a5"; }}
-              >⏹ Interrupt</button>
+              {/* Interrupt overlay */}
+              {interruptOverlayVisible && (
+                <button
+                  onClick={(e) => { e.stopPropagation(); interruptAgent(); }}
+                  style={{
+                    position: "absolute", top: -6, left: 8,
+                    background: "#7c2d12", border: "1px solid #dc2626",
+                    borderRadius: 6, color: "#fca5a5",
+                    fontSize: 11, fontWeight: 600, fontFamily: "inherit",
+                    padding: "4px 12px", cursor: "pointer",
+                    boxShadow: "0 2px 8px rgba(0,0,0,0.5)",
+                    zIndex: 10,
+                    transition: "background 0.15s, color 0.15s",
+                    whiteSpace: "nowrap",
+                  }}
+                  onMouseEnter={e => { e.currentTarget.style.background = "#991b1b"; e.currentTarget.style.color = "#fef2f2"; }}
+                  onMouseLeave={e => { e.currentTarget.style.background = "#7c2d12"; e.currentTarget.style.color = "#fca5a5"; }}
+                >⏹ Interrupt</button>
+              )}
             </div>
           ) : null;
 
@@ -1004,26 +1192,7 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
       >↓</button>
       </div>
 
-      {/* Reply preview */}
-      {replyingTo && (
-        <div style={{
-          margin: "0 10px", padding: "6px 10px", borderRadius: 6,
-          background: "#1a1a2e", border: "1px solid #4c1d95",
-          display: "flex", alignItems: "flex-start", gap: 6, flexShrink: 0,
-        }}>
-          <span style={{ fontSize: 10, color: "#8b5cf6", fontWeight: 700, flexShrink: 0, marginTop: 1 }}>↩ reply</span>
-          <div style={{ flex: 1, overflow: "hidden", minWidth: 0 }}>
-            <span style={{ fontSize: 10, color: "#6366f1", fontWeight: 600, textTransform: "capitalize" }}>{replyingTo.role}</span>
-            <div style={{ fontSize: 11, color: "#a78bfa", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-              {replyingTo.snippet}
-            </div>
-          </div>
-          <button
-            onClick={() => setReplyingTo(null)}
-            style={{ background: "none", border: "none", color: "#52525b", cursor: "pointer", fontSize: 13, lineHeight: 1, padding: 0, flexShrink: 0 }}
-          >✕</button>
-        </div>
-      )}
+      {/* Reply preview — moved into compose area below */}
 
       {/* Context badge */}
       {context && (
@@ -1152,8 +1321,27 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
       {/* Compose */}
       <div style={{
         padding: "10px 10px 12px", borderTop: "1px solid #1f1f1f", flexShrink: 0,
-        display: "flex", flexDirection: "column", gap: 6,
+        display: "flex", flexDirection: "column", gap: 0,
       }}>
+        {/* Reply preview — flush above textarea */}
+        {replyingTo && (
+          <div style={{
+            padding: "5px 10px", marginBottom: 0,
+            borderRadius: "6px 6px 0 0",
+            background: "#1a1a2e", border: "1px solid #4c1d95", borderBottom: "none",
+            display: "flex", alignItems: "center", gap: 6, flexShrink: 0,
+          }}>
+            <span style={{ fontSize: 10, color: "#8b5cf6", fontWeight: 700, flexShrink: 0 }}>↩ reply</span>
+            <span style={{ fontSize: 10, color: "#6366f1", fontWeight: 600, textTransform: "capitalize", flexShrink: 0 }}>{replyingTo.role}</span>
+            <span style={{ fontSize: 11, color: "#a78bfa", flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+              {replyingTo.snippet}
+            </span>
+            <button
+              onClick={() => setReplyingTo(null)}
+              style={{ background: "none", border: "none", color: "#52525b", cursor: "pointer", fontSize: 13, lineHeight: 1, padding: 0, flexShrink: 0 }}
+            >✕</button>
+          </div>
+        )}
         <textarea
           ref={textareaRef}
           value={draft}
@@ -1163,16 +1351,19 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
           placeholder={`Message ${agentName}...`}
           rows={3}
           style={{
-            width: "100%", background: "#18181b", border: "1px solid #3f3f46",
-            borderRadius: 6, color: "#e4e4e7", fontSize: 13, fontFamily: "inherit",
+            width: "100%", background: "#18181b",
+            border: replyingTo ? "1px solid #4c1d95" : "1px solid #3f3f46",
+            borderTop: replyingTo ? "none" : undefined,
+            borderRadius: replyingTo ? "0 0 6px 6px" : 6,
+            color: "#e4e4e7", fontSize: 13, fontFamily: "inherit",
             padding: "7px 10px", outline: "none", resize: "none", lineHeight: 1.5,
             transition: "border-color 0.15s", boxSizing: "border-box",
           }}
           onFocus={e => { e.currentTarget.style.borderColor = "#52525b"; }}
           onBlur={e => { e.currentTarget.style.borderColor = "#3f3f46"; }}
         />
-        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-          <span style={{ fontSize: 10, color: "#3f3f46" }}>Shift+Enter to send</span>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginTop: 6 }}>
+          <span style={{ fontSize: 10, color: "#e4e4e7" }}>Shift+Enter to send · Enter for new line</span>
           <div style={{ display: "flex", gap: 4 }}>
             {micAvailable && (
               <button
@@ -1232,6 +1423,16 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
           </div>
         </div>
       </div>
+
+      {/* Chat history sidebar — absolute overlay covering the full chat panel */}
+      <ChatHistorySidebar
+        isOpen={historyOpen}
+        onClose={toggleHistory}
+        onResume={resumeChat}
+        currentSessionId={sessionId}
+        serverBaseUrl={`${typeof window !== "undefined" ? window.location.protocol : "http:"}//${typeof window !== "undefined" ? window.location.hostname : "localhost"}:4221`}
+      />
     </div>
+    </>
   );
 }

--- a/plugins/mc-board/web/src/components/git-panel.tsx
+++ b/plugins/mc-board/web/src/components/git-panel.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+
+interface GitStatus {
+  branch: string;
+  dirty: boolean;
+  staged: string[];
+  unstaged: string[];
+  untracked: string[];
+  headSha?: string;
+}
+
+interface GitCommit {
+  graph: string;
+  sha: string;
+  message: string;
+}
+
+interface Props {
+  wsUrl?: string;
+  repoPath?: string;
+  accent?: string;
+}
+
+const CHAT_WS_PORT = 4221;
+
+export function GitPanel({ wsUrl, repoPath, accent = "#00E5CC" }: Props) {
+  const [collapsed, setCollapsed] = useState(() => {
+    try { return localStorage.getItem("mc-git-panel-collapsed") !== "false"; } catch { return true; }
+  });
+  const [status, setStatus] = useState<GitStatus | null>(null);
+  const [commits, setCommits] = useState<GitCommit[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<"files" | "log">("files");
+  const [configuredRepo, setConfiguredRepo] = useState<string>(
+    () => {
+      try { return localStorage.getItem("mc-git-panel-repo") || repoPath || ""; }
+      catch { return repoPath || ""; }
+    }
+  );
+  const wsRef = useRef<WebSocket | null>(null);
+
+  const currentRepo = configuredRepo || repoPath || "";
+
+  useEffect(() => {
+    try { localStorage.setItem("mc-git-panel-collapsed", String(collapsed)); } catch {}
+  }, [collapsed]);
+
+  useEffect(() => {
+    try { localStorage.setItem("mc-git-panel-repo", configuredRepo); } catch {}
+  }, [configuredRepo]);
+
+  const baseUrl = `http://127.0.0.1:${CHAT_WS_PORT}`;
+
+  const fetchStatus = useCallback(async () => {
+    if (!currentRepo) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${baseUrl}/git/status?repo=${encodeURIComponent(currentRepo)}`);
+      const data = await res.json();
+      if (!res.ok) { setError(data.error || "Failed to fetch status"); return; }
+      setStatus(data);
+    } catch {
+      setError("Cannot connect to mc-web-chat server");
+    } finally {
+      setLoading(false);
+    }
+  }, [currentRepo, baseUrl]);
+
+  const fetchLog = useCallback(async () => {
+    if (!currentRepo) return;
+    try {
+      const res = await fetch(`${baseUrl}/git/log?repo=${encodeURIComponent(currentRepo)}&limit=15`);
+      const data = await res.json();
+      if (res.ok) setCommits(data.commits || []);
+    } catch { /* silent */ }
+  }, [currentRepo, baseUrl]);
+
+  const refresh = useCallback(async () => {
+    await Promise.all([fetchStatus(), fetchLog()]);
+  }, [fetchStatus, fetchLog]);
+
+  // Subscribe to WS git_status updates
+  useEffect(() => {
+    if (!currentRepo || collapsed) return;
+
+    const wsTarget = wsUrl || `ws://127.0.0.1:${CHAT_WS_PORT}`;
+    const ws = new WebSocket(wsTarget);
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      ws.send(JSON.stringify({ type: "join" }));
+      ws.send(JSON.stringify({ type: "git_subscribe", repo: currentRepo }));
+    };
+
+    ws.onmessage = (ev) => {
+      try {
+        const data = JSON.parse(ev.data);
+        if (data.type === "git_status") {
+          setStatus(data);
+        }
+      } catch {}
+    };
+
+    ws.onerror = () => {};
+    ws.onclose = () => { wsRef.current = null; };
+
+    return () => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: "git_unsubscribe" }));
+      }
+      ws.close();
+      wsRef.current = null;
+    };
+  }, [currentRepo, collapsed, wsUrl]);
+
+  // Initial fetch
+  useEffect(() => {
+    if (!collapsed && currentRepo) {
+      refresh();
+    }
+  }, [collapsed, currentRepo, refresh]);
+
+  const dirtyCount = status ? status.staged.length + status.unstaged.length + status.untracked.length : 0;
+
+  return (
+    <div style={{
+      borderBottom: "1px solid #27272a",
+      background: "#0a0a0a",
+      fontSize: 12,
+      fontFamily: "'JetBrains Mono', 'SF Mono', 'Fira Code', monospace",
+    }}>
+      {/* Header */}
+      <div
+        onClick={() => setCollapsed(!collapsed)}
+        style={{
+          display: "flex", alignItems: "center", gap: 8,
+          padding: "6px 12px", cursor: "pointer",
+          borderBottom: collapsed ? "none" : "1px solid #1a1a1a",
+          userSelect: "none",
+        }}
+      >
+        <span style={{ color: "#52525b", fontSize: 10, transition: "transform 0.2s", transform: collapsed ? "rotate(-90deg)" : "rotate(0)" }}>▼</span>
+        <span style={{ color: "#71717a", fontSize: 10, fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.05em" }}>GIT</span>
+        {status && (
+          <>
+            <span style={{ color: accent, fontWeight: 600, fontSize: 11 }}>{status.branch}</span>
+            <span style={{
+              fontSize: 9, padding: "1px 5px", borderRadius: 3,
+              background: status.dirty ? "#2a1a1a" : "#1a2a1a",
+              color: status.dirty ? "#f87171" : "#4ade80",
+              fontWeight: 700,
+            }}>
+              {status.dirty ? `${dirtyCount} changed` : "clean"}
+            </span>
+          </>
+        )}
+        {!status && !loading && currentRepo && (
+          <span style={{ color: "#52525b", fontSize: 10 }}>no connection</span>
+        )}
+        {loading && <span style={{ color: "#52525b", fontSize: 10 }}>loading...</span>}
+      </div>
+
+      {/* Expanded panel */}
+      {!collapsed && (
+        <div style={{ padding: "0 12px 8px" }}>
+          {/* Repo path input */}
+          <div style={{ display: "flex", gap: 4, alignItems: "center", marginBottom: 6, marginTop: 4 }}>
+            <input
+              type="text"
+              value={configuredRepo}
+              onChange={e => setConfiguredRepo(e.target.value)}
+              placeholder="~/path/to/repo"
+              style={{
+                flex: 1, background: "#18181b", border: "1px solid #27272a",
+                borderRadius: 4, padding: "3px 6px", color: "#a1a1aa",
+                fontSize: 11, fontFamily: "inherit", outline: "none",
+              }}
+              onFocus={e => e.target.style.borderColor = accent}
+              onBlur={e => e.target.style.borderColor = "#27272a"}
+              onKeyDown={e => { if (e.key === "Enter") refresh(); }}
+            />
+            <button
+              onClick={refresh}
+              title="Refresh git status"
+              style={{
+                background: "#18181b", border: "1px solid #27272a",
+                borderRadius: 4, padding: "3px 8px", color: "#71717a",
+                cursor: "pointer", fontSize: 11, fontFamily: "inherit",
+              }}
+              onMouseEnter={e => { e.currentTarget.style.borderColor = accent; e.currentTarget.style.color = accent; }}
+              onMouseLeave={e => { e.currentTarget.style.borderColor = "#27272a"; e.currentTarget.style.color = "#71717a"; }}
+            >&#8635;</button>
+          </div>
+
+          {error && (
+            <div style={{ color: "#f87171", fontSize: 11, padding: "4px 0" }}>{error}</div>
+          )}
+
+          {/* Tab bar */}
+          <div style={{ display: "flex", gap: 0, marginBottom: 6 }}>
+            {(["files", "log"] as const).map(t => (
+              <button
+                key={t}
+                onClick={() => setActiveTab(t)}
+                style={{
+                  background: activeTab === t ? "#1a1a1a" : "transparent",
+                  border: "1px solid #27272a",
+                  borderBottom: activeTab === t ? "1px solid #1a1a1a" : "1px solid #27272a",
+                  borderRadius: t === "files" ? "4px 0 0 0" : "0 4px 0 0",
+                  padding: "3px 12px", color: activeTab === t ? accent : "#52525b",
+                  cursor: "pointer", fontSize: 10, fontFamily: "inherit",
+                  fontWeight: activeTab === t ? 600 : 400,
+                  textTransform: "uppercase", letterSpacing: "0.04em",
+                }}
+              >{t}</button>
+            ))}
+          </div>
+
+          {/* Files tab */}
+          {activeTab === "files" && status && (
+            <div style={{ maxHeight: 200, overflowY: "auto" }}>
+              {status.staged.length > 0 && (
+                <div style={{ marginBottom: 4 }}>
+                  <div style={{ color: "#4ade80", fontSize: 10, fontWeight: 600, marginBottom: 2 }}>STAGED ({status.staged.length})</div>
+                  {status.staged.map((f, i) => (
+                    <div key={`s-${i}`} style={{ color: "#86efac", fontSize: 11, padding: "1px 0 1px 8px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                      {f}
+                    </div>
+                  ))}
+                </div>
+              )}
+              {status.unstaged.length > 0 && (
+                <div style={{ marginBottom: 4 }}>
+                  <div style={{ color: "#fbbf24", fontSize: 10, fontWeight: 600, marginBottom: 2 }}>MODIFIED ({status.unstaged.length})</div>
+                  {status.unstaged.map((f, i) => (
+                    <div key={`u-${i}`} style={{ color: "#fcd34d", fontSize: 11, padding: "1px 0 1px 8px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                      {f}
+                    </div>
+                  ))}
+                </div>
+              )}
+              {status.untracked.length > 0 && (
+                <div style={{ marginBottom: 4 }}>
+                  <div style={{ color: "#71717a", fontSize: 10, fontWeight: 600, marginBottom: 2 }}>UNTRACKED ({status.untracked.length})</div>
+                  {status.untracked.map((f, i) => (
+                    <div key={`t-${i}`} style={{ color: "#a1a1aa", fontSize: 11, padding: "1px 0 1px 8px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                      {f}
+                    </div>
+                  ))}
+                </div>
+              )}
+              {dirtyCount === 0 && (
+                <div style={{ color: "#4ade80", fontSize: 11, padding: "4px 0", textAlign: "center" }}>
+                  Working tree clean
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Log tab */}
+          {activeTab === "log" && (
+            <div style={{ maxHeight: 200, overflowY: "auto" }}>
+              {commits.length === 0 && (
+                <div style={{ color: "#52525b", fontSize: 11, textAlign: "center", padding: "8px 0" }}>No commits</div>
+              )}
+              {commits.map((c, i) => (
+                <div key={i} style={{
+                  display: "flex", gap: 6, padding: "2px 0",
+                  fontSize: 11, lineHeight: 1.4,
+                }}>
+                  <span style={{ color: "#6366f1", flexShrink: 0, whiteSpace: "pre", fontFamily: "inherit" }}>{c.graph}</span>
+                  {c.sha && <span style={{ color: "#d97706", flexShrink: 0 }}>{c.sha.slice(0, 7)}</span>}
+                  <span style={{ color: "#d4d4d8", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{c.message}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/plugins/mc-checkpoint/cli/commands.ts
+++ b/plugins/mc-checkpoint/cli/commands.ts
@@ -8,6 +8,14 @@ import {
   restoreCheckpoint,
   pruneCheckpoints,
 } from "../src/checkpoint.js";
+import {
+  getHygieneStatus,
+  installHygiene,
+  removeHygiene,
+  loadConfig,
+  saveConfig,
+  type HygieneConfig,
+} from "../src/hygiene.js";
 import { formatPluginError, formatUserError, DOCTOR_SUGGESTION } from "../../shared/errors/format.js";
 
 export interface CliContext {
@@ -294,6 +302,141 @@ export function registerCheckpointCommands(ctx: CliContext, cfg: CheckpointConfi
         console.log(`\n${removed > 0 ? removed + " hook(s) removed" : "No hooks to remove"} in ${repoPath}`);
       } catch (err) {
         console.error(formatPluginError("mc-checkpoint", "auto-remove", err, [DOCTOR_SUGGESTION]));
+        process.exit(1);
+      }
+    });
+
+  // ── mc-checkpoint hygiene ──
+  const hygiene = checkpoint
+    .command("hygiene")
+    .description("Git hygiene enforcement — protected branches, auto-stash, dirty-state warnings");
+
+  // ── mc-checkpoint hygiene status ──
+  hygiene
+    .command("status")
+    .description("Show current repo hygiene state")
+    .option("--repo <path>", "Repository path (default: cwd)")
+    .action((opts: { repo?: string }) => {
+      try {
+        const repoPath = resolveRepo(opts.repo);
+        const status = getHygieneStatus(repoPath);
+
+        if (!status.isGitRepo) {
+          console.error(formatUserError(`Not a git repository: ${repoPath}`));
+          process.exit(1);
+        }
+
+        console.log(`Git Hygiene Status: ${repoPath}\n`);
+        console.log(`  Branch:     ${status.branch}${status.protectedBranch ? " ⚠️  (protected)" : ""}`);
+        console.log(`  State:      ${status.dirty ? "DIRTY" : "CLEAN"}`);
+        if (status.dirty) {
+          console.log(`    Staged:    ${status.stagedCount}`);
+          console.log(`    Unstaged:  ${status.unstagedCount}`);
+          console.log(`    Untracked: ${status.untrackedCount}`);
+        }
+        console.log(`\n  Protected branches: ${status.config.protectedBranches.join(", ") || "(none)"}`);
+        console.log(`  Auto-stash merge:   ${status.config.autoStashOnMerge ? "ON" : "OFF"}`);
+        console.log(`  Auto-stash rebase:  ${status.config.autoStashOnRebase ? "ON" : "OFF"}`);
+        console.log(`  Dirty switch warn:  ${status.config.warnDirtyBranchSwitch ? "ON" : "OFF"}`);
+        console.log(`\n  Hooks installed: ${status.hooksInstalled.length > 0 ? status.hooksInstalled.join(", ") : "(none)"}`);
+      } catch (err) {
+        console.error(formatPluginError("mc-checkpoint", "hygiene status", err, [DOCTOR_SUGGESTION]));
+        process.exit(1);
+      }
+    });
+
+  // ── mc-checkpoint hygiene install ──
+  hygiene
+    .command("install")
+    .description("Install git hygiene hooks in a repository")
+    .option("--repo <path>", "Repository path (default: cwd)")
+    .action((opts: { repo?: string }) => {
+      try {
+        const repoPath = resolveRepo(opts.repo);
+        const result = installHygiene(repoPath);
+
+        if (result.installed.length > 0) {
+          console.log("Installed hygiene hooks:");
+          for (const h of result.installed) console.log(`  ✓ ${h}`);
+        }
+        if (result.skipped.length > 0) {
+          console.log("Already installed:");
+          for (const h of result.skipped) console.log(`  - ${h}`);
+        }
+        console.log(`\nDone. ${result.installed.length} hook(s) installed in ${repoPath}`);
+      } catch (err) {
+        console.error(formatPluginError("mc-checkpoint", "hygiene install", err, [
+          "Ensure you are in a git repository",
+          DOCTOR_SUGGESTION,
+        ]));
+        process.exit(1);
+      }
+    });
+
+  // ── mc-checkpoint hygiene remove ──
+  hygiene
+    .command("remove")
+    .description("Remove git hygiene hooks from a repository")
+    .option("--repo <path>", "Repository path (default: cwd)")
+    .action((opts: { repo?: string }) => {
+      try {
+        const repoPath = resolveRepo(opts.repo);
+        const result = removeHygiene(repoPath);
+
+        if (result.removed.length > 0) {
+          console.log("Removed hygiene hooks:");
+          for (const h of result.removed) console.log(`  ✓ ${h}`);
+        } else {
+          console.log("No hygiene hooks found to remove.");
+        }
+      } catch (err) {
+        console.error(formatPluginError("mc-checkpoint", "hygiene remove", err, [DOCTOR_SUGGESTION]));
+        process.exit(1);
+      }
+    });
+
+  // ── mc-checkpoint hygiene config ──
+  hygiene
+    .command("config")
+    .description("Show or set hygiene configuration for a repository")
+    .option("--repo <path>", "Repository path (default: cwd)")
+    .option("--protected <branches>", "Comma-separated list of protected branches")
+    .option("--auto-stash-merge <bool>", "Auto-stash before merge (true/false)")
+    .option("--auto-stash-rebase <bool>", "Auto-stash before rebase (true/false)")
+    .option("--warn-dirty-switch <bool>", "Warn on dirty branch switch (true/false)")
+    .action((opts: { repo?: string; protected?: string; autoStashMerge?: string; autoStashRebase?: string; warnDirtySwitch?: string }) => {
+      try {
+        const repoPath = resolveRepo(opts.repo);
+        const config = loadConfig(repoPath);
+        let changed = false;
+
+        if (opts.protected !== undefined) {
+          config.protectedBranches = opts.protected.split(",").map(b => b.trim()).filter(Boolean);
+          changed = true;
+        }
+        if (opts.autoStashMerge !== undefined) {
+          config.autoStashOnMerge = opts.autoStashMerge === "true";
+          changed = true;
+        }
+        if (opts.autoStashRebase !== undefined) {
+          config.autoStashOnRebase = opts.autoStashRebase === "true";
+          changed = true;
+        }
+        if (opts.warnDirtySwitch !== undefined) {
+          config.warnDirtyBranchSwitch = opts.warnDirtySwitch === "true";
+          changed = true;
+        }
+
+        if (changed) {
+          saveConfig(repoPath, config);
+          console.log("Configuration updated:");
+        } else {
+          console.log("Current configuration:");
+        }
+
+        console.log(JSON.stringify(config, null, 2));
+      } catch (err) {
+        console.error(formatPluginError("mc-checkpoint", "hygiene config", err, [DOCTOR_SUGGESTION]));
         process.exit(1);
       }
     });

--- a/plugins/mc-checkpoint/src/hygiene.ts
+++ b/plugins/mc-checkpoint/src/hygiene.ts
@@ -1,0 +1,311 @@
+/**
+ * src/hygiene.ts
+ *
+ * Git hygiene enforcement: protected branches, auto-stash,
+ * dirty-state warnings, and pre-commit checks.
+ */
+
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface HygieneConfig {
+  protectedBranches: string[];
+  autoStashOnMerge: boolean;
+  autoStashOnRebase: boolean;
+  warnDirtyBranchSwitch: boolean;
+}
+
+export const DEFAULT_HYGIENE_CONFIG: HygieneConfig = {
+  protectedBranches: ["main", "master"],
+  autoStashOnMerge: true,
+  autoStashOnRebase: true,
+  warnDirtyBranchSwitch: true,
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function git(repoPath: string, args: string[]): string {
+  return execFileSync("git", ["-C", repoPath, ...args], {
+    encoding: "utf-8",
+    timeout: 15_000,
+  }).trim();
+}
+
+function isGitRepo(repoPath: string): boolean {
+  try {
+    git(repoPath, ["rev-parse", "--git-dir"]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ── Config persistence ───────────────────────────────────────────────────────
+
+function configPath(repoPath: string): string {
+  return path.join(repoPath, ".git", "mc-hygiene.json");
+}
+
+export function loadConfig(repoPath: string): HygieneConfig {
+  const cfgFile = configPath(repoPath);
+  if (fs.existsSync(cfgFile)) {
+    try {
+      const raw = JSON.parse(fs.readFileSync(cfgFile, "utf-8"));
+      return { ...DEFAULT_HYGIENE_CONFIG, ...raw };
+    } catch {
+      return { ...DEFAULT_HYGIENE_CONFIG };
+    }
+  }
+  return { ...DEFAULT_HYGIENE_CONFIG };
+}
+
+export function saveConfig(repoPath: string, config: HygieneConfig): void {
+  fs.writeFileSync(configPath(repoPath), JSON.stringify(config, null, 2));
+}
+
+// ── Hook scripts ─────────────────────────────────────────────────────────────
+
+const HYGIENE_MARKER = "# mc-hygiene-hook";
+
+function preCommitScript(protectedBranches: string[]): string {
+  const branchList = protectedBranches.map(b => `"${b}"`).join(" ");
+  return `#!/bin/sh
+${HYGIENE_MARKER}
+# Block direct commits to protected branches — installed by mc-checkpoint hygiene
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+PROTECTED_BRANCHES=(${branchList})
+for pb in "\${PROTECTED_BRANCHES[@]}"; do
+  if [ "$BRANCH" = "$pb" ]; then
+    echo ""
+    echo "⚠️  mc-hygiene: Direct commit to protected branch '$BRANCH' is blocked."
+    echo "   Create a feature branch first: git checkout -b my-feature"
+    echo "   To bypass: git commit --no-verify"
+    echo ""
+    exit 1
+  fi
+done
+`;
+}
+
+function preMergeStashScript(): string {
+  return `#!/bin/sh
+${HYGIENE_MARKER}
+# Auto-stash dirty changes before merge — installed by mc-checkpoint hygiene
+if [ -n "$(git status --porcelain)" ]; then
+  echo "[mc-hygiene] Auto-stashing dirty changes before merge..."
+  git stash push -m "mc-hygiene: auto-stash before merge" 2>/dev/null
+  # Write marker so post-merge can pop
+  echo "1" > "$(git rev-parse --git-dir)/mc-hygiene-stashed"
+fi
+`;
+}
+
+function postMergePopScript(): string {
+  return `#!/bin/sh
+${HYGIENE_MARKER}
+# Auto-pop stash after merge — installed by mc-checkpoint hygiene
+STASH_MARKER="$(git rev-parse --git-dir)/mc-hygiene-stashed"
+if [ -f "$STASH_MARKER" ]; then
+  rm -f "$STASH_MARKER"
+  echo "[mc-hygiene] Restoring auto-stashed changes after merge..."
+  git stash pop 2>/dev/null || echo "[mc-hygiene] Warning: could not auto-pop stash. Run 'git stash pop' manually."
+fi
+`;
+}
+
+function preRebaseStashScript(): string {
+  return `#!/bin/sh
+${HYGIENE_MARKER}
+# Auto-stash dirty changes before rebase — installed by mc-checkpoint hygiene
+if [ -n "$(git status --porcelain)" ]; then
+  echo "[mc-hygiene] Auto-stashing dirty changes before rebase..."
+  git stash push -m "mc-hygiene: auto-stash before rebase" 2>/dev/null
+  echo "1" > "$(git rev-parse --git-dir)/mc-hygiene-stashed"
+fi
+`;
+}
+
+function postRewritePopScript(): string {
+  return `#!/bin/sh
+${HYGIENE_MARKER}
+# Auto-pop stash after rebase — installed by mc-checkpoint hygiene
+STASH_MARKER="$(git rev-parse --git-dir)/mc-hygiene-stashed"
+if [ -f "$STASH_MARKER" ]; then
+  rm -f "$STASH_MARKER"
+  echo "[mc-hygiene] Restoring auto-stashed changes after rebase..."
+  git stash pop 2>/dev/null || echo "[mc-hygiene] Warning: could not auto-pop stash. Run 'git stash pop' manually."
+fi
+`;
+}
+
+function postCheckoutWarnScript(): string {
+  return `#!/bin/sh
+${HYGIENE_MARKER}
+# Warn about dirty state after branch switch — installed by mc-checkpoint hygiene
+# post-checkout receives: prev_HEAD new_HEAD flag (flag=1 for branch switch)
+if [ "$3" = "1" ]; then
+  DIRTY=$(git status --porcelain 2>/dev/null)
+  if [ -n "$DIRTY" ]; then
+    COUNT=$(echo "$DIRTY" | wc -l | tr -d ' ')
+    echo ""
+    echo "⚠️  mc-hygiene: You have $COUNT uncommitted change(s) on this branch."
+    echo "   Run 'git stash' or commit before switching branches."
+    echo ""
+  fi
+fi
+`;
+}
+
+// ── Hook installation ────────────────────────────────────────────────────────
+
+function installHookScript(repoPath: string, hookName: string, script: string): boolean {
+  const hooksDir = path.join(repoPath, ".git", "hooks");
+  if (!fs.existsSync(hooksDir)) {
+    fs.mkdirSync(hooksDir, { recursive: true });
+  }
+
+  const hookPath = path.join(hooksDir, hookName);
+
+  if (fs.existsSync(hookPath)) {
+    const existing = fs.readFileSync(hookPath, "utf-8");
+    if (existing.includes(HYGIENE_MARKER)) {
+      return false; // Already installed
+    }
+    // Append to existing hook
+    fs.appendFileSync(hookPath, "\n" + script.split("\n").slice(1).join("\n"));
+  } else {
+    fs.writeFileSync(hookPath, script);
+  }
+
+  fs.chmodSync(hookPath, 0o755);
+  return true;
+}
+
+function removeHookScript(repoPath: string, hookName: string): boolean {
+  const hookPath = path.join(repoPath, ".git", "hooks", hookName);
+  if (!fs.existsSync(hookPath)) return false;
+
+  const content = fs.readFileSync(hookPath, "utf-8");
+  if (!content.includes(HYGIENE_MARKER)) return false;
+
+  const lines = content.split("\n");
+  const markerIdx = lines.findIndex(l => l.includes(HYGIENE_MARKER));
+  if (markerIdx <= 1) {
+    fs.unlinkSync(hookPath);
+  } else {
+    const before = lines.slice(0, markerIdx);
+    fs.writeFileSync(hookPath, before.join("\n"));
+    fs.chmodSync(hookPath, 0o755);
+  }
+  return true;
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+export interface HygieneStatus {
+  isGitRepo: boolean;
+  branch: string;
+  dirty: boolean;
+  stagedCount: number;
+  unstagedCount: number;
+  untrackedCount: number;
+  protectedBranch: boolean;
+  hooksInstalled: string[];
+  config: HygieneConfig;
+}
+
+export function getHygieneStatus(repoPath: string): HygieneStatus {
+  if (!isGitRepo(repoPath)) {
+    return {
+      isGitRepo: false, branch: "", dirty: false,
+      stagedCount: 0, unstagedCount: 0, untrackedCount: 0,
+      protectedBranch: false, hooksInstalled: [], config: DEFAULT_HYGIENE_CONFIG,
+    };
+  }
+
+  const config = loadConfig(repoPath);
+  const branch = (() => { try { return git(repoPath, ["rev-parse", "--abbrev-ref", "HEAD"]); } catch { return "unknown"; } })();
+  const porcelain = (() => { try { return git(repoPath, ["status", "--porcelain"]); } catch { return ""; } })();
+
+  let staged = 0, unstaged = 0, untracked = 0;
+  for (const line of porcelain.split("\n")) {
+    if (!line) continue;
+    const x = line[0], y = line[1];
+    if (x === "?") untracked++;
+    else {
+      if (x !== " " && x !== "?") staged++;
+      if (y !== " " && y !== "?") unstaged++;
+    }
+  }
+
+  const hooksDir = path.join(repoPath, ".git", "hooks");
+  const installed: string[] = [];
+  for (const hookName of ["pre-commit", "pre-merge-commit", "post-merge", "pre-rebase", "post-rewrite", "post-checkout"]) {
+    const hookPath = path.join(hooksDir, hookName);
+    if (fs.existsSync(hookPath)) {
+      const content = fs.readFileSync(hookPath, "utf-8");
+      if (content.includes(HYGIENE_MARKER)) installed.push(hookName);
+    }
+  }
+
+  return {
+    isGitRepo: true,
+    branch,
+    dirty: staged + unstaged + untracked > 0,
+    stagedCount: staged,
+    unstagedCount: unstaged,
+    untrackedCount: untracked,
+    protectedBranch: config.protectedBranches.includes(branch),
+    hooksInstalled: installed,
+    config,
+  };
+}
+
+export function installHygiene(repoPath: string): { installed: string[]; skipped: string[] } {
+  if (!isGitRepo(repoPath)) {
+    throw new Error(`Not a git repository: ${repoPath}`);
+  }
+
+  const config = loadConfig(repoPath);
+  saveConfig(repoPath, config); // Ensure config file exists
+
+  const installed: string[] = [];
+  const skipped: string[] = [];
+
+  const hooks: { name: string; script: string }[] = [
+    { name: "pre-commit", script: preCommitScript(config.protectedBranches) },
+    { name: "post-checkout", script: postCheckoutWarnScript() },
+  ];
+
+  if (config.autoStashOnMerge) {
+    hooks.push({ name: "pre-merge-commit", script: preMergeStashScript() });
+    hooks.push({ name: "post-merge", script: postMergePopScript() });
+  }
+
+  if (config.autoStashOnRebase) {
+    hooks.push({ name: "pre-rebase", script: preRebaseStashScript() });
+    hooks.push({ name: "post-rewrite", script: postRewritePopScript() });
+  }
+
+  for (const h of hooks) {
+    if (installHookScript(repoPath, h.name, h.script)) {
+      installed.push(h.name);
+    } else {
+      skipped.push(h.name);
+    }
+  }
+
+  return { installed, skipped };
+}
+
+export function removeHygiene(repoPath: string): { removed: string[] } {
+  const hookNames = ["pre-commit", "pre-merge-commit", "post-merge", "pre-rebase", "post-rewrite", "post-checkout"];
+  const removed: string[] = [];
+  for (const name of hookNames) {
+    if (removeHookScript(repoPath, name)) removed.push(name);
+  }
+  return { removed };
+}


### PR DESCRIPTION
## Summary
- Add git tree viewer panel to mc-board web chat UI (GitPanel component) with collapsible panel showing branch name, dirty indicator, changed files grouped by staged/unstaged/untracked, and commit log with graph
- Add REST endpoints (/git/status, /git/log, /git/branches, /git/diff) to mc-web-chat server with WebSocket git_subscribe/git_unsubscribe for real-time polling
- Add git hygiene enforcement to mc-checkpoint: protected branch pre-commit hooks, auto-stash on merge/rebase, dirty-state warnings on branch switch
- Add hygiene CLI commands (install/status/config/remove)

## Files changed
- `plugins/mc-board/web/src/components/git-panel.tsx` (new) — React git panel component
- `plugins/mc-board/web/src/components/chat-panel.tsx` — Import and render GitPanel
- `plugins/mc-checkpoint/src/hygiene.ts` (new) — Hygiene enforcement module
- `plugins/mc-checkpoint/cli/commands.ts` — Add hygiene subcommands
- `plugins/mc-web-chat/server.ts` — Git API endpoints (already on main via #486)

## Test plan
- [x] GET /git/status returns branch, dirty state, staged/unstaged/untracked files
- [x] GET /git/log returns commits with graph decoration
- [x] GET /git/branches returns local and remote branches
- [x] GET /git/diff returns diff output with truncation
- [x] Git panel renders in chat UI with collapsible state
- [x] WebSocket git_subscribe pushes status changes on 30s interval
- [x] `openclaw mc-checkpoint hygiene status` works
- [x] Error handling for missing repo and non-git dirs