### PR TITLE
test(mc-board): add store + data-layer tests for 0-card, checkTitleConflict, context persistence

### DIFF
--- a/plugins/mc-board/src/data-layer.test.ts
+++ b/plugins/mc-board/src/data-layer.test.ts
@@ -1,0 +1,230 @@
+/**
+ * data-layer.test.ts — Tests for web data-layer functions (listBoardCards, listProjects, getCard).
+ *
+ * These test the same data-access patterns as web/src/lib/data.ts but against
+ * the CardStore/ProjectStore directly (since the web data layer reads the same SQLite DB).
+ * This validates that:
+ *   - Card counts are correct (not 0 when data exists)
+ *   - Projects list returns data when projects exist
+ *   - getCard returns all fields including research/notes (context persistence)
+ *
+ * Regression guards for: crd_68d9535d (0-card fetch), crd_5ba09fcc (missing projects),
+ * crd_7d62b149 (card context disappears).
+ */
+
+import { describe, expect, it, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+import { CardStore } from "./store.js";
+
+function createTestDb(): InstanceType<typeof Database> {
+  const db = new Database(":memory:");
+  db.exec("PRAGMA foreign_keys = ON");
+  db.exec(`
+    CREATE TABLE cards (
+      id               TEXT PRIMARY KEY,
+      title            TEXT NOT NULL,
+      col              TEXT NOT NULL DEFAULT 'backlog',
+      priority         TEXT NOT NULL DEFAULT 'medium',
+      tags             TEXT NOT NULL DEFAULT '[]',
+      project_id       TEXT,
+      work_type        TEXT,
+      linked_card_id   TEXT,
+      depends_on       TEXT NOT NULL DEFAULT '[]',
+      created_at       TEXT NOT NULL,
+      updated_at       TEXT NOT NULL,
+      problem_description  TEXT NOT NULL DEFAULT '',
+      implementation_plan  TEXT NOT NULL DEFAULT '',
+      acceptance_criteria  TEXT NOT NULL DEFAULT '',
+      notes            TEXT NOT NULL DEFAULT '',
+      review_notes     TEXT NOT NULL DEFAULT '',
+      research         TEXT NOT NULL DEFAULT '',
+      verify_url       TEXT NOT NULL DEFAULT '',
+      work_log         TEXT NOT NULL DEFAULT '[]',
+      attachments      TEXT NOT NULL DEFAULT '[]'
+    );
+    CREATE TABLE card_history (
+      id       INTEGER PRIMARY KEY AUTOINCREMENT,
+      card_id  TEXT NOT NULL REFERENCES cards(id) ON DELETE CASCADE,
+      col      TEXT NOT NULL,
+      moved_at TEXT NOT NULL
+    );
+    CREATE TABLE projects (
+      id          TEXT PRIMARY KEY,
+      name        TEXT NOT NULL,
+      description TEXT NOT NULL DEFAULT '',
+      work_dir    TEXT NOT NULL DEFAULT '',
+      github_repo TEXT NOT NULL DEFAULT '',
+      status      TEXT NOT NULL DEFAULT 'active',
+      created_at  TEXT NOT NULL,
+      updated_at  TEXT NOT NULL
+    );
+  `);
+  return db;
+}
+
+// ---- listBoardCards equivalent: store.list() returns correct counts ----
+
+describe("Board data layer — card listing", () => {
+  let db: InstanceType<typeof Database>;
+  let store: CardStore;
+
+  beforeEach(() => {
+    db = createTestDb();
+    store = new CardStore(db);
+  });
+
+  it("returns empty array when DB has no cards (not crash)", () => {
+    const cards = store.list();
+    expect(cards).toEqual([]);
+    expect(cards).toHaveLength(0);
+  });
+
+  it("returns correct card count when DB has cards", () => {
+    store.create({ title: "Card 1" });
+    store.create({ title: "Card 2" });
+    store.create({ title: "Card 3" });
+    const cards = store.list();
+    expect(cards).toHaveLength(3);
+  });
+
+  it("card objects have all required BoardCard fields", () => {
+    const created = store.create({ title: "Test card", priority: "high", tags: ["build"] });
+    const cards = store.list();
+    const card = cards[0];
+    expect(card.id).toBe(created.id);
+    expect(card.title).toBe("Test card");
+    expect(card.column).toBe("backlog");
+    expect(card.priority).toBe("high");
+    expect(card.tags).toEqual(["build"]);
+    expect(card.created_at).toBeDefined();
+    expect(card.updated_at).toBeDefined();
+  });
+});
+
+// ---- listProjects equivalent: projects table returns data ----
+
+describe("Board data layer — projects listing", () => {
+  let db: InstanceType<typeof Database>;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it("returns empty array when no projects exist (not crash)", () => {
+    const rows = db.prepare(
+      `SELECT id, name, description, work_dir, github_repo FROM projects WHERE status = 'active'`
+    ).all();
+    expect(rows).toEqual([]);
+  });
+
+  it("returns projects when they exist in DB", () => {
+    const now = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO projects (id, name, description, work_dir, github_repo, status, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, 'active', ?, ?)`
+    ).run("prj_001", "MiniClaw", "Plugin ecosystem", "/path/to/project", "user/repo", now, now);
+
+    db.prepare(
+      `INSERT INTO projects (id, name, description, work_dir, github_repo, status, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, 'active', ?, ?)`
+    ).run("prj_002", "OpenClaw", "Agent runtime", "/path/to/openclaw", "user/openclaw", now, now);
+
+    const rows = db.prepare(
+      `SELECT id, name, description, work_dir, github_repo FROM projects WHERE status = 'active' ORDER BY created_at ASC`
+    ).all() as Array<{ id: string; name: string; description: string; work_dir: string; github_repo: string }>;
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0].name).toBe("MiniClaw");
+    expect(rows[1].name).toBe("OpenClaw");
+  });
+
+  it("excludes inactive projects", () => {
+    const now = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO projects (id, name, description, work_dir, github_repo, status, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, 'active', ?, ?)`
+    ).run("prj_active", "Active Project", "", "", "", now, now);
+
+    db.prepare(
+      `INSERT INTO projects (id, name, description, work_dir, github_repo, status, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, 'archived', ?, ?)`
+    ).run("prj_archived", "Archived Project", "", "", "", now, now);
+
+    const rows = db.prepare(
+      `SELECT id, name FROM projects WHERE status = 'active'`
+    ).all() as Array<{ id: string; name: string }>;
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe("Active Project");
+  });
+});
+
+// ---- getCard equivalent: returns all fields including research/notes ----
+
+describe("Board data layer — getCard context persistence", () => {
+  let db: InstanceType<typeof Database>;
+  let store: CardStore;
+
+  beforeEach(() => {
+    db = createTestDb();
+    store = new CardStore(db);
+  });
+
+  it("getCard (findById) returns null-equivalent for missing card", () => {
+    expect(() => store.findById("crd_nonexistent")).toThrow(/not found/i);
+  });
+
+  it("getCard returns research field when populated", () => {
+    const card = store.create({
+      title: "Research card",
+      research: "## Findings\nImportant research data here.",
+    });
+    const found = store.findById(card.id);
+    expect(found.research).toBe("## Findings\nImportant research data here.");
+  });
+
+  it("getCard returns notes field when populated", () => {
+    const card = store.create({
+      title: "Notes card",
+      notes: "2026-03-22: Work done. Branch: crd_abc123",
+    });
+    const found = store.findById(card.id);
+    expect(found.notes).toBe("2026-03-22: Work done. Branch: crd_abc123");
+  });
+
+  it("getCard returns ALL card fields (context persistence regression)", () => {
+    const card = store.create({
+      title: "Full context card",
+      problem_description: "The problem statement",
+      implementation_plan: "Step 1, Step 2",
+      acceptance_criteria: "- [ ] criterion 1\n- [ ] criterion 2",
+      notes: "Session notes here",
+      research: "Research findings here",
+      verify_url: "http://localhost:3001/test",
+    });
+    const found = store.findById(card.id);
+    expect(found.title).toBe("Full context card");
+    expect(found.problem_description).toBe("The problem statement");
+    expect(found.implementation_plan).toBe("Step 1, Step 2");
+    expect(found.acceptance_criteria).toBe("- [ ] criterion 1\n- [ ] criterion 2");
+    expect(found.notes).toBe("Session notes here");
+    expect(found.research).toBe("Research findings here");
+    expect(found.verify_url).toBe("http://localhost:3001/test");
+    expect(found.review_notes).toBe("");
+    expect(found.column).toBe("backlog");
+    expect(found.history).toHaveLength(1);
+  });
+
+  it("getCard returns updated fields after store.update()", () => {
+    const card = store.create({ title: "Updatable card" });
+    store.update(card.id, {
+      notes: "Updated notes",
+      research: "Updated research",
+      problem_description: "Updated problem",
+    });
+    const found = store.findById(card.id);
+    expect(found.notes).toBe("Updated notes");
+    expect(found.research).toBe("Updated research");
+    expect(found.problem_description).toBe("Updated problem");
+  });
+});

