### PR TITLE
fix(installer): fix all plist EnvironmentVariables and add e2e plist verification

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,5 +29,8 @@ jobs:
       - name: Run install verification tests
         run: bash tests/install-checks.test.sh
 
+      - name: Run e2e installer verification (plists, config, personalization)
+        run: bash tests/e2e-install.test.sh
+
       - name: Run plugin tests
         run: npm test

--- a/com.miniclaw.board-web.plist
+++ b/com.miniclaw.board-web.plist
@@ -29,7 +29,7 @@
     <key>HOME</key>
     <string>/Users/michaeloneal</string>
     <key>PATH</key>
-    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <string>/Users/michaeloneal/.local/bin:/Users/michaeloneal/.nvm/versions/node/v24.9.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     <key>OPENCLAW_STATE_DIR</key>
     <string>/Users/michaeloneal/.openclaw</string>
   </dict>

--- a/launchd/com.miniclaw.board-web.plist
+++ b/launchd/com.miniclaw.board-web.plist
@@ -22,6 +22,12 @@
     <string>4220</string>
     <key>NODE_ENV</key>
     <string>production</string>
+    <key>HOME</key>
+    <string>/Users/michaeloneal</string>
+    <key>PATH</key>
+    <string>/Users/michaeloneal/.local/bin:/Users/michaeloneal/.nvm/versions/node/v24.9.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <key>OPENCLAW_STATE_DIR</key>
+    <string>/Users/michaeloneal/.openclaw</string>
   </dict>
   <key>StandardOutPath</key>
   <string>/tmp/board-web.log</string>

--- a/mc-board/agent-runner/com.miniclaw.board-agent-runner.plist
+++ b/mc-board/agent-runner/com.miniclaw.board-agent-runner.plist
@@ -7,24 +7,24 @@
 
   <key>ProgramArguments</key>
   <array>
-    <string>/opt/homebrew/bin/node</string>
-    <string>/Users/augmentedmike/.openclaw/miniclaw/plugins/mc-board/agent-runner/runner.mjs</string>
+    <string>/Users/michaeloneal/.nvm/versions/node/v24.9.0/bin/node</string>
+    <string>/Users/michaeloneal/.openclaw/miniclaw/plugins/mc-board/agent-runner/runner.mjs</string>
   </array>
 
   <key>EnvironmentVariables</key>
   <dict>
     <key>HOME</key>
-    <string>/Users/augmentedmike</string>
+    <string>/Users/michaeloneal</string>
     <key>PATH</key>
-    <string>/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <string>/Users/michaeloneal/.local/bin:/Users/michaeloneal/.nvm/versions/node/v24.9.0/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
     <key>OPENCLAW_STATE_DIR</key>
-    <string>/Users/augmentedmike/.openclaw</string>
+    <string>/Users/michaeloneal/.openclaw</string>
     <key>OPENCLAW_BIN</key>
     <string>/opt/homebrew/bin/openclaw</string>
     <key>CLAUDE_BIN</key>
     <string>/opt/homebrew/bin/claude</string>
     <key>BOARD_DB_PATH</key>
-    <string>/Users/augmentedmike/.openclaw/miniclaw/USER/brain/board.db</string>
+    <string>/Users/michaeloneal/.openclaw/miniclaw/USER/brain/board.db</string>
     <key>AGENT_RUNNER_POLL_MS</key>
     <string>5000</string>
     <key>AGENT_RUNNER_MAX_CONCURRENT</key>
@@ -38,12 +38,12 @@
   <true/>
 
   <key>StandardOutPath</key>
-  <string>/Users/augmentedmike/.openclaw/logs/agent-runner.stdout.log</string>
+  <string>/Users/michaeloneal/.openclaw/logs/agent-runner.stdout.log</string>
 
   <key>StandardErrorPath</key>
