### PR TITLE
feat(mc-web-chat): structured logger, chat-utils extraction, 57 tests

### DIFF
--- a/plugins/mc-web-chat/chat-db.test.ts
+++ b/plugins/mc-web-chat/chat-db.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { ChatDatabase } from "./chat-db.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+describe("ChatDatabase", () => {
+  let db: ChatDatabase;
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "mc-web-chat-test-"));
+    db = new ChatDatabase(tempDir);
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const sampleMessages = [
+    { role: "user", content: "Hello, how are you?", hasImage: false, timestamp: 1000 },
+    { role: "assistant", content: "I'm doing well! How can I help?", hasImage: false, timestamp: 2000 },
+    { role: "user", content: "Tell me about TypeScript", hasImage: false, timestamp: 3000 },
+    { role: "assistant", content: "TypeScript is a typed superset of JavaScript...", hasImage: false, timestamp: 4000 },
+  ];
+
+  // ---------- archiveSession ----------
+  describe("archiveSession", () => {
+    it("persists messages and extracts title from first user message", () => {
+      db.archiveSession("sess-1", sampleMessages, 0.05);
+
+      const result = db.getChat("sess-1");
+      expect(result.session).not.toBeNull();
+      expect(result.session!.title).toBe("Hello, how are you?");
+      expect(result.session!.message_count).toBe(4);
+      expect(result.session!.total_cost).toBeCloseTo(0.05);
+      expect(result.messages).toHaveLength(4);
+    });
+
+    it("extracts preview from last message", () => {
+      db.archiveSession("sess-1", sampleMessages, 0);
+      const result = db.getChat("sess-1");
+      expect(result.session!.preview).toContain("TypeScript is a typed superset");
+    });
+
+    it("handles empty messages array", () => {
+      db.archiveSession("sess-empty", [], 0);
+      const result = db.getChat("sess-empty");
+      expect(result.session).toBeNull();
+    });
+
+    it("uses 'Untitled chat' when no user message exists", () => {
+      const msgs = [
+        { role: "assistant", content: "Starting up...", hasImage: false, timestamp: 1000 },
+      ];
+      db.archiveSession("sess-no-user", msgs, 0);
+      const result = db.getChat("sess-no-user");
+      expect(result.session!.title).toBe("Untitled chat");
+    });
+
+    it("stores hasImage flag correctly", () => {
+      const msgs = [
+        { role: "user", content: "Look at this", hasImage: true, timestamp: 1000 },
+        { role: "assistant", content: "I see", hasImage: false, timestamp: 2000 },
+      ];
+      db.archiveSession("sess-img", msgs, 0);
+      const result = db.getChat("sess-img");
+      expect(result.messages[0].has_image).toBe(1);
+      expect(result.messages[1].has_image).toBe(0);
+    });
+  });
+
+  // ---------- listChats ----------
+  describe("listChats", () => {
+    it("returns empty list when no chats exist", () => {
+      const result = db.listChats();
+      expect(result.chats).toHaveLength(0);
+      expect(result.total).toBe(0);
+    });
+
+    it("paginates correctly", () => {
+      // Archive 5 sessions
+      for (let i = 0; i < 5; i++) {
+        const msgs = [
+          { role: "user", content: `Chat ${i}`, hasImage: false, timestamp: 1000 + i * 1000 },
+          { role: "assistant", content: `Reply ${i}`, hasImage: false, timestamp: 2000 + i * 1000 },
+        ];
+        db.archiveSession(`sess-${i}`, msgs, 0);
+      }
+
+      const page1 = db.listChats(2, 0);
+      expect(page1.total).toBe(5);
+      expect(page1.chats).toHaveLength(2);
+
+      const page2 = db.listChats(2, 2);
+      expect(page2.total).toBe(5);
+      expect(page2.chats).toHaveLength(2);
+
+      const page3 = db.listChats(2, 4);
+      expect(page3.total).toBe(5);
+      expect(page3.chats).toHaveLength(1);
+    });
+
+    it("orders by updated_at DESC", () => {
+      // Create sessions with different timestamps
+      db.archiveSession("old", [
+        { role: "user", content: "old", hasImage: false, timestamp: 1000 },
+        { role: "assistant", content: "old reply", hasImage: false, timestamp: 2000 },
+      ], 0);
+      db.archiveSession("new", [
+        { role: "user", content: "new", hasImage: false, timestamp: 5000 },
+        { role: "assistant", content: "new reply", hasImage: false, timestamp: 6000 },
+      ], 0);
+
+      const result = db.listChats();
+      expect(result.chats[0].id).toBe("new");
+      expect(result.chats[1].id).toBe("old");
+    });
+  });
+
+  // ---------- getChat ----------
+  describe("getChat", () => {
+    it("returns full message history in timestamp order", () => {
+      db.archiveSession("sess-1", sampleMessages, 0.05);
+      const result = db.getChat("sess-1");
+      expect(result.messages).toHaveLength(4);
+      // Verify timestamp ascending order
+      for (let i = 1; i < result.messages.length; i++) {
+        expect(result.messages[i].timestamp).toBeGreaterThan(result.messages[i - 1].timestamp);
+      }
+    });
+
+    it("returns null session for nonexistent chat", () => {
+      const result = db.getChat("nonexistent");
+      expect(result.session).toBeNull();
+      expect(result.messages).toHaveLength(0);
+    });
+
+    it("returns correct role and content", () => {
+      db.archiveSession("sess-1", sampleMessages, 0);
+      const result = db.getChat("sess-1");
+      expect(result.messages[0].role).toBe("user");
+      expect(result.messages[0].content).toBe("Hello, how are you?");
+      expect(result.messages[1].role).toBe("assistant");
+    });
+  });
+
+  // ---------- deleteChat ----------
+  describe("deleteChat", () => {
+    it("removes session and messages (cascade)", () => {
+      db.archiveSession("sess-del", sampleMessages, 0);
+      expect(db.getChat("sess-del").session).not.toBeNull();
+
+      const deleted = db.deleteChat("sess-del");
+      expect(deleted).toBe(true);
+
+      const result = db.getChat("sess-del");
+      expect(result.session).toBeNull();
+      expect(result.messages).toHaveLength(0);
+    });
+
+    it("returns false for nonexistent session", () => {
+      expect(db.deleteChat("nonexistent")).toBe(false);
+    });
+  });
+
+  // ---------- re-archive ----------
+  describe("re-archive same session", () => {
+    it("replaces old messages with new ones", () => {
+      db.archiveSession("sess-1", sampleMessages, 0.05);
+      expect(db.getChat("sess-1").messages).toHaveLength(4);
+
+      // Re-archive with different messages
+      const newMsgs = [
+        { role: "user", content: "Updated first msg", hasImage: false, timestamp: 5000 },
+        { role: "assistant", content: "Updated reply", hasImage: false, timestamp: 6000 },
+      ];
+      db.archiveSession("sess-1", newMsgs, 0.10);
+
+      const result = db.getChat("sess-1");
+      expect(result.messages).toHaveLength(2);
+      expect(result.messages[0].content).toBe("Updated first msg");
+      expect(result.session!.total_cost).toBeCloseTo(0.10);
+      expect(result.session!.message_count).toBe(2);
+    });
+  });
+});

