### PR TITLE
fix(mc-web-chat): complete topic-shift integration + resolve conflict markers

### DIFF
--- a/mc-board/web/src/components/chat-panel.tsx
+++ b/mc-board/web/src/components/chat-panel.tsx
@@ -102,6 +102,7 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
     try { return localStorage.getItem("mc-board:chat-history-open") === "true"; } catch { return false; }
   });
   const [interruptOverlayVisible, setInterruptOverlayVisible] = useState(false);
+  const [topicShift, setTopicShift] = useState<{ suggestedTopic: string; seedMessage: string } | null>(null);
 
   // Edit-last-message state
   const [editingMsgId, setEditingMsgId] = useState<string | null>(null);
@@ -482,13 +483,17 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
             break;
           case "streaming":
             setStreaming(true);
-            if (d.text) setStreamingText(d.text);
+            if (d.text) {
+              const cleanText = d.text.replace(/<topic_shift\s+detected="true"\s+new_topic="[^"]*"\s*\/>/g, "").trimEnd();
+              setStreamingText(cleanText);
+            }
             if (d.tools?.length) setStreamingTools(d.tools);
             break;
           case "result":
             setStreaming(false); setStreamingText(""); setStreamingTools([]); setInterruptOverlayVisible(false); setSentContext(null);
             if (d.text) {
-              const assistantMsg: Message = { id: generateMsgId(), role: "assistant", content: d.text };
+              const resultText = d.text.replace(/<topic_shift\s+detected="true"\s+new_topic="[^"]*"\s*\/>/g, "").trimEnd();
+              const assistantMsg: Message = { id: generateMsgId(), role: "assistant", content: resultText };
               const insertIdx = streamingInsertIndexRef.current;
               if (insertIdx !== null) {
                 setMessages(prev => [
@@ -510,6 +515,9 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
             setMessages(prev => [...prev, { id: generateMsgId(), role: "system", content: d.message, error: true }]);
             setStreaming(false); setInterruptOverlayVisible(false); setSentContext(null);
             streamingInsertIndexRef.current = null;
+            break;
+          case "topic_shift":
+            setTopicShift({ suggestedTopic: d.suggestedTopic, seedMessage: d.seedMessage || "" });
             break;
         }
       };
@@ -1474,11 +1482,10 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
 
       {/* Chat history sidebar — absolute overlay covering the full chat panel */}
       <ChatHistorySidebar
-        isOpen={historyOpen}
+        open={historyOpen}
         onClose={toggleHistory}
-        onResume={resumeChat}
+        onResumeChat={resumeChat}
         currentSessionId={sessionId}
-        serverBaseUrl={`${typeof window !== "undefined" ? window.location.protocol : "http:"}//${typeof window !== "undefined" ? window.location.hostname : "localhost"}:4221`}
       />
     </div>
     </>

--- a/plugins/mc-board/web/src/components/chat-panel.tsx
+++ b/plugins/mc-board/web/src/components/chat-panel.tsx
@@ -678,7 +678,6 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
     }]);
   }, [stopResponse]);
 
-<<<<<<< HEAD
   const startEditMessage = useCallback((msgId: string, content: string) => {
     setEditingMsgId(msgId);
     setEditDraft(content);
@@ -712,7 +711,7 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
     setEditDraft("");
     setStreaming(true);
   }, [editDraft, editingMsgId, connected, streaming, messages]);
-=======
+
   const startNewChatFromTopicShift = useCallback(() => {
     if (!topicShift || !wsRef.current || !connected) return;
     const seed = topicShift.seedMessage;
@@ -733,7 +732,6 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
       setStreaming(true);
     }
   }, [topicShift, connected]);
->>>>>>> 5b559f8 (feat(mc-web-chat): add topic-shift detection banner to chat panel)
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && e.shiftKey) {
@@ -1490,11 +1488,10 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
 
       {/* Chat history sidebar — absolute overlay covering the full chat panel */}
       <ChatHistorySidebar
-        isOpen={historyOpen}
+        open={historyOpen}
         onClose={toggleHistory}
-        onResume={resumeChat}
+        onResumeChat={resumeChat}
         currentSessionId={sessionId}
-        serverBaseUrl={`${typeof window !== "undefined" ? window.location.protocol : "http:"}//${typeof window !== "undefined" ? window.location.hostname : "localhost"}:4221`}
       />
     </div>
     </>


### PR DESCRIPTION
## Summary
- Adds missing `topicShift` useState declaration, WS `topic_shift` case handler, and `<topic_shift>` tag stripping to mc-board/chat-panel.tsx (these were referenced but never declared after PR #499 merge)
- Resolves leftover git conflict markers in plugins/mc-board/chat-panel.tsx (keeps both edit-message functions from HEAD and topic-shift callback from PR)
- Fixes ChatHistorySidebar prop mismatches (`isOpen`→`open`, `onResume`→`onResumeChat`, removes `serverBaseUrl`) in both copies

## Test plan
- [x] `npx tsc --noEmit` passes in mc-board/web/
- [x] `npx tsc --noEmit` passes in plugins/mc-board/web/
- [ ] Topic-shift banner appears when server sends `topic_shift` WS event
- [ ] `<topic_shift>` XML tags stripped from streaming and result text

🤖 Generated with [Claude Code](https://claude.com/claude-code)