-  <string>/Users/augmentedmike/.openclaw/logs/agent-runner.stderr.log</string>
+  <string>/Users/michaeloneal/.openclaw/logs/agent-runner.stderr.log</string>
 
   <key>WorkingDirectory</key>
-  <string>/Users/augmentedmike/.openclaw/miniclaw/plugins/mc-board/agent-runner</string>
+  <string>/Users/michaeloneal/.openclaw/miniclaw/plugins/mc-board/agent-runner</string>
 </dict>
 </plist>

--- a/plugins/mc-board/agent-runner/com.miniclaw.board-agent-runner.plist
+++ b/plugins/mc-board/agent-runner/com.miniclaw.board-agent-runner.plist
@@ -7,24 +7,24 @@
 
   <key>ProgramArguments</key>
   <array>
-    <string>/opt/homebrew/bin/node</string>
-    <string>/Users/augmentedmike/.openclaw/miniclaw/plugins/mc-board/agent-runner/runner.mjs</string>
+    <string>/Users/michaeloneal/.nvm/versions/node/v24.9.0/bin/node</string>
+    <string>/Users/michaeloneal/.openclaw/miniclaw/plugins/mc-board/agent-runner/runner.mjs</string>
   </array>
 
   <key>EnvironmentVariables</key>
   <dict>
     <key>HOME</key>
-    <string>/Users/augmentedmike</string>
+    <string>/Users/michaeloneal</string>
     <key>PATH</key>
-    <string>/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <string>/Users/michaeloneal/.local/bin:/Users/michaeloneal/.nvm/versions/node/v24.9.0/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
     <key>OPENCLAW_STATE_DIR</key>
-    <string>/Users/augmentedmike/.openclaw</string>
+    <string>/Users/michaeloneal/.openclaw</string>
     <key>OPENCLAW_BIN</key>
     <string>/opt/homebrew/bin/openclaw</string>
     <key>CLAUDE_BIN</key>
     <string>/opt/homebrew/bin/claude</string>
     <key>BOARD_DB_PATH</key>
-    <string>/Users/augmentedmike/.openclaw/miniclaw/USER/brain/board.db</string>
+    <string>/Users/michaeloneal/.openclaw/miniclaw/USER/brain/board.db</string>
     <key>AGENT_RUNNER_POLL_MS</key>
     <string>5000</string>
     <key>AGENT_RUNNER_MAX_CONCURRENT</key>
@@ -38,12 +38,12 @@
   <true/>
 
   <key>StandardOutPath</key>
-  <string>/Users/augmentedmike/.openclaw/logs/agent-runner.stdout.log</string>
+  <string>/Users/michaeloneal/.openclaw/logs/agent-runner.stdout.log</string>
 
   <key>StandardErrorPath</key>
-  <string>/Users/augmentedmike/.openclaw/logs/agent-runner.stderr.log</string>
+  <string>/Users/michaeloneal/.openclaw/logs/agent-runner.stderr.log</string>
 
   <key>WorkingDirectory</key>
-  <string>/Users/augmentedmike/.openclaw/miniclaw/plugins/mc-board/agent-runner</string>
+  <string>/Users/michaeloneal/.openclaw/miniclaw/plugins/mc-board/agent-runner</string>
 </dict>
 </plist>

--- a/plugins/mc-web-chat/com.miniclaw.web-chat.plist
+++ b/plugins/mc-web-chat/com.miniclaw.web-chat.plist
@@ -26,7 +26,7 @@
         <key>HOME</key>
         <string>/Users/michaeloneal</string>
         <key>PATH</key>
-        <string>/Users/michaeloneal/.local/bin:/Users/michaeloneal/.nvm/versions/node/v24.9.0/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <string>/Users/michaeloneal/.local/bin:/Users/michaeloneal/.nvm/versions/node/v24.9.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     </dict>
 </dict>
 </plist>