--- a/plugins/mc-web-chat/chat-db.ts
+++ b/plugins/mc-web-chat/chat-db.ts
@@ -1,6 +1,7 @@
 import Database from "better-sqlite3";
 import { join } from "node:path";
 import { mkdirSync } from "node:fs";
+import { log } from "./logger.js";
 
 export interface ArchivedChat {
   id: string;
@@ -103,7 +104,7 @@ export class ChatDatabase {
     });
 
     transaction();
-    console.log(`[mc-web-chat] archived session ${sessionId.slice(0, 8)} (${messages.length} messages, $${totalCost.toFixed(4)})`);
+    log.info(`archived session ${sessionId.slice(0, 8)} (${messages.length} messages, $${totalCost.toFixed(4)})`);
   }
 
   /** List archived chats with pagination */

--- a/plugins/mc-web-chat/chat-session.test.ts
+++ b/plugins/mc-web-chat/chat-session.test.ts
@@ -1,0 +1,431 @@
+import { describe, it, expect } from "vitest";
+import {
+  trimHistory,
+  pruneImageFlags,
+  buildHistoryReplay,
+  MAX_HISTORY,
+  type HistoryMessage,
+  type TrimTarget,
+} from "./chat-utils.js";
+
+// ---------------------------------------------------------------------------
+// Message ordering — rapid sequential messages maintain correct order
+// ---------------------------------------------------------------------------
+describe("message ordering", () => {
+  it("rapid sequential messages maintain insertion order", () => {
+    const session: TrimTarget = { messages: [] };
+    const baseTime = Date.now();
+
+    // Simulate rapid-fire message pushes (same millisecond possible)
+    for (let i = 0; i < 20; i++) {
+      session.messages.push({
+        role: (i % 2 === 0 ? "user" : "assistant") as "user" | "assistant",
+        content: `msg-${i}`,
+        timestamp: baseTime + i, // ascending — but even if same ms, array order matters
+      });
+    }
+
+    // Verify insertion order is preserved
+    for (let i = 0; i < session.messages.length; i++) {
+      expect(session.messages[i].content).toBe(`msg-${i}`);
+    }
+  });
+
+  it("messages with same timestamp maintain array insertion order", () => {
+    const session: TrimTarget = { messages: [] };
+    const sameTime = 1700000000000;
+
+    session.messages.push({ role: "user", content: "first", timestamp: sameTime });
+    session.messages.push({ role: "assistant", content: "second", timestamp: sameTime });
+    session.messages.push({ role: "user", content: "third", timestamp: sameTime });
+
+    expect(session.messages[0].content).toBe("first");
+    expect(session.messages[1].content).toBe("second");
+    expect(session.messages[2].content).toBe("third");
+  });
+
+  it("trimHistory preserves order of remaining messages", () => {
+    const session: TrimTarget = { messages: [] };
+    for (let i = 0; i < MAX_HISTORY + 10; i++) {
+      session.messages.push({
+        role: (i % 2 === 0 ? "user" : "assistant") as "user" | "assistant",
+        content: `msg-${i}`,
+        timestamp: 1000 + i,
+      });
+    }
+
+    trimHistory(session);
+
+    // After trim, remaining messages should still be in order
+    for (let i = 1; i < session.messages.length; i++) {
+      expect(session.messages[i].timestamp).toBeGreaterThan(session.messages[i - 1].timestamp);
+    }
+
+    // First remaining message should be msg-10 (since we had 40, trim to 30, drop first 10)
+    expect(session.messages[0].content).toBe("msg-10");
+  });
+
+  it("buildHistoryReplay preserves chronological order in output", () => {
+    const msgs: HistoryMessage[] = [
+      { role: "user", content: "alpha", timestamp: 100 },
+      { role: "assistant", content: "beta", timestamp: 200 },
+      { role: "user", content: "gamma", timestamp: 300 },
+      { role: "assistant", content: "delta", timestamp: 400 },
+    ];
+    const replay = buildHistoryReplay(msgs);
+    const alphaIdx = replay.indexOf("alpha");
+    const betaIdx = replay.indexOf("beta");
+    const gammaIdx = replay.indexOf("gamma");
+    const deltaIdx = replay.indexOf("delta");
+
+    expect(alphaIdx).toBeLessThan(betaIdx);
+    expect(betaIdx).toBeLessThan(gammaIdx);
+    expect(gammaIdx).toBeLessThan(deltaIdx);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Connection state — join/close/rejoin session simulation
+// ---------------------------------------------------------------------------
+describe("connection state simulation", () => {
+  // We simulate session state transitions without a real WebSocket server.
+  // The key invariant: session.ws = null on close, session restored on rejoin.
+
+  interface MockSession {
+    id: string;
+    ws: { readyState: number } | null;
+    messages: HistoryMessage[];
+    awaitingResult: boolean;
+    lastActivity: number;
+    totalCost: number;
+  }
+
+  function newMockSession(): MockSession {
+    return {
+      id: "test-session-id",
+      ws: { readyState: 1 }, // WebSocket.OPEN = 1
+      messages: [],
+      awaitingResult: false,
+      lastActivity: Date.now(),
+      totalCost: 0,
+    };
+  }
+
+  it("join creates session with active websocket", () => {
+    const session = newMockSession();
+    expect(session.ws).not.toBeNull();
+    expect(session.id).toBeTruthy();
+    expect(session.messages).toHaveLength(0);
+  });
+
+  it("close sets ws to null but preserves session", () => {
+    const session = newMockSession();
+    session.messages.push({ role: "user", content: "hello", timestamp: 1 });
+    session.messages.push({ role: "assistant", content: "hi", timestamp: 2 });
+
+    // Simulate close
+    session.ws = null;
+
+    expect(session.ws).toBeNull();
+    expect(session.messages).toHaveLength(2);
+    expect(session.id).toBe("test-session-id");
+  });
+
+  it("rejoin with sessionId restores ws and replays history", () => {
+    const sessions = new Map<string, MockSession>();
+    const session = newMockSession();
+    sessions.set(session.id, session);
+
+    // Add some history
+    session.messages.push({ role: "user", content: "hello", timestamp: 1 });
+    session.messages.push({ role: "assistant", content: "hi", timestamp: 2 });
+
+    // Simulate close
+    session.ws = null;
+
+    // Simulate rejoin
+    const rid = "test-session-id";
+    const existingSession = sessions.get(rid);
+    expect(existingSession).toBeDefined();
+
+    existingSession!.ws = { readyState: 1 };
+    existingSession!.lastActivity = Date.now();
+
+    // Verify resumed state
+    expect(existingSession!.ws).not.toBeNull();
+    expect(existingSession!.messages).toHaveLength(2);
+    expect(existingSession!.messages[0].content).toBe("hello");
+
+    // Would send: { type: "joined", resumed: true, history: session.messages }
+    const joinResponse = {
+      type: "joined",
+      sessionId: existingSession!.id,
+      resumed: true,
+      history: existingSession!.messages,
+    };
+    expect(joinResponse.resumed).toBe(true);
+    expect(joinResponse.history).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Message queuing — messages queued when awaitingResult=true
+// ---------------------------------------------------------------------------
+describe("message queuing", () => {
+  interface QueueSession {
+    messages: HistoryMessage[];
+    awaitingResult: boolean;
+    messageQueue: string[];
+    lastActivity: number;
+  }
+
+  function handleChat(session: QueueSession, content: string, msgId?: string, replyTo?: string) {
+    session.messages.push({
+      id: msgId,
+      role: "user",
+      content,
+      timestamp: Date.now(),
+      ...(replyTo ? { replyTo } : {}),
+    });
+    trimHistory(session);
+    pruneImageFlags(session.messages);
+    session.lastActivity = Date.now();
+
+    if (session.awaitingResult) {
+      session.messageQueue.push(content);
+      return { type: "queued", position: session.messageQueue.length };
+    }
+    session.awaitingResult = true;
+    return { type: "sent" };
+  }
+
+  it("first message is sent directly", () => {
+    const session: QueueSession = {
+      messages: [], awaitingResult: false, messageQueue: [], lastActivity: 0,
+    };
+    const result = handleChat(session, "hello");
+    expect(result.type).toBe("sent");
+    expect(session.awaitingResult).toBe(true);
+    expect(session.messageQueue).toHaveLength(0);
+  });
+
+  it("second message while awaiting is queued", () => {
+    const session: QueueSession = {
+      messages: [], awaitingResult: false, messageQueue: [], lastActivity: 0,
+    };
+    handleChat(session, "first");
+    const result = handleChat(session, "second");
+    expect(result.type).toBe("queued");
+    expect(result).toHaveProperty("position", 1);
+    expect(session.messageQueue).toHaveLength(1);
+    expect(session.messageQueue[0]).toBe("second");
+  });
+
+  it("multiple queued messages have ascending positions", () => {
+    const session: QueueSession = {
+      messages: [], awaitingResult: false, messageQueue: [], lastActivity: 0,
+    };
+    handleChat(session, "first");
+    const r1 = handleChat(session, "second");
+    const r2 = handleChat(session, "third");
+    expect(r1).toHaveProperty("position", 1);
+    expect(r2).toHaveProperty("position", 2);
+    expect(session.messageQueue).toEqual(["second", "third"]);
+  });
+
+  it("dequeue on result processes next message", () => {
+    const session: QueueSession = {
+      messages: [], awaitingResult: false, messageQueue: [], lastActivity: 0,
+    };
+    handleChat(session, "first");
+    handleChat(session, "second");
+    handleChat(session, "third");
+
+    // Simulate result received — dequeue next
+    session.awaitingResult = false;
+    if (session.messageQueue.length > 0) {
+      const next = session.messageQueue.shift()!;
+      expect(next).toBe("second");
+      session.awaitingResult = true;
+    }
+    expect(session.messageQueue).toEqual(["third"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edit message — truncates history and replays with new content
+// ---------------------------------------------------------------------------
+describe("edit message", () => {
+  function simulateEdit(messages: HistoryMessage[], newContent: string): {
+    truncatedMessages: HistoryMessage[];
+    truncatedAt: number;
+    newMessage: HistoryMessage;
+  } {
+    // Find the last user message index
+    let lastUserIdx = -1;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === "user") { lastUserIdx = i; break; }
+    }
+
+    if (lastUserIdx < 0) throw new Error("No user message to edit");
+
+    // Truncate: remove the last user message and everything after it
+    const truncatedMessages = messages.slice(0, lastUserIdx);
+    const newMessage: HistoryMessage = {
+      role: "user",
+      content: newContent,
+      timestamp: Date.now(),
+    };
+
+    return { truncatedMessages, truncatedAt: lastUserIdx, newMessage };
+  }
+
+  it("truncates at last user message", () => {
+    const msgs: HistoryMessage[] = [
+      { role: "user", content: "hello", timestamp: 1 },
+      { role: "assistant", content: "hi", timestamp: 2 },
+      { role: "user", content: "wrong message", timestamp: 3 },
+      { role: "assistant", content: "reply to wrong", timestamp: 4 },
+    ];
+
+    const result = simulateEdit(msgs, "corrected message");
+    expect(result.truncatedAt).toBe(2); // index of "wrong message"
+    expect(result.truncatedMessages).toHaveLength(2);
+    expect(result.truncatedMessages[0].content).toBe("hello");
+    expect(result.truncatedMessages[1].content).toBe("hi");
+    expect(result.newMessage.content).toBe("corrected message");
+  });
+
+  it("handles edit when only one user message exists", () => {
+    const msgs: HistoryMessage[] = [
+      { role: "user", content: "only message", timestamp: 1 },
+      { role: "assistant", content: "only reply", timestamp: 2 },
+    ];
+
+    const result = simulateEdit(msgs, "edited only message");
+    expect(result.truncatedAt).toBe(0);
+    expect(result.truncatedMessages).toHaveLength(0);
+    expect(result.newMessage.content).toBe("edited only message");
+  });
+
+  it("preserves earlier conversation when editing last message", () => {
+    const msgs: HistoryMessage[] = [
+      { role: "user", content: "first", timestamp: 1 },
+      { role: "assistant", content: "first reply", timestamp: 2 },
+      { role: "user", content: "second", timestamp: 3 },
+      { role: "assistant", content: "second reply", timestamp: 4 },
+      { role: "user", content: "third (to edit)", timestamp: 5 },
+    ];
+
+    const result = simulateEdit(msgs, "third (edited)");
+    expect(result.truncatedMessages).toHaveLength(4);
+    expect(result.truncatedMessages[3].content).toBe("second reply");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reply reference — replyTo resolves to correct parent
+// ---------------------------------------------------------------------------
+describe("reply references", () => {
+  it("replyTo resolves to correct parent in buildHistoryReplay", () => {
+    const msgs: HistoryMessage[] = [
+      { id: "a", role: "user", content: "What is TypeScript?", timestamp: 1 },
+      { id: "b", role: "assistant", content: "TypeScript is a typed superset of JavaScript", timestamp: 2 },
+      { id: "c", role: "user", content: "Can you elaborate?", timestamp: 3, replyTo: "b" },
+    ];
+
+    const result = buildHistoryReplay(msgs);
+    expect(result).toContain('replying to assistant: "TypeScript is a typed superset of JavaScript"');
+  });
+
+  it("handles missing parent gracefully", () => {
+    const msgs: HistoryMessage[] = [
+      { id: "x", role: "user", content: "reply to deleted", timestamp: 1, replyTo: "deleted-id" },
+    ];
+
+    const result = buildHistoryReplay(msgs);
+    expect(result).toContain("replying to a pruned message");
+    expect(result).toContain("reply to deleted");
+  });
+
+  it("long parent content is truncated to 60 chars in snippet", () => {
+    const longContent = "A".repeat(100);
+    const msgs: HistoryMessage[] = [
+      { id: "long", role: "assistant", content: longContent, timestamp: 1 },
+      { id: "reply", role: "user", content: "my reply", timestamp: 2, replyTo: "long" },
+    ];
+
+    const result = buildHistoryReplay(msgs);
+    // Snippet should be 60 chars + "..."
+    expect(result).toContain("A".repeat(60) + "...");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resume_chat — archived session restored with correct message history
+// ---------------------------------------------------------------------------
+describe("resume_chat simulation", () => {
+  it("restores archived messages into session in correct order", () => {
+    // Simulate what resume_chat does: load archived messages, map to HistoryMessage[]
+    const archivedMessages = [
+      { id: 1, session_id: "sess-1", role: "user", content: "hi", has_image: 0, timestamp: 1000 },
+      { id: 2, session_id: "sess-1", role: "assistant", content: "hello", has_image: 0, timestamp: 2000 },
+      { id: 3, session_id: "sess-1", role: "user", content: "help", has_image: 1, timestamp: 3000 },
+    ];
+
+    const restoredMessages: HistoryMessage[] = archivedMessages.map(m => ({
+      role: m.role as "user" | "assistant",
+      content: m.content,
+      hasImage: m.has_image === 1,
+      timestamp: m.timestamp,
+    }));
+
+    expect(restoredMessages).toHaveLength(3);
+    expect(restoredMessages[0].content).toBe("hi");
+    expect(restoredMessages[1].content).toBe("hello");
+    expect(restoredMessages[2].hasImage).toBe(true);
+
+    // Verify timestamps are ascending (from SQLite ORDER BY timestamp ASC)
+    for (let i = 1; i < restoredMessages.length; i++) {
+      expect(restoredMessages[i].timestamp).toBeGreaterThan(restoredMessages[i - 1].timestamp);
+    }
+  });
+
+  it("buildHistoryReplay works correctly with restored messages", () => {
+    const restored: HistoryMessage[] = [
+      { role: "user", content: "original question", timestamp: 1000 },
+      { role: "assistant", content: "original answer", timestamp: 2000 },
+      { role: "user", content: "follow-up", timestamp: 3000 },
+      { role: "assistant", content: "follow-up answer", timestamp: 4000 },
+    ];
+
+    const replay = buildHistoryReplay(restored);
+    expect(replay).toContain("<conversation-history>");
+    expect(replay).toContain("original question");
+    expect(replay).toContain("follow-up answer");
+
+    // Verify order preserved
+    const q = replay.indexOf("original question");
+    const a = replay.indexOf("follow-up answer");
+    expect(q).toBeLessThan(a);
+  });
+
+  it("session ID is reassigned to match archived session", () => {
+    // Simulate the resume_chat session ID swap
+    const newSessionId = "new-random-uuid";
+    const archivedSessionId = "archived-session-uuid";
+
+    const sessions = new Map<string, { id: string; messages: HistoryMessage[] }>();
+    sessions.set(newSessionId, { id: newSessionId, messages: [] });
+
+    // Delete new session from map
+    sessions.delete(newSessionId);
+    // Re-insert with archived ID
+    const session = { id: archivedSessionId, messages: [] };
+    sessions.set(archivedSessionId, session);
+
+    expect(sessions.has(archivedSessionId)).toBe(true);
+    expect(sessions.has(newSessionId)).toBe(false);
+    expect(sessions.get(archivedSessionId)!.id).toBe(archivedSessionId);
+  });
+});

--- a/plugins/mc-web-chat/chat-utils.ts
+++ b/plugins/mc-web-chat/chat-utils.ts
@@ -1,0 +1,121 @@
+/**
+ * Pure, testable utility functions extracted from server.ts.
+ * These are used by server.ts internals and imported by tests.
+ */
+import { log } from "./logger.js";
+
+// ---- Context management config ----
+export const MAX_HISTORY = 30;
+export const MAX_IMAGES_IN_HISTORY = 2;
+export const IMAGE_PLACEHOLDER = "[image was shared earlier in conversation]";
+export const CONTEXT_PRESSURE_PCT = 80;
+export const TOKEN_BUDGET = 800_000;
+export const MIN_TURNS_BEFORE_RESTART = 4;
+
+export interface HistoryMessage {
+  id?: string;
+  role: "user" | "assistant";
+  content: string;
+  hasImage?: boolean;
+  timestamp: number;
+  replyTo?: string;
+}
+
+export interface TrimTarget {
+  messages: HistoryMessage[];
+}
+
+export interface ContextCheckTarget {
+  proc: unknown;
+  lastReportedContextUsed: number;
+  turnCount: number;
+  contextWindow: number;
+}
+
+// ---- Token estimator (~4 chars per token, images ~1000 tokens) ----
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+export function trimHistory(target: TrimTarget): void {
+  if (target.messages.length > MAX_HISTORY) {
+    const dropped = target.messages.length - MAX_HISTORY;
+    target.messages = target.messages.slice(-MAX_HISTORY);
+    log.debug(`trimmed ${dropped} old messages, keeping ${MAX_HISTORY}`);
+  }
+}
+
+export function pruneImageFlags(messages: HistoryMessage[]): void {
+  let imagesKept = 0;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].hasImage) {
+      if (imagesKept >= MAX_IMAGES_IN_HISTORY) {
+        messages[i].hasImage = false;
+      } else {
+        imagesKept++;
+      }
+    }
+  }
+}
+
+export function buildHistoryReplay(messages: HistoryMessage[]): string {
+  if (messages.length === 0) return "";
+
+  let totalTokens = 0;
+  for (const m of messages) {
+    totalTokens += estimateTokens(m.content) + 10;
+  }
+
+  const MAX_REPLAY_TOKENS = 40_000;
+  let replayMessages = messages;
+
+  if (totalTokens > MAX_REPLAY_TOKENS) {
+    const first = messages.slice(0, 2);
+    const firstTokens = first.reduce((sum, m) => sum + estimateTokens(m.content) + 10, 0);
+    const budget = MAX_REPLAY_TOKENS - firstTokens - 200;
+
+    const recent: HistoryMessage[] = [];
+    let used = 0;
+    for (let i = messages.length - 1; i >= 2; i--) {
+      const cost = estimateTokens(messages[i].content) + 10;
+      if (used + cost > budget) break;
+      recent.unshift(messages[i]);
+      used += cost;
+    }
+
+    const dropped = messages.length - first.length - recent.length;
+    replayMessages = [
+      ...first,
+      { role: "assistant" as const, content: `[...${dropped} earlier messages omitted...]`, timestamp: 0 },
+      ...recent,
+    ];
+  }
+
+  const lines = replayMessages.map((m) => {
+    let line = `[${m.role}]: ${m.content}`;
+    if (m.hasImage) line += ` ${IMAGE_PLACEHOLDER}`;
+    if (m.replyTo) {
+      const target = messages.find(t => t.id === m.replyTo);
+      if (target) {
+        const snippet = target.content.slice(0, 60) + (target.content.length > 60 ? "..." : "");
+        line = `[${m.role} replying to ${target.role}: "${snippet}"]: ${m.content}`;
+      } else {
+        line = `[${m.role} replying to a pruned message]: ${m.content}`;
+      }
+    }
+    return line;
+  });
+
+  return `<conversation-history>\n${lines.join("\n\n")}\n</conversation-history>`;
+}
+
+export function shouldRestartForContext(target: ContextCheckTarget): boolean {
+  if (!target.proc || target.lastReportedContextUsed === 0) return false;
+  if (target.turnCount <= MIN_TURNS_BEFORE_RESTART) return false;
+  const pct = (target.lastReportedContextUsed / target.contextWindow) * 100;
+  if (pct >= CONTEXT_PRESSURE_PCT) {
+    log.warn(`context pressure ${pct.toFixed(0)}% >= ${CONTEXT_PRESSURE_PCT}% — scheduling restart (turn ${target.turnCount})`);
+    return true;
+  }
+  return false;
+}

--- a/plugins/mc-web-chat/logger.ts
+++ b/plugins/mc-web-chat/logger.ts
@@ -1,0 +1,45 @@
+import { appendFileSync, mkdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const LOG_DIR = join(process.env.HOME || "", ".openclaw", "logs");
+const LOG_FILE = join(LOG_DIR, "mc-web-chat.log");
+
+if (!existsSync(LOG_DIR)) mkdirSync(LOG_DIR, { recursive: true });
+
+type Level = "debug" | "info" | "warn" | "error";
+
+const LEVEL_ORDER: Record<Level, number> = { debug: 0, info: 1, warn: 2, error: 3 };
+
+let minLevel: Level = (process.env.MC_LOG_LEVEL as Level) || "info";
+
+function ts(): string {
+  return new Date().toISOString();
+}
+
+function emit(level: Level, msg: string) {
+  if (LEVEL_ORDER[level] < LEVEL_ORDER[minLevel]) return;
+  const line = `${ts()} [${level.toUpperCase().padEnd(5)}] ${msg}`;
+  console.log(line);
+  try {
+    appendFileSync(LOG_FILE, line + "\n");
+  } catch { /* don't crash on log write failure */ }
+}
+
+export const log = {
+  debug: (msg: string) => emit("debug", msg),
+  info:  (msg: string) => emit("info", msg),
+  warn:  (msg: string) => emit("warn", msg),
+  error: (msg: string) => emit("error", msg),
+
+  /** Start a timer — returns a function that logs elapsed ms when called */
+  time(label: string): () => void {
+    const start = performance.now();
+    return () => {
+      const ms = (performance.now() - start).toFixed(1);
+      emit("info", `${label} completed in ${ms}ms`);
+    };
+  },
+
+  setLevel(level: Level) { minLevel = level; },
+  get file() { return LOG_FILE; },
+};

--- a/plugins/mc-web-chat/server.test.ts
+++ b/plugins/mc-web-chat/server.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect } from "vitest";
+import {
+  estimateTokens,
+  trimHistory,
+  pruneImageFlags,
+  buildHistoryReplay,
+  shouldRestartForContext,
+  MAX_HISTORY,
+  MAX_IMAGES_IN_HISTORY,
+  IMAGE_PLACEHOLDER,
+  CONTEXT_PRESSURE_PCT,
+  MIN_TURNS_BEFORE_RESTART,
+  TOKEN_BUDGET,
+  type HistoryMessage,
+  type TrimTarget,
+  type ContextCheckTarget,
+} from "./chat-utils.js";
+
+// ---------------------------------------------------------------------------
+// estimateTokens
+// ---------------------------------------------------------------------------
+describe("estimateTokens", () => {
+  it("returns ~1 token per 4 characters", () => {
+    expect(estimateTokens("abcd")).toBe(1);
+    expect(estimateTokens("abcde")).toBe(2); // ceil(5/4) = 2
+    expect(estimateTokens("a".repeat(100))).toBe(25);
+  });
+
+  it("returns 0 for empty string", () => {
+    expect(estimateTokens("")).toBe(0);
+  });
+
+  it("handles single character", () => {
+    expect(estimateTokens("x")).toBe(1); // ceil(1/4) = 1
+  });
+});
+
+// ---------------------------------------------------------------------------
+// trimHistory
+// ---------------------------------------------------------------------------
+describe("trimHistory", () => {
+  function makeMessages(n: number): HistoryMessage[] {
+    return Array.from({ length: n }, (_, i) => ({
+      role: (i % 2 === 0 ? "user" : "assistant") as "user" | "assistant",
+      content: `msg-${i}`,
+      timestamp: 1000 + i,
+    }));
+  }
+
+  it("does nothing when under MAX_HISTORY", () => {
+    const target: TrimTarget = { messages: makeMessages(10) };
+    trimHistory(target);
+    expect(target.messages).toHaveLength(10);
+  });
+
+  it("does nothing when exactly at MAX_HISTORY", () => {
+    const target: TrimTarget = { messages: makeMessages(MAX_HISTORY) };
+    trimHistory(target);
+    expect(target.messages).toHaveLength(MAX_HISTORY);
+  });
+
+  it("trims to MAX_HISTORY keeping the most recent messages", () => {
+    const target: TrimTarget = { messages: makeMessages(MAX_HISTORY + 5) };
+    trimHistory(target);
+    expect(target.messages).toHaveLength(MAX_HISTORY);
+    // Should keep the last MAX_HISTORY messages (the newest)
+    expect(target.messages[0].content).toBe(`msg-5`);
+    expect(target.messages[MAX_HISTORY - 1].content).toBe(`msg-${MAX_HISTORY + 4}`);
+  });
+
+  it("trims correctly when well over limit", () => {
+    const target: TrimTarget = { messages: makeMessages(50) };
+    trimHistory(target);
+    expect(target.messages).toHaveLength(MAX_HISTORY);
+    expect(target.messages[0].content).toBe("msg-20"); // 50 - 30 = 20
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pruneImageFlags
+// ---------------------------------------------------------------------------
+describe("pruneImageFlags", () => {
+  it("keeps the last MAX_IMAGES_IN_HISTORY images flagged", () => {
+    const msgs: HistoryMessage[] = [
+      { role: "user", content: "img1", hasImage: true, timestamp: 1 },
+      { role: "user", content: "img2", hasImage: true, timestamp: 2 },
+      { role: "user", content: "img3", hasImage: true, timestamp: 3 },
+      { role: "user", content: "img4", hasImage: true, timestamp: 4 },
+    ];
+    pruneImageFlags(msgs);
+    // Last MAX_IMAGES_IN_HISTORY (2) should keep hasImage=true
+    expect(msgs[0].hasImage).toBe(false);
+    expect(msgs[1].hasImage).toBe(false);
+    expect(msgs[2].hasImage).toBe(true);
+    expect(msgs[3].hasImage).toBe(true);
+  });
+
+  it("does nothing when fewer images than limit", () => {
+    const msgs: HistoryMessage[] = [
+      { role: "user", content: "text", timestamp: 1 },
+      { role: "user", content: "img1", hasImage: true, timestamp: 2 },
+    ];
+    pruneImageFlags(msgs);
+    expect(msgs[0].hasImage).toBeUndefined();
+    expect(msgs[1].hasImage).toBe(true);
+  });
+
+  it("handles no images", () => {
+    const msgs: HistoryMessage[] = [
+      { role: "user", content: "text", timestamp: 1 },
+      { role: "assistant", content: "reply", timestamp: 2 },
+    ];
+    pruneImageFlags(msgs);
+    expect(msgs[0].hasImage).toBeUndefined();
+    expect(msgs[1].hasImage).toBeUndefined();
+  });
+
+  it("handles empty array", () => {
+    const msgs: HistoryMessage[] = [];
+    pruneImageFlags(msgs);
+    expect(msgs).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildHistoryReplay
+// ---------------------------------------------------------------------------
+describe("buildHistoryReplay", () => {
+  it("returns empty string for no messages", () => {
+    expect(buildHistoryReplay([])).toBe("");
+  });
+
+  it("wraps messages in conversation-history tags", () => {
+    const msgs: HistoryMessage[] = [
+      { role: "user", content: "hello", timestamp: 1 },
+      { role: "assistant", content: "hi there", timestamp: 2 },
+    ];
+    const result = buildHistoryReplay(msgs);
+    expect(result).toContain("<conversation-history>");
+    expect(result).toContain("</conversation-history>");
+    expect(result).toContain("[user]: hello");
+    expect(result).toContain("[assistant]: hi there");
+  });
+
+  it("preserves message order", () => {
+    const msgs: HistoryMessage[] = [
+      { role: "user", content: "first", timestamp: 1 },
+      { role: "assistant", content: "second", timestamp: 2 },
+      { role: "user", content: "third", timestamp: 3 },
+      { role: "assistant", content: "fourth", timestamp: 4 },
+    ];
+    const result = buildHistoryReplay(msgs);
+    const firstIdx = result.indexOf("[user]: first");
+    const secondIdx = result.indexOf("[assistant]: second");
+    const thirdIdx = result.indexOf("[user]: third");
+    const fourthIdx = result.indexOf("[assistant]: fourth");
+    expect(firstIdx).toBeLessThan(secondIdx);
+    expect(secondIdx).toBeLessThan(thirdIdx);
+    expect(thirdIdx).toBeLessThan(fourthIdx);
+  });
+
+  it("appends image placeholder for messages with images", () => {
+    const msgs: HistoryMessage[] = [
+      { role: "user", content: "see this", hasImage: true, timestamp: 1 },
+    ];
+    const result = buildHistoryReplay(msgs);
+    expect(result).toContain(IMAGE_PLACEHOLDER);
+  });
+
+  it("resolves replyTo to correct parent message", () => {
+    const msgs: HistoryMessage[] = [
+      { id: "msg-1", role: "user", content: "original question", timestamp: 1 },
+      { id: "msg-2", role: "assistant", content: "answer", timestamp: 2 },
+      { id: "msg-3", role: "user", content: "followup", timestamp: 3, replyTo: "msg-1" },
+    ];
+    const result = buildHistoryReplay(msgs);
+    expect(result).toContain('replying to user: "original question"');
+    expect(result).toContain("followup");
+  });
+
+  it("handles replyTo with missing/pruned parent", () => {
+    const msgs: HistoryMessage[] = [
+      { id: "msg-5", role: "user", content: "reply to gone msg", timestamp: 1, replyTo: "msg-nonexistent" },
+    ];
+    const result = buildHistoryReplay(msgs);
+    expect(result).toContain("replying to a pruned message");
+  });
+
+  it("truncates large history keeping first 2 and recent messages", () => {
+    // Create messages that exceed 40k token budget
+    // Each message ~4000 chars = ~1000 tokens + 10 overhead = 1010 tokens
+    // 40+ messages at 1010 tokens each = ~40400 tokens — exceeds 40k
+    const msgs: HistoryMessage[] = Array.from({ length: 50 }, (_, i) => ({
+      role: (i % 2 === 0 ? "user" : "assistant") as "user" | "assistant",
+      content: `message-${i}: ${"x".repeat(4000)}`,
+      timestamp: 1000 + i,
+    }));
+    const result = buildHistoryReplay(msgs);
+    // Should contain first 2 messages
+    expect(result).toContain("message-0:");
+    expect(result).toContain("message-1:");
+    // Should contain "earlier messages omitted" separator
+    expect(result).toContain("earlier messages omitted");
+    // Should contain some recent messages (last ones)
+    expect(result).toContain("message-49:");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shouldRestartForContext
+// ---------------------------------------------------------------------------
+describe("shouldRestartForContext", () => {
+  it("returns false when no process", () => {
+    const target: ContextCheckTarget = {
+      proc: null,
+      lastReportedContextUsed: 700000,
+      turnCount: 10,
+      contextWindow: TOKEN_BUDGET,
+    };
+    expect(shouldRestartForContext(target)).toBe(false);
+  });
+
+  it("returns false when lastReportedContextUsed is 0", () => {
+    const target: ContextCheckTarget = {
+      proc: {},
+      lastReportedContextUsed: 0,
+      turnCount: 10,
+      contextWindow: TOKEN_BUDGET,
+    };
+    expect(shouldRestartForContext(target)).toBe(false);
+  });
+
+  it("returns false when turnCount <= MIN_TURNS_BEFORE_RESTART", () => {
+    const target: ContextCheckTarget = {
+      proc: {},
+      lastReportedContextUsed: TOKEN_BUDGET * 0.9,
+      turnCount: MIN_TURNS_BEFORE_RESTART,
+      contextWindow: TOKEN_BUDGET,
+    };
+    expect(shouldRestartForContext(target)).toBe(false);
+  });
+
+  it("returns true when context usage >= CONTEXT_PRESSURE_PCT", () => {
+    const target: ContextCheckTarget = {
+      proc: {},
+      lastReportedContextUsed: TOKEN_BUDGET * (CONTEXT_PRESSURE_PCT / 100),
+      turnCount: MIN_TURNS_BEFORE_RESTART + 1,
+      contextWindow: TOKEN_BUDGET,
+    };
+    expect(shouldRestartForContext(target)).toBe(true);
+  });
+
+  it("returns false when context usage below threshold", () => {
+    const target: ContextCheckTarget = {
+      proc: {},
+      lastReportedContextUsed: TOKEN_BUDGET * 0.5,
+      turnCount: MIN_TURNS_BEFORE_RESTART + 1,
+      contextWindow: TOKEN_BUDGET,
+    };
+    expect(shouldRestartForContext(target)).toBe(false);
+  });
+});

--- a/plugins/mc-web-chat/server.ts
+++ b/plugins/mc-web-chat/server.ts
@@ -4,35 +4,24 @@ import { spawn, type ChildProcess, execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { readFileSync, readdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
+import { log } from "./logger.js";
 import { ChatDatabase } from "./chat-db.js";
+import {
+  estimateTokens, trimHistory, pruneImageFlags, buildHistoryReplay,
+  shouldRestartForContext, MAX_HISTORY, IMAGE_PLACEHOLDER,
+  CONTEXT_PRESSURE_PCT, TOKEN_BUDGET, MIN_TURNS_BEFORE_RESTART,
+  type HistoryMessage,
+} from "./chat-utils.js";
+
+export type { HistoryMessage };
+export { estimateTokens, trimHistory, pruneImageFlags, buildHistoryReplay, shouldRestartForContext };
+export { MAX_HISTORY, IMAGE_PLACEHOLDER, CONTEXT_PRESSURE_PCT, TOKEN_BUDGET, MIN_TURNS_BEFORE_RESTART };
 
 export interface ChatServerOptions {
   port: number;
   claudeBin: string;
   workspaceDir: string;
   stateDir?: string;
-}
-
-// ---- Context management config ----
-export const MAX_HISTORY = 30;          // rolling window of messages kept server-side
-export const MAX_IMAGES_IN_HISTORY = 2; // only keep last N images; older ones get placeholder
-export const IMAGE_PLACEHOLDER = "[image was shared earlier in conversation]";
-export const CONTEXT_PRESSURE_PCT = 80; // at 80% usage, proactively restart with summary
-export const TOKEN_BUDGET = 800_000;    // Claude Code uses 1M context; leave 200k headroom
-export const MIN_TURNS_BEFORE_RESTART = 4; // don't check pressure until Nth turn (avoids restart loop from replay)
-
-// ---- Token estimator (~4 chars per token, images ~1000 tokens) ----
-export function estimateTokens(text: string): number {
-  return Math.ceil(text.length / 4);
-}
-
-export interface HistoryMessage {
-  id?: string;
-  role: "user" | "assistant";
-  content: string;
-  hasImage?: boolean; // flag — actual image data is never stored
-  timestamp: number;
-  replyTo?: string; // ID of the message being replied to
 }
 
 export function startChatServer(opts: ChatServerOptions) {
@@ -47,22 +36,24 @@ export function startChatServer(opts: ChatServerOptions) {
     try {
       chatDb.archiveSession(session.id, session.messages, session.totalCost);
     } catch (err) {
-      console.log(`[mc-web-chat] failed to archive session ${session.id}: ${err}`);
+      log.error(`failed to archive session ${session.id}: ${err}`);
     }
   }
 
   // ---- Workspace loader ----
   function loadWorkspacePrompt(): string {
+    const done = log.time("workspace load");
     try {
       const files = readdirSync(workspaceDir).filter((f) => f.endsWith(".md")).sort();
       const parts = files.map((f) => {
         const content = readFileSync(join(workspaceDir, f), "utf-8");
         return `# ${f}\n${content}`;
       });
-      console.log(`[mc-web-chat] workspace loaded ${files.length} files`);
+      log.info(`workspace loaded ${files.length} files`);
+      done();
       return parts.join("\n\n");
     } catch (e) {
-      console.log(`[mc-web-chat] workspace not found: ${e}`);
+      log.warn(`workspace not found: ${e}`);
       return "";
     }
   }
@@ -101,6 +92,7 @@ export function startChatServer(opts: ChatServerOptions) {
     messages: HistoryMessage[];
     currentTopic: string | null; // tracks the current conversation topic
     pendingSeedMessage: string | null; // message to auto-send after new_chat from topic shift
+    turnTimer: (() => void) | null; // elapsed-time logger for current turn
   }
 
   const chatSessions = new Map<string, ChatSession>();
@@ -112,120 +104,18 @@ export function startChatServer(opts: ChatServerOptions) {
       totalCost: 0, contextWindow: TOKEN_BUDGET, lastReportedContextUsed: 0,
       turnCount: 0, awaitingResult: false, messageQueue: [], procHasContext: false,
       lastActivity: Date.now(), messages: [],
-      currentTopic: null, pendingSeedMessage: null,
+      currentTopic: null, pendingSeedMessage: null, turnTimer: null,
     };
   }
 
-  // ---- Context management functions ----
-
-  function trimHistory(session: ChatSession) {
-    if (session.messages.length > MAX_HISTORY) {
-      const dropped = session.messages.length - MAX_HISTORY;
-      session.messages = session.messages.slice(-MAX_HISTORY);
-      console.log(`[mc-web-chat] trimmed ${dropped} old messages, keeping ${MAX_HISTORY}`);
-    }
-  }
-
-  /**
-   * Prune image flags from older messages.
-   * We never store actual image data — but we track which messages HAD images
-   * so we can tell Claude "an image was shared here" vs nothing.
-   * Only the last MAX_IMAGES_IN_HISTORY messages keep their hasImage flag.
-   */
-  function pruneImageFlags(messages: HistoryMessage[]): void {
-    let imagesKept = 0;
-    for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i].hasImage) {
-        if (imagesKept >= MAX_IMAGES_IN_HISTORY) {
-          messages[i].hasImage = false; // strip flag from old ones
-        } else {
-          imagesKept++;
-        }
-      }
-    }
-  }
-
-  /**
-   * Build conversation history for replay when process restarts.
-   * This is the key function — it creates a condensed summary that fits
-   * in a single first-turn message without blowing context.
-   */
-  function buildHistoryReplay(messages: HistoryMessage[]): string {
-    if (messages.length === 0) return "";
-
-    // Estimate total tokens for full replay
-    let totalTokens = 0;
-    for (const m of messages) {
-      totalTokens += estimateTokens(m.content) + 10; // +10 for role prefix overhead
-    }
-
-    // If full replay fits in ~40k tokens, use it verbatim
-    const MAX_REPLAY_TOKENS = 40_000;
-    let replayMessages = messages;
-
-    if (totalTokens > MAX_REPLAY_TOKENS) {
-      // Too big — keep first 2 (establishes topic) + last N that fit
-      const first = messages.slice(0, 2);
-      const firstTokens = first.reduce((sum, m) => sum + estimateTokens(m.content) + 10, 0);
-      const budget = MAX_REPLAY_TOKENS - firstTokens - 200; // 200 for separator
-
-      const recent: HistoryMessage[] = [];
-      let used = 0;
-      for (let i = messages.length - 1; i >= 2; i--) {
-        const cost = estimateTokens(messages[i].content) + 10;
-        if (used + cost > budget) break;
-        recent.unshift(messages[i]);
-        used += cost;
-      }
-
-      const dropped = messages.length - first.length - recent.length;
-      replayMessages = [
-        ...first,
-        { role: "assistant" as const, content: `[...${dropped} earlier messages omitted...]`, timestamp: 0 },
-        ...recent,
-      ];
-    }
-
-    const lines = replayMessages.map((m) => {
-      let line = `[${m.role}]: ${m.content}`;
-      if (m.hasImage) line += ` ${IMAGE_PLACEHOLDER}`;
-      if (m.replyTo) {
-        const target = messages.find(t => t.id === m.replyTo);
-        if (target) {
-          const snippet = target.content.slice(0, 60) + (target.content.length > 60 ? "..." : "");
-          line = `[${m.role} replying to ${target.role}: "${snippet}"]: ${m.content}`;
-        } else {
-          line = `[${m.role} replying to a pruned message]: ${m.content}`;
-        }
-      }
-      return line;
-    });
-
-    return `<conversation-history>\n${lines.join("\n\n")}\n</conversation-history>`;
-  }
-
-  /**
-   * Check if context pressure is high enough to warrant a proactive restart.
-   * Returns true if we should kill the process and replay history on next message.
-   */
-  function shouldRestartForContext(session: ChatSession): boolean {
-    if (!session.proc || session.lastReportedContextUsed === 0) return false;
-    // Don't restart on early turns — the history replay inflates the first few results
-    if (session.turnCount <= MIN_TURNS_BEFORE_RESTART) return false;
-    const pct = (session.lastReportedContextUsed / session.contextWindow) * 100;
-    if (pct >= CONTEXT_PRESSURE_PCT) {
-      console.log(`[mc-web-chat] context pressure ${pct.toFixed(0)}% >= ${CONTEXT_PRESSURE_PCT}% — scheduling restart (turn ${session.turnCount})`);
-      return true;
-    }
-    return false;
-  }
+  // ---- Context management functions (imported from chat-utils.ts) ----
 
   /**
    * Proactively restart the Claude process with a clean context.
    * Kills the current process; next sendMessageToProcess will spawn fresh + replay.
    */
   function proactiveRestart(session: ChatSession) {
-    console.log(`[mc-web-chat] context full — killing session ${session.id} (${session.messages.length} messages, turn ${session.turnCount})`);
+    log.warn(`context full — killing session ${session.id} (${session.messages.length} messages, turn ${session.turnCount})`);
     if (session.proc) {
       session.proc.kill();
       session.proc = null;
@@ -260,7 +150,7 @@ export function startChatServer(opts: ChatServerOptions) {
       "--verbose", "--dangerously-skip-permissions",
     ], { stdio: ["pipe", "pipe", "pipe"] });
 
-    console.log(`[mc-web-chat] spawning claude for session ${session.id}`);
+    log.info(`spawning claude for session ${session.id}`);
 
     proc.stdout!.on("data", (chunk: Buffer) => {
       session.buffer += chunk.toString();
@@ -307,7 +197,7 @@ export function startChatServer(opts: ChatServerOptions) {
               detectedTopicShift = topicMatch[1];
               // Strip the tag from the result text
               resultText = resultText.replace(topicShiftRegex, "").trimEnd();
-              console.log(`[mc-web-chat] topic shift detected: "${detectedTopicShift}" (was: "${session.currentTopic}")`);
+              log.info(`topic shift detected: "${detectedTopicShift}" (was: "${session.currentTopic}")`);
             }
 
             // Extract topic label from first response if not set yet
@@ -369,6 +259,7 @@ export function startChatServer(opts: ChatServerOptions) {
             }
 
             session.awaitingResult = false;
+            if (session.turnTimer) { session.turnTimer(); session.turnTimer = null; }
 
             // Check context pressure AFTER sending result
             if (shouldRestartForContext(session)) {
@@ -385,11 +276,11 @@ export function startChatServer(opts: ChatServerOptions) {
 
     proc.stderr!.on("data", (chunk: Buffer) => {
       const msg = chunk.toString().trim();
-      if (msg) console.log(`[mc-web-chat stderr] ${msg}`);
+      if (msg) log.warn(`stderr: ${msg}`);
     });
 
     proc.on("exit", (code) => {
-      console.log(`[mc-web-chat] claude exited: ${code}`);
+      log.info(`claude exited: ${code}`);
       session.proc = null;
       session.awaitingResult = false;
       session.procHasContext = false;
@@ -471,11 +362,12 @@ ${session.currentTopic ? `Current conversation topic: ${session.currentTopic}` :
     // Images only for current turn — never persisted in history
     const messageContent = buildMessageContent(msg, images);
     const hasImages = images && images.length > 0;
-    console.log(
-      `[mc-web-chat] turn ${session.turnCount}: sending message` +
+    log.info(
+      `turn ${session.turnCount}: sending message` +
       `${hasImages ? ` (${images.length} image${images.length > 1 ? "s" : ""})` : ""}` +
       ` [history: ${session.messages.length}, ctx: ${session.lastReportedContextUsed}/${session.contextWindow}]`
     );
+    session.turnTimer = log.time(`turn ${session.turnCount} response`);
     proc.stdin!.write(JSON.stringify({ type: "user", message: { role: "user", content: messageContent } }) + "\n");
   }
 
@@ -941,7 +833,7 @@ ${session.currentTopic ? `Current conversation topic: ${session.currentTopic}` :
       client.ping();
       setTimeout(() => {
         if (alive.value === true && (client as any).__pongAlive === alive) {
-          console.log("[mc-web-chat] terminating unresponsive client (no pong)");
+          log.warn("terminating unresponsive client (no pong)");
           client.terminate();
         }
       }, PONG_TIMEOUT);
@@ -960,7 +852,7 @@ ${session.currentTopic ? `Current conversation topic: ${session.currentTopic}` :
     const now = Date.now();
     for (const [id, sess] of chatSessions) {
       if (!sess.ws && !sess.proc && (now - sess.lastActivity) > SESSION_TTL) {
-        console.log(`[mc-web-chat] cleaning up stale session ${id} (idle ${Math.round((now - sess.lastActivity) / 60000)}min)`);
+        log.info(`cleaning up stale session ${id} (idle ${Math.round((now - sess.lastActivity) / 60000)}min)`);
         archiveSession(sess);
         chatSessions.delete(id);
       }
@@ -968,7 +860,7 @@ ${session.currentTopic ? `Current conversation topic: ${session.currentTopic}` :
   }, 5 * 60 * 1000);
 
   server.listen(port, () => {
-    console.log(`[mc-web-chat] WebSocket server on ws://127.0.0.1:${port}`);
+    log.info(`WebSocket server on ws://127.0.0.1:${port} — log file: ${log.file}`);
   });
 
   server.on("close", () => {

--- a/plugins/mc-web-chat/vitest.config.ts
+++ b/plugins/mc-web-chat/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["**/*.test.ts"],
+    exclude: ["**/node_modules/**"],
+  },
+});


### PR DESCRIPTION
## Summary

- Extract context management functions (trimHistory, pruneImageFlags, buildHistoryReplay, shouldRestartForContext) from server.ts into chat-utils.ts
- Add structured file logger with turn timings (logger.ts)
- Replace inline console.log calls with structured log calls
- Add 57 unit tests covering ordering, connection, db, and edit bugs

## Test plan

- [ ] Run `npx vitest` in plugins/mc-web-chat to verify all 57 tests pass
- [ ] Verify mc-web-chat starts and serves correctly with new logger
- [ ] Check log output appears in structured format