### PR TITLE
fix: resolve merge conflict markers in chat-panel.tsx

### DIFF
--- a/plugins/mc-board/web/src/components/chat-panel.tsx
+++ b/plugins/mc-board/web/src/components/chat-panel.tsx
@@ -678,7 +678,6 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
     }]);
   }, [stopResponse]);
 
-<<<<<<< HEAD
   const startEditMessage = useCallback((msgId: string, content: string) => {
     setEditingMsgId(msgId);
     setEditDraft(content);
@@ -712,7 +711,7 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
     setEditDraft("");
     setStreaming(true);
   }, [editDraft, editingMsgId, connected, streaming, messages]);
-=======
+
   const startNewChatFromTopicShift = useCallback(() => {
     if (!topicShift || !wsRef.current || !connected) return;
     const seed = topicShift.seedMessage;
@@ -733,7 +732,6 @@ export function ChatPanel({ open, onToggle, pendingContext, onContextConsumed, p
       setStreaming(true);
     }
   }, [topicShift, connected]);
->>>>>>> 5b559f8 (feat(mc-web-chat): add topic-shift detection banner to chat panel)
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && e.shiftKey) {


### PR DESCRIPTION
**Critical Fix:** Resolves unresolved merge conflict markers that were shipped to upstream/main in commit 266850c (PR #499).

## Problem
PR #499 was merged with unresolved conflict markers in `plugins/mc-board/web/src/components/chat-panel.tsx` (lines 681-736). This causes syntax errors in the code.

## Resolution
Both sets of functions are independent and should coexist:
- `startEditMessage`, `cancelEditMessage`, `submitEditMessage` (from main/HEAD) — allow editing messages
- `startNewChatFromTopicShift` (from PR #474) — start new chat from topic shift

This commit removes the conflict markers and keeps both function definitions.