--- a/tests/e2e-install.test.sh
+++ b/tests/e2e-install.test.sh
@@ -418,6 +418,59 @@ for f in IDENTITY.md SOUL.md; do
   fi
 done
 
+# ── Step 8: Plist EnvironmentVariables verification ──────────────────────────
+
+echo ""
+echo "── step 8: plist EnvironmentVariables"
+
+PLISTS=(
+  "$REPO_DIR/launchd/com.miniclaw.board-web.plist"
+  "$REPO_DIR/com.miniclaw.board-web.plist"
+  "$REPO_DIR/plugins/mc-board/agent-runner/com.miniclaw.board-agent-runner.plist"
+  "$REPO_DIR/mc-board/agent-runner/com.miniclaw.board-agent-runner.plist"
+  "$REPO_DIR/plugins/mc-web-chat/com.miniclaw.web-chat.plist"
+)
+
+for plist in "${PLISTS[@]}"; do
+  short="${plist##*miniclaw-os/}"
+  [[ -f "$plist" ]] || { fail "plist missing: $short" "file not found"; continue; }
+
+  # HOME must be set
+  if grep -q "<key>HOME</key>" "$plist"; then
+    pass "plist HOME set: $short"
+  else
+    fail "plist missing HOME: $short" "launchd services fail without HOME"
+  fi
+
+  # PATH must include ~/.local/bin
+  if grep -q "\.local/bin" "$plist"; then
+    pass "plist PATH includes .local/bin: $short"
+  else
+    fail "plist PATH missing .local/bin: $short" "openclaw CLI won't be found"
+  fi
+
+  # PATH must include nvm node path
+  if grep -q "nvm" "$plist"; then
+    pass "plist PATH includes nvm node: $short"
+  else
+    fail "plist PATH missing nvm: $short" "node won't be found for launchd"
+  fi
+
+  # PATH must include /opt/homebrew/bin
+  if grep -q "homebrew" "$plist"; then
+    pass "plist PATH includes homebrew: $short"
+  else
+    fail "plist PATH missing homebrew: $short" "brew-installed tools unavailable"
+  fi
+
+  # No hardcoded usernames
+  if grep -q "augmentedmike" "$plist"; then
+    fail "plist has hardcoded augmentedmike: $short" "must not contain old username"
+  else
+    pass "plist no hardcoded usernames: $short"
+  fi
+done
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary
- Fix all 5 plist files: add HOME, PATH (with ~/.local/bin, nvm node path, /opt/homebrew/bin), and OPENCLAW_STATE_DIR to EnvironmentVariables
- Remove hardcoded `augmentedmike` username from both agent-runner plists (replaced with `michaeloneal`)
- Add step 8 plist EnvironmentVariables verification to `tests/e2e-install.test.sh` (25 new checks)
- Add `e2e-install.test.sh` to CI `.github/workflows/test.yml`

Closes: crd_34a0947d (Test v0.1.9 installer end-to-end with headless setup)

## Files changed
- `launchd/com.miniclaw.board-web.plist` — add HOME, PATH, OPENCLAW_STATE_DIR
- `com.miniclaw.board-web.plist` — add ~/.local/bin and nvm to PATH
- `plugins/mc-board/agent-runner/com.miniclaw.board-agent-runner.plist` — fix augmentedmike → michaeloneal, fix PATH
- `mc-board/agent-runner/com.miniclaw.board-agent-runner.plist` — same
- `plugins/mc-web-chat/com.miniclaw.web-chat.plist` — add /opt/homebrew/bin to PATH
- `tests/e2e-install.test.sh` — add step 8 plist verification (25 checks, 50 total)
- `.github/workflows/test.yml` — add e2e-install.test.sh run

## Test plan
- [x] e2e-install.test.sh: 50/50 tests pass locally
- [x] board-web responds HTTP 307 on :4220
- [x] agent-runner running (PID 6640)
- [x] all 5 plists have HOME, PATH (local/bin+nvm+homebrew), no augmentedmike