### PR TITLE
fix(mc-board): expand search input to fill toolbar width

### DIFF
--- a/plugins/mc-board/web/src/components/board.tsx
+++ b/plugins/mc-board/web/src/components/board.tsx
@@ -276,7 +276,7 @@ export function Board({ selectedProject, initialCardId, onToast, notifsEnabled, 
             onFocus={() => { setSearchOpen(true); setSearchFocused(true); }}
             onBlur={() => setSearchFocused(false)}
             style={{
-              flex: "1 1 200px", maxWidth: 280, minWidth: 0,
+              flex: "1 1 auto", minWidth: 120,
               background: searchFocused ? "#18181b" : "transparent",
               border: searchFocused ? `1px solid ${accent}` : "1px solid rgba(63,63,70,0.4)",
               borderRadius: 4, padding: "5px 8px", color: "#e4e4e7",


### PR DESCRIPTION
## Summary

- Change search input `flex: "1 1 200px", maxWidth: 280` → `flex: "1 1 auto", minWidth: 120`
- Input now grows to fill available toolbar space while buttons remain pinned right
- `minWidth: 120` prevents collapse on narrow viewports

Closes #510
Card: crd_b38da44d

## Test plan
- [ ] Search input expands to fill available toolbar width
- [ ] Action buttons (New Request, show held, Last Hour Summary) remain pinned to the right edge
- [ ] Input + buttons span the full toolbar width
- [ ] Layout does not break on narrow viewports (input has reasonable min-width)
- [ ] No visual regression in search results dropdown positioning