### PR TITLE
sync(mc-board/web): add install-plists.sh, plist templates; sync deploy/watch scripts

### DIFF
--- a/mc-board/web/com.miniclaw.board-web-watcher.plist.template
+++ b/mc-board/web/com.miniclaw.board-web-watcher.plist.template
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.miniclaw.board-web-watcher</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>__PLUGIN_DIR__/watch-deploy.sh</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>__PLUGIN_DIR__</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+  <key>StandardOutPath</key>
+  <string>__HOME__/.openclaw/logs/board-web-watcher.log</string>
+  <key>StandardErrorPath</key>
+  <string>__HOME__/.openclaw/logs/board-web-watcher.log</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>__HOME__</string>
+    <key>PATH</key>
+    <string>__HOME__/.local/bin:__NODE_BIN_DIR__:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
+</dict>
+</plist>

--- a/mc-board/web/com.miniclaw.board-web.plist.template
+++ b/mc-board/web/com.miniclaw.board-web.plist.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.miniclaw.board-web</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>__NODE_BIN__</string>
+    <string>__PLUGIN_DIR__/node_modules/next/dist/bin/next</string>
+    <string>start</string>
+    <string>-p</string>
+    <string>4220</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>__PLUGIN_DIR__</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PORT</key>
+    <string>4220</string>
+    <key>NODE_ENV</key>
+    <string>production</string>
+    <key>HOME</key>
+    <string>__HOME__</string>
+    <key>PATH</key>
+    <string>__HOME__/.local/bin:__NODE_BIN_DIR__:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>/tmp/board-web.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/board-web.err</string>
+  <key>KeepAlive</key>
+  <true/>
+</dict>
+</plist>

--- a/mc-board/web/deploy.sh
+++ b/mc-board/web/deploy.sh
@@ -10,11 +10,31 @@ set -e
 DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$DIR"
 
+# ── Drift detection ──────────────────────────────────────────────────────────
+# Compare live plugins dir against the source repo to catch direct-write drift.
+REPO_SRC="$HOME/.openclaw/projects/miniclaw-os/plugins/mc-board/web/src"
+LIVE_SRC="$DIR/src"
+if [ -d "$REPO_SRC" ]; then
+  DRIFT=$(diff -rq "$REPO_SRC" "$LIVE_SRC" \
+    --exclude='node_modules' --exclude='.next' --exclude='*.log' 2>/dev/null \
+    | grep -E '\.(tsx?|ts)' | head -10 || true)
+  if [ -n "$DRIFT" ]; then
+    echo ""
+    echo "⚠️  DRIFT DETECTED — live plugins dir differs from repo:"
+    echo "$DRIFT"
+    echo ""
+    echo "Run: ~/.openclaw/projects/miniclaw-os/scripts/sync-dev.sh"
+    echo "Or manually resolve differences before deploying."
+    echo ""
+  fi
+fi
+
 PLIST="$HOME/Library/LaunchAgents/com.miniclaw.board-web.plist"
 UID_NUM=$(id -u)
 
 # Stop the server FIRST — no more serving stale chunks during build
 launchctl bootout "gui/$UID_NUM" "$PLIST" 2>/dev/null || true
+pgrep -f "next-server|next start.*4220" 2>/dev/null | xargs kill -9 2>/dev/null || true
 sleep 1
 
 # Back up the current build in case this one fails
@@ -36,7 +56,11 @@ else
   fi
 fi
 
+# Kill anything still on the port
+pgrep -f "next-server|next start.*4220" 2>/dev/null | xargs kill -9 2>/dev/null || true
+sleep 1
+
 # Start the server (with new or restored build)
-launchctl bootstrap "gui/$UID_NUM" "$PLIST"
+launchctl bootstrap "gui/$UID_NUM" "$PLIST" 2>/dev/null || launchctl load "$PLIST" 2>/dev/null
 
 echo "deployed"

