### PR TITLE
docs(mc-memo): document CLI syntax and memory pipeline integration

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -270,7 +270,15 @@ Per-card scratchpad with timestamped notes. Prevents re-trying failed approaches
 
 ```bash
 # Memos auto-created at ~/.openclaw/miniclaw/USER/memos/<card_id>.md
+openclaw mc-memo write <card_id> "note text"   # append timestamped note
+openclaw mc-memo read <card_id>                # read all notes for a card
+openclaw mc-memo list                          # list all memo files
+openclaw mc-memo clear <card_id>               # delete the memo file
 ```
+
+**Memory pipeline:** mc-memo integrates with mc-memory for unified recall and promotion to long-term KB. Use `openclaw mc-memory promote --from memo --ref <card_id>` to graduate a memo's knowledge into `mc-kb` with auto-tags `promoted` and `from-memo`. The `mc-reflection` nightly cron surfaces promoted KB entries in its gather context.
+
+> **Note:** Memos are permanent flat files — there is no built-in TTL or expiry. Ephemeral notes stay until manually cleared or the nightly reflection agent decides to promote/discard them.
 
 ---
 


### PR DESCRIPTION
## Summary

- Documents the correct `mc-memo` CLI syntax (`write <cardId> <note>`, `read`, `list`, `clear`) with concrete examples
- Explains the full memory pipeline: mc-memo → mc-memory promote → mc-kb, including auto-tags `promoted` and `from-memo`  
- Notes that mc-reflection nightly gather surfaces promoted KB entries in its context
- Clarifies that memos have no built-in TTL/expiry — they are permanent flat files

Surfaced from E2E memory pipeline validation (crd_c8efb63d). Existing FEATURES.md lacked CLI examples and didn't describe the promotion path.

Closes #524