--- a/plugins/mc-board/src/store.test.ts
+++ b/plugins/mc-board/src/store.test.ts
@@ -30,7 +30,8 @@ function createTestDb(): InstanceType<typeof Database> {
       review_notes     TEXT NOT NULL DEFAULT '',
       research         TEXT NOT NULL DEFAULT '',
       verify_url       TEXT NOT NULL DEFAULT '',
-      work_log         TEXT NOT NULL DEFAULT '[]'
+      work_log         TEXT NOT NULL DEFAULT '[]',
+      attachments      TEXT NOT NULL DEFAULT '[]'
     );
     CREATE TABLE card_history (
       id       INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -114,5 +115,152 @@ describe("CardStore.move() criteria reset", () => {
     const card = createCardInColumn(store, db, "in-review", "");
     const moved = store.move(card, "in-progress");
     expect(moved.acceptance_criteria).toBe("");
+  });
+});
+
+// ---- store.list() card count ----
+
+describe("CardStore.list() card count", () => {
+  let db: InstanceType<typeof Database>;
+  let store: CardStore;
+
+  beforeEach(() => {
+    db = createTestDb();
+    store = new CardStore(db);
+  });
+
+  it("returns 0 cards when store is empty", () => {
+    expect(store.list()).toHaveLength(0);
+  });
+
+  it("returns correct count after creating 1 card", () => {
+    store.create({ title: "Card A" });
+    expect(store.list()).toHaveLength(1);
+  });
+
+  it("returns correct count after creating 5 cards", () => {
+    for (let i = 0; i < 5; i++) {
+      store.create({ title: `Card ${i}` });
+    }
+    expect(store.list()).toHaveLength(5);
+  });
+
+  it("returns correct count when filtering by column", () => {
+    const card = store.create({ title: "Card A" });
+    store.create({ title: "Card B" });
+    // Move card A to in-progress
+    db.prepare("UPDATE cards SET col = ? WHERE id = ?").run("in-progress", card.id);
+    expect(store.list("backlog")).toHaveLength(1);
+    expect(store.list("in-progress")).toHaveLength(1);
+    expect(store.list()).toHaveLength(2);
+  });
+});
+
+// ---- store.create() + findById() roundtrip ----
+
+describe("CardStore create/findById roundtrip", () => {
+  let db: InstanceType<typeof Database>;
+  let store: CardStore;
+
+  beforeEach(() => {
+    db = createTestDb();
+    store = new CardStore(db);
+  });
+
+  it("create returns a card with correct title", () => {
+    const card = store.create({ title: "My new card" });
+    expect(card.title).toBe("My new card");
+    expect(card.id).toMatch(/^crd_/);
+    expect(card.column).toBe("backlog");
+  });
+
+  it("findById retrieves the same card that was created", () => {
+    const created = store.create({ title: "Roundtrip card" });
+    const found = store.findById(created.id);
+    expect(found.id).toBe(created.id);
+    expect(found.title).toBe("Roundtrip card");
+    expect(found.column).toBe("backlog");
+  });
+
+  it("findById throws for non-existent id", () => {
+    expect(() => store.findById("crd_nonexistent")).toThrow(/not found/i);
+  });
+
+  it("create preserves all optional fields", () => {
+    const card = store.create({
+      title: "Full card",
+      priority: "high",
+      tags: ["build", "infra"],
+      problem_description: "The problem",
+      implementation_plan: "The plan",
+      acceptance_criteria: "- [ ] step 1",
+      notes: "Some notes",
+      research: "Research data",
+    });
+    const found = store.findById(card.id);
+    expect(found.priority).toBe("high");
+    expect(found.tags).toEqual(["build", "infra"]);
+    expect(found.problem_description).toBe("The problem");
+    expect(found.implementation_plan).toBe("The plan");
+    expect(found.acceptance_criteria).toBe("- [ ] step 1");
+    expect(found.notes).toBe("Some notes");
+    expect(found.research).toBe("Research data");
+  });
+});
+
+// ---- store.checkTitleConflict() ----
+
+describe("CardStore.checkTitleConflict()", () => {
+  let db: InstanceType<typeof Database>;
+  let store: CardStore;
+
+  beforeEach(() => {
+    db = createTestDb();
+    store = new CardStore(db);
+  });
+
+  it("is a callable function on the store", () => {
+    expect(typeof store.checkTitleConflict).toBe("function");
+  });
+
+  it("returns null when no cards exist", () => {
+    const result = store.checkTitleConflict("Any title");
+    expect(result).toBeNull();
+  });
+
+  it("detects exact title conflict", () => {
+    store.create({ title: "Fix login bug" });
+    const result = store.checkTitleConflict("Fix login bug");
+    expect(result).not.toBeNull();
+    expect(result!.similarity).toBe(1.0);
+  });
+
+  it("returns null when titles are distinct", () => {
+    store.create({ title: "Fix login bug" });
+    const result = store.checkTitleConflict("Add dark mode to dashboard UI");
+    expect(result).toBeNull();
+  });
+
+  it("excludes card by excludeId", () => {
+    const card = store.create({ title: "Fix login bug" });
+    const result = store.checkTitleConflict("Fix login bug", { excludeId: card.id });
+    expect(result).toBeNull();
+  });
+
+  it("excludes shipped cards from conflict check", () => {
+    const card = store.create({ title: "Fix login bug" });
+    // Move card to shipped
+    db.prepare("UPDATE cards SET col = ? WHERE id = ?").run("shipped", card.id);
+    const result = store.checkTitleConflict("Fix login bug");
+    expect(result).toBeNull();
+  });
+
+  it("detects conflict among multiple cards", () => {
+    store.create({ title: "Card alpha" });
+    store.create({ title: "Fix login bug" });
+    store.create({ title: "Card beta" });
+    const result = store.checkTitleConflict("Fix login bug");
+    expect(result).not.toBeNull();
+    expect(result!.card.title).toBe("Fix login bug");
   });
 });


### PR DESCRIPTION
## Summary
- Adds `store.test.ts` (26 tests) covering `list()` count correctness, `create`/`findById` roundtrip, and `checkTitleConflict()` callable + results
- Adds `data-layer.test.ts` (11 tests) covering card listing count, projects listing, and `getCard` context persistence
- Fixes attachments column missing from test schemas; 298 tests pass, 0 failures

## Regression guards
- `crd_68d9535d` — 0-card fetch bug (store.list() count tests)
- `crd_ab4939f2` — checkSimilarCards/checkTitleConflict crash (callable + result tests)
- `crd_5ba09fcc` — missing projects in dropdown (projects listing tests)
- `crd_7d62b149` — card context disappears (getCard field persistence tests)

## Test plan
- [x] 298 vitest tests pass (0 failures)
- [x] store.list() count verified correct
- [x] store.checkTitleConflict() callable and returns expected results
- [x] CLI commands (create/list/show/update/move/board/next/archive) all pass
- [x] Projects listing tests pass
- [x] getCard context persistence tests pass

Card: crd_4b245820