### PR TITLE
fix(mc-board): remove orphaned memory stat pill CSS rule

### DIFF
--- a/plugins/mc-board/web/src/app/globals.css
+++ b/plugins/mc-board/web/src/app/globals.css
@@ -120,7 +120,6 @@ a { color: inherit; }
 .stat-pill[data-col="shipped"]::before { background: #22c55e; }
 .stat-pill[data-col="projects"]::before { background: #52525b; }
 .stat-pill[data-col="tokens"]::before { background: #a855f7; }
-.stat-pill[data-col="memory"]::before { background: #06b6d4; }
 
 /* ── Top bar icon buttons (chat, alerts) ── */
 .top-bar-icon-btn {


### PR DESCRIPTION
## Summary
- Removes orphaned `.stat-pill[data-col="memory"]::before` CSS rule from `globals.css`
- The memory stat pill was removed from the top bar in 896cbd07 but the color rule was left behind as dead code
- No functional change — the rule was never reached since no element with `data-col="memory"` is rendered

## Test plan
- [ ] Verify build passes with no errors
- [ ] Confirm stats bar shows: projects, backlog, in-progress, in-review, shipped, version (no memory pill)
- [ ] Verify Memory tab badge still shows memoryFiles / kbEntries count

Closes #521
Tracks card: crd_3ca4e6e7