--- a/mc-board/web/install-plists.sh
+++ b/mc-board/web/install-plists.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# install-plists.sh — Render plist templates and install to ~/Library/LaunchAgents/
+#
+# Detects HOME, node binary, and plugin directory automatically.
+# Substitutes __HOME__, __NODE_BIN__, __NODE_BIN_DIR__, __PLUGIN_DIR__ placeholders
+# in .plist.template files, writes rendered plists, and loads them via launchctl.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# PLUGIN_DIR must always resolve to the LIVE install location, never a repo clone.
+# The live install is at ~/.openclaw/miniclaw/plugins/mc-board/web/
+# If this script is run from a repo clone (e.g. USER/projects/miniclaw-os/...),
+# using $SCRIPT_DIR would produce wrong paths in the plist.
+PLUGIN_DIR="$HOME/.openclaw/miniclaw/plugins/mc-board/web"
+if [ ! -d "$PLUGIN_DIR" ]; then
+  echo "ERROR: Live plugin dir not found at $PLUGIN_DIR" >&2
+  echo "  (script ran from: $SCRIPT_DIR)" >&2
+  exit 1
+fi
+LAUNCH_AGENTS_DIR="$HOME/Library/LaunchAgents"
+UID_NUM="$(id -u)"
+
+# --- Detect node binary ---
+NODE_BIN=""
+if command -v node &>/dev/null; then
+  NODE_BIN="$(command -v node)"
+elif [ -d "$HOME/.nvm" ]; then
+  # Source nvm and get node path
+  export NVM_DIR="$HOME/.nvm"
+  [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+  if command -v node &>/dev/null; then
+    NODE_BIN="$(command -v node)"
+  fi
+fi
+
+if [ -z "$NODE_BIN" ]; then
+  echo "ERROR: Cannot find node binary. Install Node.js or configure nvm." >&2
+  exit 1
+fi
+
+NODE_BIN_DIR="$(dirname "$NODE_BIN")"
+
+echo "Configuration:"
+echo "  HOME:         $HOME"
+echo "  NODE_BIN:     $NODE_BIN"
+echo "  NODE_BIN_DIR: $NODE_BIN_DIR"
+echo "  PLUGIN_DIR:   $PLUGIN_DIR"
+echo ""
+
+# --- Ensure LaunchAgents dir exists ---
+mkdir -p "$LAUNCH_AGENTS_DIR"
+
+# --- Render and install each template ---
+render_template() {
+  local template="$1"
+  local basename="$(basename "$template" .template)"
+  local output="$LAUNCH_AGENTS_DIR/$basename"
+
+  echo "Rendering $basename..."
+  sed \
+    -e "s|__HOME__|$HOME|g" \
+    -e "s|__NODE_BIN__|$NODE_BIN|g" \
+    -e "s|__NODE_BIN_DIR__|$NODE_BIN_DIR|g" \
+    -e "s|__PLUGIN_DIR__|$PLUGIN_DIR|g" \
+    "$template" > "$output"
+
+  echo "  Written to $output"
+
+  # Reload the service
+  local label="$(basename "$basename" .plist)"
+  echo "  Reloading $label..."
+  launchctl bootout "gui/$UID_NUM/$label" 2>/dev/null || true
+  sleep 1
+  launchctl bootstrap "gui/$UID_NUM" "$output"
+  echo "  Loaded $label"
+}
+
+for tmpl in "$SCRIPT_DIR"/*.plist.template; do
+  [ -f "$tmpl" ] || continue
+  render_template "$tmpl"
+done
+
+echo ""
+echo "Done. Both services installed and loaded."

--- a/mc-board/web/watch-deploy.sh
+++ b/mc-board/web/watch-deploy.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # watch-deploy.sh — Watch mc-board web source files and auto-deploy on changes
 # Uses fswatch with debounce to detect changes, then runs deploy.sh
+# Uses a lock file to prevent concurrent deploys
 set -euo pipefail
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -9,6 +10,7 @@ cd "$DIR"
 LOG_DIR="$HOME/.openclaw/logs"
 LOG_FILE="$LOG_DIR/board-web-watcher.log"
 DEPLOY_SCRIPT="$DIR/deploy.sh"
+LOCK_FILE="$DIR/.deploy.lock"
 COOLDOWN=3  # seconds between deploys
 
 mkdir -p "$LOG_DIR"
@@ -19,7 +21,7 @@ log() {
 
 log "Watcher starting — monitoring $DIR for changes"
 log "Watching: src/, public/, next.config.ts, package.json"
-log "Ignoring: .next/, node_modules/, .git/"
+log "Ignoring: .next/, .next-backup/, node_modules/, .git/, deploy.sh, watch-deploy.sh"
 log "Debounce latency: ${COOLDOWN}s"
 
 # fswatch flags:
@@ -36,15 +38,26 @@ fswatch \
   --exclude '\.git' \
   --exclude '\.swp$' \
   --exclude '\.DS_Store' \
+  --exclude 'deploy\.sh' \
+  --exclude 'watch-deploy\.sh' \
+  --exclude '\.deploy\.lock' \
   "$DIR/src" \
   "$DIR/public" \
   "$DIR/next.config.ts" \
   "$DIR/package.json" \
   | while read -r event; do
+    # Skip if a deploy is already running
+    if [ -f "$LOCK_FILE" ]; then
+      log "Change detected — deploy already running, skipping"
+      continue
+    fi
+
     log "Change detected — starting deploy..."
+    touch "$LOCK_FILE"
     if bash "$DEPLOY_SCRIPT" >> "$LOG_FILE" 2>&1; then
       log "Deploy completed successfully"
     else
       log "Deploy FAILED (exit code $?)"
     fi
+    rm -f "$LOCK_FILE"
   done


### PR DESCRIPTION
Syncs mc-board/web/ with the live plugins/mc-board/web/ directory.

- Adds missing install-plists.sh (renders plist templates, installs to ~/Library/LaunchAgents/)
- Adds com.miniclaw.board-web.plist.template
- Adds com.miniclaw.board-web-watcher.plist.template
- Updates deploy.sh: stop-first pattern, kill logic, launchctl fallback
- Updates watch-deploy.sh: lock file, extra fswatch excludes

Fixes v0.1.9 release zip criteria.